### PR TITLE
feat: add ArdaConfirmDialog and ArdaItemDrawer components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [1.1.0] - 2026-02-13
+
+### Added
+
+- Atom component: ArdaConfirmDialog for cancel-with-confirmation flows
+- Organism component: ArdaItemDrawer with view, add, and edit modes for inventory items
+- Exported public types: ItemData, Supply, Money, Quantity, Duration, Locator, ItemClassification, OrderMechanism, Currency, TimeUnit, ItemDrawerMode
+
 ## [1.0.0] - 2026-02-12
 
 ### Added

--- a/src/components/atoms/confirm-dialog/confirm-dialog.mdx
+++ b/src/components/atoms/confirm-dialog/confirm-dialog.mdx
@@ -1,0 +1,54 @@
+import { Canvas, Meta, ArgTypes } from '@storybook/blocks';
+import * as ConfirmDialogStories from './confirm-dialog.stories';
+
+<Meta of={ConfirmDialogStories} />
+
+# ArdaConfirmDialog
+
+A modal confirmation dialog for destructive or important actions. Renders as a centered overlay with backdrop, focus trapping, and keyboard support.
+
+## Configuration Lifecycle
+
+### Static Configuration (Design Time)
+
+Properties that define the dialog content and appearance:
+
+- **title** &#8212; Dialog heading text
+- **message** &#8212; Descriptive body explaining the action
+- **confirmLabel** &#8212; Text for the confirm button (default: "Confirm")
+- **cancelLabel** &#8212; Text for the cancel button (default: "Cancel")
+- **confirmVariant** &#8212; Visual style: "destructive" (red) or "primary" (blue)
+
+### Runtime Configuration (Dynamic)
+
+Properties that control dialog visibility and behavior:
+
+- **open** &#8212; Whether the dialog is currently visible
+- **onConfirm** &#8212; Callback when the user confirms the action
+- **onCancel** &#8212; Callback when the user cancels or presses Escape
+
+## Usage
+
+### Default
+
+<Canvas of={ConfirmDialogStories.Default} />
+
+### Custom Labels
+
+<Canvas of={ConfirmDialogStories.CustomLabels} />
+
+## Props
+
+<ArgTypes of={ConfirmDialogStories} />
+
+## Accessibility
+
+- Uses `role="alertdialog"` with `aria-modal="true"`
+- Title linked via `aria-labelledby`, message via `aria-describedby`
+- Focus is trapped inside the dialog when open
+- Escape key triggers the cancel action
+- Focus is restored to the previously focused element when closed
+
+## Related Components
+
+- **ArdaItemDrawer** &#8212; Uses ArdaConfirmDialog for the cancel-with-confirmation flow in edit mode

