### PR TITLE
fix: repair sync-to-publish pipeline

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,6 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v6
       - name: Enable auto-merge
         run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      changelog-modified: ${{ steps.changelog-check.outputs.modified }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -116,13 +118,14 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # For push events, compare against the previous commit.
-          # For PRs, compare against the base branch.
+          # For PRs, compare against the PR's base branch.
           if [ "$EVENT_NAME" = "push" ]; then
             DIFF_RANGE="${BEFORE_SHA}..HEAD"
           else
-            DIFF_RANGE="origin/main...HEAD"
+            DIFF_RANGE="origin/${BASE_REF}...HEAD"
           fi
           if git diff --name-only "$DIFF_RANGE" | grep -q '^CHANGELOG.md$'; then
             echo "modified=true" >> "$GITHUB_OUTPUT"
@@ -145,7 +148,7 @@ jobs:
           tag: ${{ steps.clq-extract.outputs.tag }}
 
   tag:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.validate-release.outputs.changelog-modified == 'true'
     needs: [validate-release]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,37 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check if CHANGELOG.md was modified
+        id: changelog-check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          # For push events, compare against the previous commit.
+          # For PRs, compare against the base branch.
+          if [ "$EVENT_NAME" = "push" ]; then
+            DIFF_RANGE="${BEFORE_SHA}..HEAD"
+          else
+            DIFF_RANGE="origin/main...HEAD"
+          fi
+          if git diff --name-only "$DIFF_RANGE" | grep -q '^CHANGELOG.md$'; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "modified=false" >> "$GITHUB_OUTPUT"
+            echo "CHANGELOG.md not modified — skipping release validation"
+          fi
       - name: 'Extract tag from the changelog'
+        if: steps.changelog-check.outputs.modified == 'true'
         uses: denisa/clq-action@v1
         id: clq-extract
         with:
           changeMap: .github/clq/changemap.json
           mode: release
-      - uses: denisa/semantic-tag-helper@v1
+      - name: Validate tag
+        if: steps.changelog-check.outputs.modified == 'true'
+        uses: denisa/semantic-tag-helper@v1
         with:
           mode: test
           tag: ${{ steps.clq-extract.outputs.tag }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/src/components/organisms/shared/entity-viewer/entity-viewer.test.tsx
+++ b/src/components/organisms/shared/entity-viewer/entity-viewer.test.tsx
@@ -725,7 +725,7 @@ describe('mount-time validation', () => {
 
     // Should not have mount-time errors (design config errors may fire but not mount ones)
     const mountErrors = consoleErrorSpy.mock.calls.filter(
-      (call) => typeof call[0] === 'string' && call[0].includes('MountConfig'),
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('MountConfig'),
     );
     expect(mountErrors).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

Fixes 4 issues that break the automated sync-to-publish pipeline:

- **auto-merge.yml**: Add missing `actions/checkout` step — `gh pr merge` requires git repo context
- **validate-release**: Skip tag validation when `CHANGELOG.md` is unmodified — automated PRs (sync, dependabot) don't bump versions, so the existing-tag check permanently blocks them
- **react-docgen**: Patch Storybook's docgen Vite plugin to skip `vendored/` and `shims/` files — `react-docgen`'s babel traverse crashes on complex TypeScript from arda-frontend-app
- **entity-viewer.test.tsx**: Add explicit type annotation for implicit `any` exposed by dependabot TypeScript bump

## Test plan

- [ ] `build-and-test` CI passes (lint, tsc, unit tests, storybook build, storybook test runner)
- [ ] `vrt` CI passes (baseline generation)
- [ ] `validate-release` passes (CHANGELOG.md not modified in this PR → skip)
- [ ] After merge: re-run sync workflow from arda-frontend-app and verify app-sync PR CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)