### PR TITLE
fix: story test and GitHub Actions version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: "Extract tag from the changelog"
         uses: denisa/clq-action@v1
         id: clq-extract
@@ -78,7 +78,7 @@ jobs:
       contents: write
       deployments: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: denisa/clq-action@v1
         id: clq-extract
         with:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,14 +16,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build-storybook
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: storybook-static
       - id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,13 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: "Extract version from changelog"
         uses: denisa/clq-action@v1
         id: clq-extract
         with:
           changeMap: .github/clq/changemap.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://npm.pkg.github.com

--- a/src/components/organisms/item-drawer/item-drawer.stories.tsx
+++ b/src/components/organisms/item-drawer/item-drawer.stories.tsx
@@ -159,7 +159,8 @@ export const ViewToEdit: Story = {
     const canvas = within(canvasElement);
 
     // Scene 1: Drawer is open in view mode with sample item data
-    await expect(canvas.getByText('Hydraulic Cylinder HC-500')).toBeInTheDocument();
+    const nameElements = canvas.getAllByText('Hydraulic Cylinder HC-500');
+    await expect(nameElements.length).toBeGreaterThanOrEqual(1);
     await expect(canvas.getByText('HYD-CYL-HC500')).toBeInTheDocument();
     await delay(1500);
 


### PR DESCRIPTION
## Summary

- Fix ViewToEdit story play function that fails due to duplicate text query (`getByText` → `getAllByText` for item name appearing in header and content)
- Bump GitHub Actions: checkout v4/v5→v6, setup-node v4→v6, upload-pages-artifact v3→v4 (supersedes Dependabot PRs #2, #3, #4)

## Test plan

- [x] CI story test passes (verified on side-drawer branch)
- [ ] All CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)