### PR TITLE
Fix deploy-pages and publish workflow failures

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pages: write
   id-token: write
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@arda-cards/ui-components",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Add `contents: read` permission to deploy-pages workflow (private repo needs explicit checkout permission)
- Remove `private: true` from package.json to allow `npm publish` to GitHub Packages

## Test plan
- [x] CI build-and-test passes on branch
- [ ] Verify deploy-pages succeeds after merge
- [ ] Verify publish succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)