--- a/src/components/atoms/confirm-dialog/confirm-dialog.stories.tsx
+++ b/src/components/atoms/confirm-dialog/confirm-dialog.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from '@storybook/test';
+
+import { ArdaConfirmDialog } from './confirm-dialog';
+
+const meta: Meta<typeof ArdaConfirmDialog> = {
+  title: 'Components/Atoms/ConfirmDialog',
+  component: ArdaConfirmDialog,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A modal confirmation dialog for destructive or important actions. Centered with backdrop overlay, focus trapping, and Escape key support.',
+      },
+    },
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Dialog title displayed as a heading.',
+      table: { category: 'Static' },
+    },
+    message: {
+      control: 'text',
+      description: 'Descriptive message body explaining what will happen.',
+      table: { category: 'Static' },
+    },
+    confirmLabel: {
+      control: 'text',
+      description: 'Label for the confirm action button.',
+      table: { category: 'Static' },
+    },
+    cancelLabel: {
+      control: 'text',
+      description: 'Label for the cancel action button.',
+      table: { category: 'Static' },
+    },
+    confirmVariant: {
+      control: 'select',
+      options: ['destructive', 'primary'],
+      description: 'Visual style of the confirm button.',
+      table: { category: 'Static' },
+    },
+    open: {
+      control: 'boolean',
+      description: 'Whether the dialog is open.',
+      table: { category: 'Runtime' },
+    },
+    onConfirm: {
+      action: 'confirmed',
+      table: { category: 'Events' },
+    },
+    onCancel: {
+      action: 'cancelled',
+      table: { category: 'Events' },
+    },
+  },
+  args: {
+    title: 'Are you sure?',
+    message: 'This action cannot be undone.',
+    open: true,
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArdaConfirmDialog>;
+
+export const Default: Story = {};
+
+export const CustomLabels: Story = {
+  args: {
+    title: 'Discard changes?',
+    message: 'You have unsaved changes that will be lost.',
+    confirmLabel: 'Discard',
+    cancelLabel: 'Keep editing',
+    confirmVariant: 'destructive',
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const confirmButton = canvas.getByRole('button', { name: 'Confirm' });
+    await userEvent.click(confirmButton);
+    await expect(args.onConfirm).toHaveBeenCalledTimes(1);
+  },
+};

--- a/src/components/atoms/confirm-dialog/confirm-dialog.test.tsx
+++ b/src/components/atoms/confirm-dialog/confirm-dialog.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ArdaConfirmDialog } from './confirm-dialog';
+
+const defaultProps = {
+  title: 'Confirm action',
+  message: 'Are you sure you want to proceed?',
+  open: true,
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('ArdaConfirmDialog', () => {
+  it('renders title and message when open', () => {
+    render(<ArdaConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('Confirm action')).toBeInTheDocument();
+    expect(screen.getByText('Are you sure you want to proceed?')).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<ArdaConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    const onCancel = vi.fn();
+    render(<ArdaConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel on Escape key', async () => {
+    const onCancel = vi.fn();
+    render(<ArdaConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    await userEvent.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('has correct ARIA attributes', () => {
+    render(<ArdaConfirmDialog {...defaultProps} />);
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    expect(dialog).toHaveAttribute('aria-describedby');
+  });
+
+  it('is not visible when open is false', () => {
+    render(<ArdaConfirmDialog {...defaultProps} open={false} />);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/confirm-dialog/confirm-dialog.tsx
+++ b/src/components/atoms/confirm-dialog/confirm-dialog.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useId, useRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+/** Design-time configuration. */
+export interface ArdaConfirmDialogStaticConfig {
+  /** Dialog title. */
+  title: string;
+  /** Descriptive message body. */
+  message: string;
+  /** Label for the confirm (destructive) action. Default: "Confirm". */
+  confirmLabel?: string;
+  /** Label for the cancel (safe) action. Default: "Cancel". */
+  cancelLabel?: string;
+  /** Visual style of the confirm button. Default: "destructive". */
+  confirmVariant?: 'destructive' | 'primary';
+}
+
+/** Runtime configuration. */
+export interface ArdaConfirmDialogRuntimeConfig {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Called when the user confirms. */
+  onConfirm: () => void;
+  /** Called when the user cancels or closes. */
+  onCancel: () => void;
+}
+
+export interface ArdaConfirmDialogProps
+  extends ArdaConfirmDialogStaticConfig, ArdaConfirmDialogRuntimeConfig {}
+
+export function ArdaConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  confirmVariant = 'destructive',
+  open,
+  onConfirm,
+  onCancel,
+}: ArdaConfirmDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Focus trap: move focus into dialog when opened, restore when closed
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+      // Focus the first focusable element (cancel button) after render
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const firstEl = focusable?.[0];
+      if (firstEl) {
+        firstEl.focus();
+      }
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [open]);
+
+  // Escape key handler
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      }
+      // Focus trap: cycle focus within dialog
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0] as HTMLElement | undefined;
+        const last = focusable[focusable.length - 1] as HTMLElement | undefined;
+        if (!first || !last) return;
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [onCancel],
+  );
+
+  if (!open) return null;
+
+  const confirmButtonStyles =
+    confirmVariant === 'destructive'
+      ? 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500'
+      : 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500';
+
+  return (
+    // Backdrop overlay
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center transition-opacity duration-200"
+      onClick={onCancel}
+      onKeyDown={handleKeyDown}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" />
+
+      {/* Dialog panel */}
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className={cn(
+          'relative z-10 w-full max-w-md rounded-lg bg-white p-6 shadow-xl',
+          'animate-in fade-in duration-200',
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id={titleId} className="text-lg font-semibold text-gray-900">
+          {title}
+        </h2>
+        <p id={descId} className="mt-2 text-sm text-gray-600">
+          {message}
+        </p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={cn(
+              'rounded-md px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2',
+              confirmButtonStyles,
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/item-drawer/item-drawer.mdx
+++ b/src/components/organisms/item-drawer/item-drawer.mdx
@@ -1,0 +1,99 @@
+import { Canvas, Meta, ArgTypes } from '@storybook/blocks';
+import * as ItemDrawerStories from './item-drawer.stories';
+
+<Meta of={ItemDrawerStories} />
+
+# ArdaItemDrawer
+
+A right-side slide-in panel for viewing, adding, and editing inventory items. Supports three operating modes &#8212; view, add, and edit &#8212; with a confirmation dialog for unsaved changes.
+
+## Configuration Lifecycle
+
+### Static Configuration (Design Time)
+
+Properties that define the drawer's structure, set at composition time:
+
+- **title** &#8212; Override the drawer header title. When omitted, the title is derived from the current mode: the item name in view mode, "Add New Item" in add mode, or "Edit Item" in edit mode.
+- **classificationTypes** &#8212; Array of classification type strings for the form select dropdown. When empty, the classification type renders as a free-text input instead.
+- **orderMechanismLabels** &#8212; Partial map to override the default display labels for order mechanism enum values (e.g. PURCHASE_ORDER &#8594; "Purchase Order").
+
+### Runtime Configuration (Dynamic)
+
+Properties driven by application state that change during the component's lifetime:
+
+- **open** &#8212; Controls drawer visibility. The panel slides in from the right with a 300ms transform transition.
+- **mode** &#8212; Current operating mode: "view" (read-only field display), "add" (empty form), or "edit" (form pre-populated from item prop).
+- **item** &#8212; Item data for view and edit modes. Ignored in add mode.
+- **onClose** &#8212; Called when the drawer requests to close (overlay click, X button, or Escape key in view mode).
+- **onSubmit** &#8212; Called with the form data when the user submits the form in add or edit mode.
+- **onEdit** &#8212; Called when the user clicks the Edit button in view mode. The parent should respond by switching mode to "edit".
+
+## Modes
+
+<table>
+  <thead>
+    <tr>
+      <th>Mode</th>
+      <th>Content</th>
+      <th>Footer Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>view</td>
+      <td>Read-only field display with image preview, grouped label/value rows</td>
+      <td>Edit button</td>
+    </tr>
+    <tr>
+      <td>add</td>
+      <td>Empty form with all item fields organized into sections</td>
+      <td>Cancel, Add Item</td>
+    </tr>
+    <tr>
+      <td>edit</td>
+      <td>Form pre-populated from item prop</td>
+      <td>Cancel, Save</td>
+    </tr>
+  </tbody>
+</table>
+
+### Cancel Behavior
+
+When the user clicks Cancel in add or edit mode:
+
+1. If the form has no unsaved changes, the drawer closes (add mode) or returns to view mode (edit mode).
+2. If changes are detected, an ArdaConfirmDialog appears asking to discard changes.
+3. On confirm ("Discard"), changes are discarded and the drawer closes or returns to view mode.
+4. On cancel ("Keep editing"), the dialog closes and the user remains in the form.
+
+## Usage
+
+### View Mode
+
+<Canvas of={ItemDrawerStories.ViewMode} />
+
+### Add Mode
+
+<Canvas of={ItemDrawerStories.AddMode} />
+
+### Edit Mode
+
+<Canvas of={ItemDrawerStories.EditMode} />
+
+## Props
+
+<ArgTypes of={ItemDrawerStories} />
+
+## Accessibility
+
+- The drawer panel uses `role="dialog"` with `aria-modal="true"`.
+- The header title is linked via `aria-labelledby` for screen reader context.
+- The close button has `aria-label="Close drawer"`.
+- Escape key closes the drawer in view mode, or triggers the cancel flow in add/edit modes.
+- Focus moves to the first focusable element when the drawer opens.
+- All form inputs have associated `label` elements with `htmlFor` attributes.
+- The confirmation dialog uses `role="alertdialog"` with focus trapping and Escape key support.
+
+## Related Components
+
+- **ArdaConfirmDialog** &#8212; Atom used for the cancel-with-confirmation flow when discarding unsaved form changes.

--- a/src/components/organisms/item-drawer/item-drawer.stories.tsx
+++ b/src/components/organisms/item-drawer/item-drawer.stories.tsx
@@ -1,0 +1,212 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from '@storybook/test';
+
+import { ArdaItemDrawer, sampleItem } from './item-drawer';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const meta: Meta<typeof ArdaItemDrawer> = {
+  title: 'Components/Organisms/ArdaItemDrawer',
+  component: ArdaItemDrawer,
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A right-side slide-in panel for viewing, adding, and editing inventory items. Supports view, add, and edit modes with a confirmation dialog for unsaved changes.',
+      },
+    },
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Override the drawer header title. Defaults to mode-appropriate text.',
+      table: { category: 'Static' },
+    },
+    classificationTypes: {
+      control: false,
+      description: 'Classification type options for the form select dropdown.',
+      table: { category: 'Static' },
+    },
+    orderMechanismLabels: {
+      control: false,
+      description: 'Override labels for order mechanism options.',
+      table: { category: 'Static' },
+    },
+    open: {
+      control: 'boolean',
+      description: 'Whether the drawer is open.',
+      table: { category: 'Runtime' },
+    },
+    mode: {
+      control: 'select',
+      options: ['view', 'add', 'edit'],
+      description: 'Current operating mode.',
+      table: { category: 'Runtime' },
+    },
+    item: {
+      control: false,
+      description: 'Item data for view/edit modes.',
+      table: { category: 'Runtime' },
+    },
+    onClose: {
+      action: 'closed',
+      table: { category: 'Events' },
+    },
+    onSubmit: {
+      action: 'submitted',
+      table: { category: 'Events' },
+    },
+    onEdit: {
+      action: 'edit-clicked',
+      table: { category: 'Events' },
+    },
+  },
+  args: {
+    open: true,
+    onClose: fn(),
+    onSubmit: fn(),
+    onEdit: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArdaItemDrawer>;
+
+/* ------------------------------------------------------------------ */
+/*  Static Stories                                                     */
+/* ------------------------------------------------------------------ */
+
+export const ViewMode: Story = {
+  args: {
+    mode: 'view',
+    item: sampleItem,
+  },
+};
+
+export const AddMode: Story = {
+  args: {
+    mode: 'add',
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    mode: 'edit',
+    item: sampleItem,
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    open: false,
+    mode: 'view',
+    item: sampleItem,
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Interactive Stories                                                 */
+/* ------------------------------------------------------------------ */
+
+export const FillAndSubmit: Story = {
+  args: {
+    mode: 'add',
+    onSubmit: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // Scene 1: Drawer is open in add mode with empty form
+    await delay(1500);
+
+    // Scene 2: Fill item name and SKU
+    const nameInput = canvas.getByLabelText('Name');
+    await userEvent.type(nameInput, 'Hydraulic Pump HP-200');
+    const skuInput = canvas.getByLabelText('Internal SKU');
+    await userEvent.type(skuInput, 'HYD-PMP-HP200');
+    await delay(1500);
+
+    // Scene 3: Fill supplier and unit cost
+    const supplierInput = canvas.getByLabelText('Supplier', { selector: '#primary-supplier' });
+    await userEvent.type(supplierInput, 'Parker Hannifin');
+    const unitCostInput = canvas.getByLabelText('Unit Cost', { selector: '#primary-unitcost' });
+    await userEvent.clear(unitCostInput);
+    await userEvent.type(unitCostInput, '245.50');
+    await delay(1500);
+
+    // Scene 4: Click submit, verify onSubmit called
+    const submitButton = canvas.getByRole('button', { name: 'Add Item' });
+    await userEvent.click(submitButton);
+    await expect(args.onSubmit).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const ViewToEdit: Story = {
+  args: {
+    mode: 'view',
+    item: sampleItem,
+    onEdit: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // Scene 1: Drawer is open in view mode with sample item data
+    await expect(canvas.getByText('Hydraulic Cylinder HC-500')).toBeInTheDocument();
+    await expect(canvas.getByText('HYD-CYL-HC500')).toBeInTheDocument();
+    await delay(1500);
+
+    // Scene 2: Click Edit button
+    const editButton = canvas.getByRole('button', { name: /edit/i });
+    await userEvent.click(editButton);
+    await expect(args.onEdit).toHaveBeenCalledTimes(1);
+    await delay(1500);
+
+    // Scene 3: Verify the edit callback was invoked (parent would switch to edit mode)
+    // In a real app, the parent would re-render with mode='edit' and the form pre-populated.
+    // We verify the callback was called with the right context.
+    await expect(args.onEdit).toHaveBeenCalled();
+  },
+};
+
+export const EditWithCancel: Story = {
+  args: {
+    mode: 'edit',
+    item: sampleItem,
+    onEdit: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // Scene 1: Drawer is open in edit mode with pre-populated form
+    const nameInput = canvas.getByLabelText('Name');
+    await expect(nameInput).toHaveValue('Hydraulic Cylinder HC-500');
+    await delay(1500);
+
+    // Scene 2: Modify a field to make the form dirty
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Modified Item Name');
+    await delay(1500);
+
+    // Scene 3: Click Cancel -- confirm dialog appears
+    const cancelButton = canvas.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelButton);
+    await delay(500);
+    const discardDialog = canvas.getByRole('alertdialog');
+    await expect(discardDialog).toBeInTheDocument();
+    await expect(canvas.getByText('Discard changes?')).toBeInTheDocument();
+    await delay(1500);
+
+    // Scene 4: Click Discard -- confirm dialog closes, onEdit called to return to view mode
+    const discardButton = canvas.getByRole('button', { name: 'Discard' });
+    await userEvent.click(discardButton);
+    await expect(args.onEdit).toHaveBeenCalledTimes(1);
+  },
+};

--- a/src/components/organisms/item-drawer/item-drawer.test.tsx
+++ b/src/components/organisms/item-drawer/item-drawer.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ArdaItemDrawer, sampleItem } from './item-drawer';
+
+const baseProps = {
+  open: true,
+  mode: 'view' as const,
+  item: sampleItem,
+  onClose: vi.fn(),
+  onSubmit: vi.fn(),
+  onEdit: vi.fn(),
+};
+
+describe('ArdaItemDrawer', () => {
+  // 1. Renders item data in view mode
+  it('renders item data in view mode (name, SKU, supplier visible)', () => {
+    render(<ArdaItemDrawer {...baseProps} />);
+    // Item name appears in both header and content; verify at least one
+    const nameElements = screen.getAllByText('Hydraulic Cylinder HC-500');
+    expect(nameElements.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('HYD-CYL-HC500')).toBeInTheDocument();
+    expect(screen.getByText('Fastenal Corp.')).toBeInTheDocument();
+  });
+
+  // 2. Renders empty form in add mode
+  it('renders empty form in add mode', () => {
+    const { item: _, ...addProps } = baseProps;
+    render(<ArdaItemDrawer {...addProps} mode="add" />);
+    expect(screen.getByText('Add New Item')).toBeInTheDocument();
+    const nameInput = screen.getByLabelText('Name');
+    expect(nameInput).toHaveValue('');
+  });
+
+  // 3. Pre-populates form in edit mode from item prop
+  it('pre-populates form in edit mode from item prop', () => {
+    render(<ArdaItemDrawer {...baseProps} mode="edit" />);
+    expect(screen.getByText('Edit Item')).toBeInTheDocument();
+    const nameInput = screen.getByLabelText('Name');
+    expect(nameInput).toHaveValue('Hydraulic Cylinder HC-500');
+    const skuInput = screen.getByLabelText('Internal SKU');
+    expect(skuInput).toHaveValue('HYD-CYL-HC500');
+  });
+
+  // 4. Calls onClose when overlay clicked
+  it('calls onClose when overlay clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const { container } = render(<ArdaItemDrawer {...baseProps} onClose={onClose} />);
+    const overlay = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(overlay).toBeInTheDocument();
+    await user.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // 5. Calls onClose when X button clicked
+  it('calls onClose when X button clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<ArdaItemDrawer {...baseProps} onClose={onClose} />);
+    await user.click(screen.getByLabelText('Close drawer'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // 6. Calls onClose on Escape key (view mode, no unsaved changes)
+  it('calls onClose on Escape key when no unsaved changes', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<ArdaItemDrawer {...baseProps} onClose={onClose} />);
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // 7. Calls onSubmit with form data when form submitted
+  it('calls onSubmit with form data when form submitted', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ArdaItemDrawer {...baseProps} mode="edit" onSubmit={onSubmit} />);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Hydraulic Cylinder HC-500' }),
+    );
+  });
+
+  // 8. Calls onEdit when edit button clicked in view mode
+  it('calls onEdit when edit button clicked in view mode', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<ArdaItemDrawer {...baseProps} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  // 9. Shows confirm dialog when cancelling edit with unsaved changes
+  it('shows confirm dialog when cancelling edit with unsaved changes', async () => {
+    const user = userEvent.setup();
+    render(<ArdaItemDrawer {...baseProps} mode="edit" />);
+    // Make a change to trigger dirty detection
+    const nameInput = screen.getByLabelText('Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed');
+    // Click Cancel
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Confirm dialog should appear
+    expect(screen.getByText('Discard changes?')).toBeInTheDocument();
+    expect(screen.getByText('You have unsaved changes that will be lost.')).toBeInTheDocument();
+  });
+
+  // 10. Discards changes and returns to view mode on confirm
+  it('discards changes and returns to view mode on confirm', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<ArdaItemDrawer {...baseProps} mode="edit" onEdit={onEdit} />);
+    // Make a change
+    const nameInput = screen.getByLabelText('Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed');
+    // Click Cancel to trigger dialog
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Click Discard in the confirm dialog
+    await user.click(screen.getByRole('button', { name: 'Discard' }));
+    // Should call onEdit to return to view mode
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  // 11. Stays in edit mode on cancel of confirm dialog
+  it('stays in edit mode on cancel of confirm dialog', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<ArdaItemDrawer {...baseProps} mode="edit" onEdit={onEdit} />);
+    // Make a change
+    const nameInput = screen.getByLabelText('Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'X');
+    // Click Cancel to trigger dialog
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Confirm dialog should appear
+    expect(screen.getByText('Discard changes?')).toBeInTheDocument();
+    // Click Keep editing
+    await user.click(screen.getByRole('button', { name: 'Keep editing' }));
+    // Dialog should close, onEdit should not have been called
+    expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument();
+    expect(onEdit).not.toHaveBeenCalled();
+    // Form should still be visible with modified value
+    expect(screen.getByLabelText('Name')).toHaveValue('X');
+  });
+
+  // 12. Not rendered / invisible when open={false}
+  it('is invisible when open is false', () => {
+    const { container } = render(<ArdaItemDrawer {...baseProps} open={false} />);
+    const panel = screen.getByRole('dialog', { hidden: true });
+    expect(panel.className).toContain('translate-x-full');
+    const overlay = container.querySelector('[aria-hidden="true"]');
+    expect(overlay?.className).toContain('invisible');
+  });
+
+  // 13. Has role="dialog" and aria-modal="true"
+  it('has role="dialog" and aria-modal="true"', () => {
+    render(<ArdaItemDrawer {...baseProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+  });
+
+  // 14. Drawer has correct width class
+  it('has correct width classes on the panel', () => {
+    render(<ArdaItemDrawer {...baseProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('sm:w-[420px]');
+    expect(dialog.className).toContain('lg:w-[460px]');
+  });
+});

--- a/src/components/organisms/item-drawer/item-drawer.tsx
+++ b/src/components/organisms/item-drawer/item-drawer.tsx
@@ -1,0 +1,1179 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { X, Pencil, Package, ImageOff, ChevronDown, ChevronRight } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { ArdaConfirmDialog } from '@/components/atoms/confirm-dialog/confirm-dialog';
+
+/* ------------------------------------------------------------------ */
+/*  Value Types                                                       */
+/* ------------------------------------------------------------------ */
+
+export type Currency = 'USD' | 'CAD' | 'EUR' | 'GBP';
+
+export interface Money {
+  value: number;
+  currency: Currency;
+}
+
+export type TimeUnit = 'HOUR' | 'DAY' | 'WEEK';
+
+export interface Duration {
+  length: number;
+  unit: TimeUnit;
+}
+
+export interface Quantity {
+  amount: number;
+  unit: string;
+}
+
+export type OrderMechanism =
+  | 'PURCHASE_ORDER'
+  | 'EMAIL'
+  | 'PHONE'
+  | 'IN_STORE'
+  | 'ONLINE'
+  | 'RFQ'
+  | 'PRODUCTION'
+  | 'THIRD_PARTY'
+  | 'OTHER';
+
+/* ------------------------------------------------------------------ */
+/*  Domain Types                                                      */
+/* ------------------------------------------------------------------ */
+
+export interface ItemClassification {
+  type: string;
+  subType?: string;
+}
+
+export interface Locator {
+  facility: string;
+  department?: string;
+  location?: string;
+}
+
+export interface Supply {
+  supplier: string;
+  name?: string;
+  sku?: string;
+  orderMechanism?: OrderMechanism;
+  url?: string;
+  minimumQuantity?: Quantity;
+  orderQuantity?: Quantity;
+  unitCost?: Money;
+  averageLeadTime?: Duration;
+  orderNotes?: string;
+  orderCost: Money;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Item Type                                                         */
+/* ------------------------------------------------------------------ */
+
+export interface ItemData {
+  entityId?: string;
+  name: string;
+  imageUrl?: string;
+  classification?: ItemClassification;
+  useCase?: string;
+  locator?: Locator;
+  internalSKU?: string;
+  generalLedgerCode?: string;
+  minQuantity?: Quantity;
+  notes?: string;
+  cardNotesDefault?: string;
+  taxable?: boolean;
+  primarySupply?: Supply;
+  secondarySupply?: Supply;
+  defaultSupply?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Defaults                                                          */
+/* ------------------------------------------------------------------ */
+
+export const defaultMoney: Money = { value: 0, currency: 'USD' };
+export const defaultQuantity: Quantity = { amount: 1, unit: 'each' };
+
+export const emptyItem: ItemData = {
+  name: '',
+  classification: { type: '' },
+  locator: { facility: '' },
+  minQuantity: defaultQuantity,
+  taxable: true,
+  primarySupply: {
+    supplier: '',
+    orderCost: defaultMoney,
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Sample Data                                                       */
+/* ------------------------------------------------------------------ */
+
+export const sampleItem: ItemData = {
+  entityId: 'item-001',
+  name: 'Hydraulic Cylinder HC-500',
+  imageUrl: 'https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?w=400&h=300&fit=crop',
+  classification: { type: 'Filters', subType: 'Hydraulic' },
+  useCase: 'Maintenance',
+  locator: {
+    facility: 'Main Warehouse',
+    department: 'MRO',
+    location: 'W-03-B2',
+  },
+  internalSKU: 'HYD-CYL-HC500',
+  generalLedgerCode: '6120-MRO',
+  minQuantity: { amount: 5, unit: 'each' },
+  notes: 'Requires pressure test before installation.',
+  cardNotesDefault: 'Handle with care - precision component',
+  taxable: true,
+  primarySupply: {
+    supplier: 'Fastenal Corp.',
+    name: 'HC-500 Hydraulic Cylinder',
+    sku: 'FAS-HC500-A',
+    orderMechanism: 'ONLINE',
+    url: 'https://fastenal.com/hc500',
+    minimumQuantity: { amount: 1, unit: 'each' },
+    orderQuantity: { amount: 5, unit: 'each' },
+    unitCost: { value: 189.99, currency: 'USD' },
+    averageLeadTime: { length: 5, unit: 'DAY' },
+    orderNotes: 'Free shipping over $500',
+    orderCost: { value: 949.95, currency: 'USD' },
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Drawer Config Interfaces                                          */
+/* ------------------------------------------------------------------ */
+
+export type ItemDrawerMode = 'view' | 'add' | 'edit';
+
+/** Design-time configuration. */
+export interface ArdaItemDrawerStaticConfig {
+  /** Override the drawer header title. Defaults to mode-appropriate text. */
+  title?: string;
+  /** Classification type options for the form select. */
+  classificationTypes?: string[];
+  /** OrderMechanism labels map override. */
+  orderMechanismLabels?: Partial<Record<OrderMechanism, string>>;
+}
+
+/** Runtime configuration. */
+export interface ArdaItemDrawerRuntimeConfig {
+  /** Whether the drawer is open. */
+  open: boolean;
+  /** Current operating mode. */
+  mode: ItemDrawerMode;
+  /** Item data for view/edit modes. Ignored in add mode. */
+  item?: ItemData;
+  /** Called when the drawer requests to close. */
+  onClose: () => void;
+  /** Called when the user submits the form (add or edit). */
+  onSubmit?: (data: ItemData) => void;
+  /** Called when the user clicks Edit from view mode. */
+  onEdit?: () => void;
+}
+
+/** Combined props for ArdaItemDrawer. */
+export interface ArdaItemDrawerProps
+  extends ArdaItemDrawerStaticConfig, ArdaItemDrawerRuntimeConfig {}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+const ORDER_MECHANISM_LABELS: Record<OrderMechanism, string> = {
+  PURCHASE_ORDER: 'Purchase Order',
+  EMAIL: 'Email',
+  PHONE: 'Phone',
+  IN_STORE: 'In Store',
+  ONLINE: 'Online',
+  RFQ: 'RFQ',
+  PRODUCTION: 'Production',
+  THIRD_PARTY: 'Third Party',
+  OTHER: 'Other',
+};
+
+const ALL_ORDER_MECHANISMS: OrderMechanism[] = [
+  'PURCHASE_ORDER',
+  'EMAIL',
+  'PHONE',
+  'IN_STORE',
+  'ONLINE',
+  'RFQ',
+  'PRODUCTION',
+  'THIRD_PARTY',
+  'OTHER',
+];
+
+const ALL_CURRENCIES: Currency[] = ['USD', 'CAD', 'EUR', 'GBP'];
+
+const ALL_TIME_UNITS: TimeUnit[] = ['HOUR', 'DAY', 'WEEK'];
+
+function formatMoney(money: Money | undefined): string {
+  if (!money) return '-';
+  return `${money.currency} ${money.value.toFixed(2)}`;
+}
+
+function formatQuantity(qty: Quantity | undefined): string {
+  if (!qty) return '-';
+  return `${qty.amount} ${qty.unit}`;
+}
+
+function formatDuration(dur: Duration | undefined): string {
+  if (!dur) return '-';
+  const unitLabel = dur.unit.charAt(0) + dur.unit.slice(1).toLowerCase();
+  return `${dur.length} ${unitLabel}${dur.length !== 1 ? 's' : ''}`;
+}
+
+/** Deep-compare two ItemData objects for dirty detection. */
+function isItemDirty(a: ItemData, b: ItemData): boolean {
+  return JSON.stringify(a) !== JSON.stringify(b);
+}
+
+/**
+ * Set or remove an optional key from an object.
+ * Needed because exactOptionalPropertyTypes prevents `{ ...obj, key: val || undefined }`.
+ */
+function withOptional<T extends object, K extends keyof T>(obj: T, key: K, value: string): T {
+  const copy = { ...obj };
+  if (value) {
+    (copy as Record<string, unknown>)[key as string] = value;
+  } else {
+    delete (copy as Record<string, unknown>)[key as string];
+  }
+  return copy;
+}
+
+/** Build a Supply with defaults for missing optional fields. */
+function ensureSupply(supply: Supply | undefined): Supply {
+  return supply ?? { supplier: '', orderCost: defaultMoney };
+}
+
+/** Build a Quantity with defaults. */
+function ensureQuantity(qty: Quantity | undefined): Quantity {
+  return qty ?? { ...defaultQuantity };
+}
+
+/* ------------------------------------------------------------------ */
+/*  View-mode sub-components                                          */
+/* ------------------------------------------------------------------ */
+
+function FieldRow({ label, value }: { label: string; value: string | undefined }) {
+  return (
+    <div className="flex justify-between py-2 border-b border-gray-100 last:border-b-0">
+      <span className="text-sm text-gray-500">{label}</span>
+      <span className="text-sm text-gray-900 text-right max-w-[60%] break-words">
+        {value || '-'}
+      </span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-6">
+      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{title}</h3>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  View Mode Content                                                 */
+/* ------------------------------------------------------------------ */
+
+function ViewModeContent({
+  item,
+  mechanismLabels,
+}: {
+  item: ItemData;
+  mechanismLabels: Record<OrderMechanism, string>;
+}) {
+  const classification = item.classification;
+  const locator = item.locator;
+  const supply = item.primarySupply;
+
+  return (
+    <>
+      {/* Image preview */}
+      <div className="mb-6">
+        {item.imageUrl ? (
+          <img
+            src={item.imageUrl}
+            alt={item.name}
+            className="w-full h-48 object-cover rounded-lg"
+          />
+        ) : (
+          <div className="w-full h-48 bg-gray-100 rounded-lg flex items-center justify-center">
+            <ImageOff size={48} className="text-gray-300" />
+          </div>
+        )}
+      </div>
+
+      {/* Item name */}
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">{item.name}</h2>
+
+      {/* Item section */}
+      <Section title="Item">
+        <FieldRow label="SKU" value={item.internalSKU} />
+        <FieldRow label="GL Code" value={item.generalLedgerCode} />
+        <FieldRow
+          label="Classification"
+          value={
+            classification
+              ? [classification.type, classification.subType].filter(Boolean).join(' / ')
+              : undefined
+          }
+        />
+        <FieldRow label="Use Case" value={item.useCase} />
+      </Section>
+
+      {/* Location section */}
+      <Section title="Location">
+        <FieldRow label="Facility" value={locator?.facility} />
+        <FieldRow label="Department" value={locator?.department} />
+        <FieldRow label="Location" value={locator?.location} />
+      </Section>
+
+      {/* Stock section */}
+      <Section title="Stock">
+        <FieldRow label="Min Quantity" value={formatQuantity(item.minQuantity)} />
+        <FieldRow
+          label="Taxable"
+          value={item.taxable === undefined ? '-' : item.taxable ? 'Yes' : 'No'}
+        />
+      </Section>
+
+      {/* Supply section */}
+      {supply && (
+        <Section title="Supply">
+          <FieldRow label="Supplier" value={supply.supplier} />
+          <FieldRow label="Unit Cost" value={formatMoney(supply.unitCost)} />
+          <FieldRow label="Order Qty" value={formatQuantity(supply.orderQuantity)} />
+          <FieldRow label="Lead Time" value={formatDuration(supply.averageLeadTime)} />
+          <FieldRow
+            label="Order Mechanism"
+            value={supply.orderMechanism ? mechanismLabels[supply.orderMechanism] : undefined}
+          />
+        </Section>
+      )}
+
+      {/* Notes section */}
+      {(item.notes || item.cardNotesDefault) && (
+        <Section title="Notes">
+          <FieldRow label="Notes" value={item.notes} />
+          <FieldRow label="Card Notes" value={item.cardNotesDefault} />
+        </Section>
+      )}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Form sub-components                                               */
+/* ------------------------------------------------------------------ */
+
+const fieldClasses =
+  'w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500';
+
+function FormField({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3">
+      <label htmlFor={htmlFor} className="block text-sm font-medium text-gray-700 mb-1">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function FormSelect({
+  id,
+  value,
+  onChange,
+  options,
+  placeholder,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={fieldClasses}
+    >
+      {placeholder && <option value="">{placeholder}</option>}
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function FormTextarea({
+  id,
+  value,
+  onChange,
+  placeholder,
+  rows = 3,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  rows?: number;
+}) {
+  return (
+    <textarea
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      rows={rows}
+      className={fieldClasses}
+    />
+  );
+}
+
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  return (
+    <div className="mb-4 border border-gray-200 rounded-lg">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 w-full px-4 py-3 text-left text-sm font-semibold text-gray-700 hover:bg-gray-50 transition-colors rounded-t-lg"
+      >
+        {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        {title}
+      </button>
+      {isOpen && <div className="px-4 pb-4">{children}</div>}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Supply Fields                                                     */
+/* ------------------------------------------------------------------ */
+
+function SupplyFields({
+  prefix,
+  supply,
+  onChange,
+  mechanismLabels,
+}: {
+  prefix: string;
+  supply: Supply;
+  onChange: (updated: Supply) => void;
+  mechanismLabels: Record<OrderMechanism, string>;
+}) {
+  const update = <K extends keyof Supply>(key: K, val: Supply[K]) => {
+    onChange({ ...supply, [key]: val });
+  };
+
+  const unitCost = supply.unitCost ?? { ...defaultMoney };
+  const minQty = ensureQuantity(supply.minimumQuantity);
+  const orderQty = ensureQuantity(supply.orderQuantity);
+  const leadTime = supply.averageLeadTime ?? { length: 0, unit: 'DAY' as TimeUnit };
+
+  return (
+    <>
+      <FormField label="Supplier" htmlFor={`${prefix}-supplier`}>
+        <input
+          id={`${prefix}-supplier`}
+          type="text"
+          value={supply.supplier}
+          onChange={(e) => update('supplier', e.target.value)}
+          placeholder="Supplier name"
+          className={fieldClasses}
+        />
+      </FormField>
+
+      <FormField label="Product Name" htmlFor={`${prefix}-name`}>
+        <input
+          id={`${prefix}-name`}
+          type="text"
+          value={supply.name ?? ''}
+          onChange={(e) => update('name', e.target.value || undefined)}
+          placeholder="Product name"
+          className={fieldClasses}
+        />
+      </FormField>
+
+      <FormField label="Supplier SKU" htmlFor={`${prefix}-sku`}>
+        <input
+          id={`${prefix}-sku`}
+          type="text"
+          value={supply.sku ?? ''}
+          onChange={(e) => update('sku', e.target.value || undefined)}
+          placeholder="Supplier SKU"
+          className={fieldClasses}
+        />
+      </FormField>
+
+      <FormField label="Order Mechanism" htmlFor={`${prefix}-mechanism`}>
+        <FormSelect
+          id={`${prefix}-mechanism`}
+          value={supply.orderMechanism ?? ''}
+          onChange={(v) => update('orderMechanism', (v || undefined) as OrderMechanism | undefined)}
+          options={ALL_ORDER_MECHANISMS.map((m) => ({ value: m, label: mechanismLabels[m] }))}
+          placeholder="Select..."
+        />
+      </FormField>
+
+      <FormField label="URL" htmlFor={`${prefix}-url`}>
+        <input
+          id={`${prefix}-url`}
+          type="url"
+          value={supply.url ?? ''}
+          onChange={(e) => update('url', e.target.value || undefined)}
+          placeholder="https://..."
+          className={fieldClasses}
+        />
+      </FormField>
+
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Min Qty" htmlFor={`${prefix}-minqty`}>
+          <input
+            id={`${prefix}-minqty`}
+            type="number"
+            min={0}
+            value={minQty.amount}
+            onChange={(e) =>
+              update('minimumQuantity', { ...minQty, amount: Number(e.target.value) })
+            }
+            className={fieldClasses}
+          />
+        </FormField>
+        <FormField label="Min Qty Unit" htmlFor={`${prefix}-minqty-unit`}>
+          <input
+            id={`${prefix}-minqty-unit`}
+            type="text"
+            value={minQty.unit}
+            onChange={(e) => update('minimumQuantity', { ...minQty, unit: e.target.value })}
+            className={fieldClasses}
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Order Qty" htmlFor={`${prefix}-orderqty`}>
+          <input
+            id={`${prefix}-orderqty`}
+            type="number"
+            min={0}
+            value={orderQty.amount}
+            onChange={(e) =>
+              update('orderQuantity', { ...orderQty, amount: Number(e.target.value) })
+            }
+            className={fieldClasses}
+          />
+        </FormField>
+        <FormField label="Order Qty Unit" htmlFor={`${prefix}-orderqty-unit`}>
+          <input
+            id={`${prefix}-orderqty-unit`}
+            type="text"
+            value={orderQty.unit}
+            onChange={(e) => update('orderQuantity', { ...orderQty, unit: e.target.value })}
+            className={fieldClasses}
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Unit Cost" htmlFor={`${prefix}-unitcost`}>
+          <input
+            id={`${prefix}-unitcost`}
+            type="number"
+            min={0}
+            step={0.01}
+            value={unitCost.value}
+            onChange={(e) => update('unitCost', { ...unitCost, value: Number(e.target.value) })}
+            className={fieldClasses}
+          />
+        </FormField>
+        <FormField label="Currency" htmlFor={`${prefix}-unitcost-currency`}>
+          <FormSelect
+            id={`${prefix}-unitcost-currency`}
+            value={unitCost.currency}
+            onChange={(v) => update('unitCost', { ...unitCost, currency: v as Currency })}
+            options={ALL_CURRENCIES.map((c) => ({ value: c, label: c }))}
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Lead Time" htmlFor={`${prefix}-leadtime`}>
+          <input
+            id={`${prefix}-leadtime`}
+            type="number"
+            min={0}
+            value={leadTime.length}
+            onChange={(e) =>
+              update('averageLeadTime', { ...leadTime, length: Number(e.target.value) })
+            }
+            className={fieldClasses}
+          />
+        </FormField>
+        <FormField label="Time Unit" htmlFor={`${prefix}-leadtime-unit`}>
+          <FormSelect
+            id={`${prefix}-leadtime-unit`}
+            value={leadTime.unit}
+            onChange={(v) => update('averageLeadTime', { ...leadTime, unit: v as TimeUnit })}
+            options={ALL_TIME_UNITS.map((u) => ({
+              value: u,
+              label: u.charAt(0) + u.slice(1).toLowerCase(),
+            }))}
+          />
+        </FormField>
+      </div>
+
+      <FormField label="Order Notes" htmlFor={`${prefix}-ordernotes`}>
+        <FormTextarea
+          id={`${prefix}-ordernotes`}
+          value={supply.orderNotes ?? ''}
+          onChange={(v) => update('orderNotes', v || undefined)}
+          placeholder="Order notes..."
+          rows={2}
+        />
+      </FormField>
+
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Order Cost" htmlFor={`${prefix}-ordercost`}>
+          <input
+            id={`${prefix}-ordercost`}
+            type="number"
+            min={0}
+            step={0.01}
+            value={supply.orderCost.value}
+            onChange={(e) =>
+              update('orderCost', { ...supply.orderCost, value: Number(e.target.value) })
+            }
+            className={fieldClasses}
+          />
+        </FormField>
+        <FormField label="Currency" htmlFor={`${prefix}-ordercost-currency`}>
+          <FormSelect
+            id={`${prefix}-ordercost-currency`}
+            value={supply.orderCost.currency}
+            onChange={(v) => update('orderCost', { ...supply.orderCost, currency: v as Currency })}
+            options={ALL_CURRENCIES.map((c) => ({ value: c, label: c }))}
+          />
+        </FormField>
+      </div>
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Form Mode Content                                                 */
+/* ------------------------------------------------------------------ */
+
+function FormModeContent({
+  formData,
+  setFormData,
+  classificationTypes,
+  mechanismLabels,
+}: {
+  formData: ItemData;
+  setFormData: React.Dispatch<React.SetStateAction<ItemData>>;
+  classificationTypes: string[];
+  mechanismLabels: Record<OrderMechanism, string>;
+}) {
+  const updateField = <K extends keyof ItemData>(key: K, value: ItemData[K]) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const classification = formData.classification ?? { type: '' };
+  const locator = formData.locator ?? { facility: '' };
+  const minQty = ensureQuantity(formData.minQuantity);
+  const primarySupply = ensureSupply(formData.primarySupply);
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      {/* Section 1: Item Details */}
+      <Section title="Item Details">
+        <FormField label="Name" htmlFor="item-name">
+          <input
+            id="item-name"
+            type="text"
+            value={formData.name}
+            onChange={(e) => updateField('name', e.target.value)}
+            placeholder="Item name"
+            className={fieldClasses}
+          />
+        </FormField>
+
+        <FormField label="Image URL" htmlFor="item-imageurl">
+          <input
+            id="item-imageurl"
+            type="url"
+            value={formData.imageUrl ?? ''}
+            onChange={(e) => updateField('imageUrl', e.target.value || undefined)}
+            placeholder="https://..."
+            className={fieldClasses}
+          />
+        </FormField>
+
+        <FormField label="Internal SKU" htmlFor="item-sku">
+          <input
+            id="item-sku"
+            type="text"
+            value={formData.internalSKU ?? ''}
+            onChange={(e) => updateField('internalSKU', e.target.value || undefined)}
+            placeholder="SKU"
+            className={fieldClasses}
+          />
+        </FormField>
+
+        <FormField label="GL Code" htmlFor="item-glcode">
+          <input
+            id="item-glcode"
+            type="text"
+            value={formData.generalLedgerCode ?? ''}
+            onChange={(e) => updateField('generalLedgerCode', e.target.value || undefined)}
+            placeholder="General Ledger Code"
+            className={fieldClasses}
+          />
+        </FormField>
+      </Section>
+
+      {/* Section 2: Classification */}
+      <Section title="Classification">
+        <FormField label="Type" htmlFor="item-class-type">
+          {classificationTypes.length > 0 ? (
+            <FormSelect
+              id="item-class-type"
+              value={classification.type}
+              onChange={(v) => updateField('classification', { ...classification, type: v })}
+              options={classificationTypes.map((t) => ({ value: t, label: t }))}
+              placeholder="Select type..."
+            />
+          ) : (
+            <input
+              id="item-class-type"
+              type="text"
+              value={classification.type}
+              onChange={(e) =>
+                updateField('classification', { ...classification, type: e.target.value })
+              }
+              placeholder="Classification type"
+              className={fieldClasses}
+            />
+          )}
+        </FormField>
+
+        <FormField label="Sub-Type" htmlFor="item-class-subtype">
+          <input
+            id="item-class-subtype"
+            type="text"
+            value={classification.subType ?? ''}
+            onChange={(e) =>
+              updateField('classification', withOptional(classification, 'subType', e.target.value))
+            }
+            placeholder="Sub-type"
+            className={fieldClasses}
+          />
+        </FormField>
+
+        <FormField label="Use Case" htmlFor="item-usecase">
+          <input
+            id="item-usecase"
+            type="text"
+            value={formData.useCase ?? ''}
+            onChange={(e) => updateField('useCase', e.target.value || undefined)}
+            placeholder="Use case"
+            className={fieldClasses}
+          />
+        </FormField>
+      </Section>
+
+      {/* Section 3: Location */}
+      <Section title="Location">
+        <FormField label="Facility" htmlFor="item-facility">
+          <input
+            id="item-facility"
+            type="text"
+            value={locator.facility}
+            onChange={(e) => updateField('locator', { ...locator, facility: e.target.value })}
+            placeholder="Facility"
+            className={fieldClasses}
+          />
+        </FormField>
+
+        <FormField label="Department" htmlFor="item-department">
+          <input
+            id="item-department"
+            type="text"
+            value={locator.department ?? ''}
+            onChange={(e) =>
+              updateField('locator', withOptional(locator, 'department', e.target.value))
+            }
+            placeholder="Department"
+            className={fieldClasses}
+          />
+        </FormField>
+
+        <FormField label="Location" htmlFor="item-location">
+          <input
+            id="item-location"
+            type="text"
+            value={locator.location ?? ''}
+            onChange={(e) =>
+              updateField('locator', withOptional(locator, 'location', e.target.value))
+            }
+            placeholder="Location"
+            className={fieldClasses}
+          />
+        </FormField>
+      </Section>
+
+      {/* Section 4: Stock Settings */}
+      <Section title="Stock Settings">
+        <div className="grid grid-cols-2 gap-3">
+          <FormField label="Min Quantity" htmlFor="item-minqty">
+            <input
+              id="item-minqty"
+              type="number"
+              min={0}
+              value={minQty.amount}
+              onChange={(e) =>
+                updateField('minQuantity', { ...minQty, amount: Number(e.target.value) })
+              }
+              className={fieldClasses}
+            />
+          </FormField>
+          <FormField label="Unit" htmlFor="item-minqty-unit">
+            <input
+              id="item-minqty-unit"
+              type="text"
+              value={minQty.unit}
+              onChange={(e) => updateField('minQuantity', { ...minQty, unit: e.target.value })}
+              className={fieldClasses}
+            />
+          </FormField>
+        </div>
+
+        <div className="mb-3 flex items-center gap-2">
+          <input
+            id="item-taxable"
+            type="checkbox"
+            checked={formData.taxable ?? false}
+            onChange={(e) => updateField('taxable', e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <label htmlFor="item-taxable" className="text-sm font-medium text-gray-700">
+            Taxable
+          </label>
+        </div>
+
+        <FormField label="Card Notes Default" htmlFor="item-cardnotes">
+          <FormTextarea
+            id="item-cardnotes"
+            value={formData.cardNotesDefault ?? ''}
+            onChange={(v) => updateField('cardNotesDefault', v || undefined)}
+            placeholder="Default card notes..."
+            rows={2}
+          />
+        </FormField>
+      </Section>
+
+      {/* Section 5: Primary Supply */}
+      <Section title="Primary Supply">
+        <SupplyFields
+          prefix="primary"
+          supply={primarySupply}
+          onChange={(updated) => updateField('primarySupply', updated)}
+          mechanismLabels={mechanismLabels}
+        />
+      </Section>
+
+      {/* Section 6: Secondary Supply (collapsible) */}
+      <CollapsibleSection
+        title="Secondary Supply (Optional)"
+        defaultOpen={!!formData.secondarySupply?.supplier}
+      >
+        <SupplyFields
+          prefix="secondary"
+          supply={ensureSupply(formData.secondarySupply)}
+          onChange={(updated) => updateField('secondarySupply', updated)}
+          mechanismLabels={mechanismLabels}
+        />
+      </CollapsibleSection>
+
+      {/* Section 7: Notes */}
+      <Section title="Notes">
+        <FormField label="Notes" htmlFor="item-notes">
+          <FormTextarea
+            id="item-notes"
+            value={formData.notes ?? ''}
+            onChange={(v) => updateField('notes', v || undefined)}
+            placeholder="Additional notes..."
+          />
+        </FormField>
+      </Section>
+    </form>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ArdaItemDrawer Component                                          */
+/* ------------------------------------------------------------------ */
+
+export function ArdaItemDrawer({
+  title,
+  classificationTypes = [],
+  orderMechanismLabels,
+  open,
+  mode,
+  item,
+  onClose,
+  onSubmit,
+  onEdit,
+}: ArdaItemDrawerProps) {
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const mechanismLabels: Record<OrderMechanism, string> = {
+    ...ORDER_MECHANISM_LABELS,
+    ...orderMechanismLabels,
+  };
+
+  // Form state management
+  const initialFormData = mode === 'edit' && item ? item : emptyItem;
+  const [formData, setFormData] = useState<ItemData>(initialFormData);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const originalRef = useRef<ItemData>(initialFormData);
+
+  // Re-initialize form when mode or item changes
+  useEffect(() => {
+    const data = mode === 'edit' && item ? item : emptyItem;
+    setFormData(data);
+    originalRef.current = data;
+  }, [mode, item]);
+
+  // Resolve the header title based on mode and props
+  const resolvedTitle =
+    title ??
+    (mode === 'view'
+      ? (item?.name ?? 'Item Details')
+      : mode === 'add'
+        ? 'Add New Item'
+        : 'Edit Item');
+
+  // Determine if form has unsaved changes
+  const isDirty = useCallback(() => {
+    if (mode === 'view') return false;
+    return isItemDirty(formData, originalRef.current);
+  }, [formData, mode]);
+
+  // Cancel flow: show confirm dialog if dirty, otherwise close/return to view
+  const handleCancel = useCallback(() => {
+    if (isDirty()) {
+      setConfirmOpen(true);
+    } else if (mode === 'edit') {
+      // No changes in edit mode: return to view mode
+      onEdit?.();
+    } else {
+      // Add mode with no changes: close drawer
+      onClose();
+    }
+  }, [isDirty, mode, onEdit, onClose]);
+
+  // Confirm discard: discard changes and close/return
+  const handleConfirmDiscard = useCallback(() => {
+    setConfirmOpen(false);
+    if (mode === 'edit') {
+      setFormData(originalRef.current);
+      onEdit?.();
+    } else {
+      onClose();
+    }
+  }, [mode, onEdit, onClose]);
+
+  // Cancel discard: close dialog, stay in form
+  const handleCancelDiscard = useCallback(() => {
+    setConfirmOpen(false);
+  }, []);
+
+  // Submit handler
+  const handleSubmit = useCallback(() => {
+    onSubmit?.(formData);
+  }, [formData, onSubmit]);
+
+  // Handle overlay click and X button: in form modes, trigger cancel flow
+  const handleCloseRequest = useCallback(() => {
+    if (mode === 'view') {
+      onClose();
+    } else {
+      handleCancel();
+    }
+  }, [mode, onClose, handleCancel]);
+
+  // Escape key handler
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      // Don't handle Escape when confirm dialog is open (it handles its own Escape)
+      if (confirmOpen) return;
+      if (e.key === 'Escape') {
+        if (mode === 'view') {
+          onClose();
+        } else {
+          handleCancel();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose, mode, handleCancel, confirmOpen]);
+
+  // Focus management: focus first focusable element when drawer opens
+  useEffect(() => {
+    if (!open) return;
+
+    // Small delay to let the transition start before focusing
+    const timer = setTimeout(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      const focusable = panel.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      focusable?.focus();
+    }, 50);
+
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className={cn(
+          'fixed inset-0 z-50 bg-black/60 transition-all duration-300',
+          open ? 'visible opacity-100' : 'invisible opacity-0',
+        )}
+        onClick={handleCloseRequest}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className={cn(
+          'fixed right-0 inset-y-0 z-50 w-full sm:w-[420px] lg:w-[460px] bg-white shadow-xl flex flex-col transition-transform duration-300',
+          open ? 'translate-x-0' : 'translate-x-full',
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-2 min-w-0">
+            <Package size={20} className="text-gray-400 shrink-0" />
+            <h2 id={titleId} className="text-base font-semibold text-gray-900 truncate">
+              {resolvedTitle}
+            </h2>
+          </div>
+          <button
+            onClick={handleCloseRequest}
+            aria-label="Close drawer"
+            className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {mode === 'view' && item && (
+            <ViewModeContent item={item} mechanismLabels={mechanismLabels} />
+          )}
+          {(mode === 'add' || mode === 'edit') && (
+            <FormModeContent
+              formData={formData}
+              setFormData={setFormData}
+              classificationTypes={classificationTypes}
+              mechanismLabels={mechanismLabels}
+            />
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-200">
+          {mode === 'view' && (
+            <button
+              onClick={onEdit}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
+            >
+              <Pencil size={16} />
+              Edit
+            </button>
+          )}
+          {(mode === 'add' || mode === 'edit') && (
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                className="px-4 py-2 rounded-lg bg-gray-900 text-white text-sm font-medium hover:bg-gray-800 transition-colors"
+              >
+                {mode === 'add' ? 'Add Item' : 'Save'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Confirm discard dialog */}
+      <ArdaConfirmDialog
+        open={confirmOpen}
+        title="Discard changes?"
+        message="You have unsaved changes that will be lost."
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+        confirmVariant="destructive"
+        onConfirm={handleConfirmDiscard}
+        onCancel={handleCancelDiscard}
+      />
+    </>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,13 @@ export type {
   ArdaButtonSize,
 } from './components/atoms/button/button';
 
+export { ArdaConfirmDialog } from './components/atoms/confirm-dialog/confirm-dialog';
+export type {
+  ArdaConfirmDialogProps,
+  ArdaConfirmDialogStaticConfig,
+  ArdaConfirmDialogRuntimeConfig,
+} from './components/atoms/confirm-dialog/confirm-dialog';
+
 // Molecules
 export { ArdaItemCard } from './components/molecules/item-card/item-card';
 export type { ArdaItemCardProps } from './components/molecules/item-card/item-card';
@@ -25,6 +32,30 @@ export {
 // Organisms
 export { ArdaSidebar } from './components/organisms/sidebar/sidebar';
 export type { ArdaSidebarProps, NavItem } from './components/organisms/sidebar/sidebar';
+
+export {
+  ArdaItemDrawer,
+  sampleItem,
+  emptyItem,
+  defaultMoney,
+  defaultQuantity,
+} from './components/organisms/item-drawer/item-drawer';
+export type {
+  ArdaItemDrawerProps,
+  ArdaItemDrawerStaticConfig,
+  ArdaItemDrawerRuntimeConfig,
+  ItemData,
+  ItemDrawerMode,
+  Supply,
+  Money,
+  Quantity,
+  Duration,
+  Locator,
+  ItemClassification,
+  OrderMechanism,
+  Currency,
+  TimeUnit,
+} from './components/organisms/item-drawer/item-drawer';
 
 // Utilities
 export { cn } from './lib/utils';


### PR DESCRIPTION
## Summary

- Add `ArdaConfirmDialog` atom: reusable modal confirmation dialog with focus trap, Escape key support, ARIA alertdialog semantics, and destructive/primary variants
- Add `ArdaItemDrawer` organism: right-side slide-in panel with view, add, and edit modes for inventory items. Includes production-faithful data model (ItemData with nested Supply, Money, Quantity, Locator, etc.), 7-section form, and cancel-with-confirmation flow
- Export both components and all public types from package index
- CHANGELOG updated to v1.1.0

## Artifacts

| File | Description |
|------|-------------|
| `confirm-dialog.tsx` | Component + interfaces |
| `confirm-dialog.stories.tsx` | 3 stories (Default, CustomLabels, Interactive) |
| `confirm-dialog.test.tsx` | 6 unit tests |
| `confirm-dialog.mdx` | Documentation |
| `item-drawer.tsx` | Component + types + data model (~1215 lines) |
| `item-drawer.stories.tsx` | 4 static + 3 interactive stories with play functions |
| `item-drawer.test.tsx` | 14 unit tests |
| `item-drawer.mdx` | Documentation |
| `index.ts` | Package exports |
| `CHANGELOG.md` | v1.1.0 entry |

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 63/63 tests passing (7 files)
- [x] `npm run build-storybook` — builds successfully
- [ ] Verify stories render correctly in Storybook UI
- [ ] Verify interactive play functions complete without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)