### PR TITLE
ci: auto-approve automated sync PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,6 +12,13 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+      - name: Auto-approve sync PRs
+        if: >-
+          github.event.pull_request.user.login == 'systems-arda'
+          && github.event.pull_request.head.ref == 'app-sync'
+        run: gh pr review ${{ github.event.pull_request.number }} --approve
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Enable auto-merge
         run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
         env:


### PR DESCRIPTION
## Summary

- Auto-approve sync PRs so they don't require manual review approval
- Only applies when **both** conditions match:
  - PR author is `systems-arda` (the PAT used by the sync workflow)
  - Head branch is `app-sync` (the automated sync branch)
- Uses `github.token` (github-actions[bot]) for the approval — a different identity from the PR author
- All other PRs still require manual review as before

## How it works

The auto-merge workflow now has a conditional approval step before enabling auto-merge:
1. Check if PR is from `systems-arda` on `app-sync` → approve with `github.token`
2. Enable auto-merge with PAT (unchanged)

## Test plan

- [ ] Merge this PR
- [ ] Push to `dev` on arda-frontend-app to trigger a sync
- [ ] Verify the sync PR is auto-approved and auto-merged without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)