### PR TITLE
ci: use PAT for auto-merge to trigger downstream workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN || github.token }}


### PR DESCRIPTION
## Summary

- Switch auto-merge workflow from `github.token` to `secrets.CROSS_REPO_TOKEN` (PAT)
- Pushes made by `GITHUB_TOKEN` don't trigger further workflow runs (GitHub's infinite-loop prevention), so auto-merged PRs never fired the `tag` / `deploy` / `publish` workflows on main
- Using a PAT attributes the merge push to a real user, allowing the full pipeline to run

## Prerequisites

- `CROSS_REPO_TOKEN` secret must be set on this repo (same PAT as in arda-frontend-app)

## Test plan

- [ ] Verify `CROSS_REPO_TOKEN` secret is set on ux-prototype
- [ ] Merge this PR
- [ ] Trigger a sync from arda-frontend-app (push to dev)
- [ ] Verify the auto-merged sync PR triggers ci → tag → deploy on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)