### PR TITLE
Disable basic authentication add Procurement Use Case Section & Personas

### DIFF
--- a/.storybook/middleware.js
+++ b/.storybook/middleware.js
@@ -1,26 +1,29 @@
-const SECRET = process.env.STORYBOOK_SECRET || 'ArdaSecretPrototypes';
-const REALM = 'Arda Prototypes';
+// Basic auth middleware — DISABLED.
+// To re-enable, uncomment the auth logic below and remove the early next() call.
+
+// const SECRET = process.env.STORYBOOK_SECRET || 'ArdaSecretPrototypes';
+// const REALM = 'Arda Prototypes';
 
 export default function expressMiddleware(app) {
   app.use((req, res, next) => {
-    // TODO: Re-enable basic auth after design session
     return next();
 
-    const header = req.headers.authorization;
-
-    if (header) {
-      const [scheme, encoded] = header.split(' ');
-      if (scheme === 'Basic' && encoded) {
-        const decoded = Buffer.from(encoded, 'base64').toString('utf-8');
-        const pass = decoded.includes(':') ? decoded.split(':').slice(1).join(':') : decoded;
-        if (pass === SECRET) {
-          return next();
-        }
-      }
-    }
-
-    res.statusCode = 401;
-    res.setHeader('WWW-Authenticate', `Basic realm="${REALM}"`);
-    res.end('Access denied');
+    // --- Basic auth (commented out) ---
+    // const header = req.headers.authorization;
+    //
+    // if (header) {
+    //   const [scheme, encoded] = header.split(' ');
+    //   if (scheme === 'Basic' && encoded) {
+    //     const decoded = Buffer.from(encoded, 'base64').toString('utf-8');
+    //     const pass = decoded.includes(':') ? decoded.split(':').slice(1).join(':') : decoded;
+    //     if (pass === SECRET) {
+    //       return next();
+    //     }
+    //   }
+    // }
+    //
+    // res.statusCode = 401;
+    // res.setHeader('WWW-Authenticate', `Basic realm="${REALM}"`);
+    // res.end('Access denied');
   });
 }

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -70,6 +70,13 @@ const preview: Preview = {
           'Dev Witness',
           'Canary Refactor',
           'Use Cases',
+          [
+            'Reference',
+            'Procurement',
+            ['Context', 'References', 'Orders', 'Receiving', '*'],
+            'Samples',
+            '*',
+          ],
           'Archive',
           ['About', 'Applications', '*'],
           '*',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [2.0.1] - 2026-03-06
+
+### Fixed
+
+- Disabled HTTP Basic Authentication on Vercel Edge middleware, Express server, and Storybook
+  dev middleware — the Storybook site is now publicly accessible without credentials
+- Updated stakeholder instructions, README, and Makefile to reflect removal of auth
+
 ## [2.0.0] - 2026-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [2.0.1] - 2026-03-06
+## [2.1.0] - 2026-03-06
+
+### Added
+
+- Procurement use-case documentation pages: Context, References, Orders, and Receiving
+- Persona documentation pages: Alan (Account Admin), David (Purchasing Manager),
+  Irene (Inventory Manager), Keisha (Receiving Clerk), Sam (Shop-Floor Worker)
+- Storybook sidebar ordering for procurement use-case section
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ coverage-summary: ## Show coverage summary
 
 ## -- Serving & Publishing ----------------------------------------------------
 
-serve: build ## Serve built Storybook with basic auth
+serve: build ## Serve built Storybook locally
 	npm run serve
 
-preview: build ## Build, serve with basic auth, and watch src/ for auto-rebuild
+preview: build ## Build, serve (port 8080), and watch src/ for auto-rebuild
 	node tools/watch-rebuild.js
 
 publish: ## Build library and publish to GitHub Packages

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A shared React component library and interactive prototype gallery for Arda, bui
 
 The Storybook gallery is deployed to two environments:
 
-| Environment                 | URL                                        | Access                               | Deploys on                   |
-| --------------------------- | ------------------------------------------ | ------------------------------------ | ---------------------------- |
-| **Vercel** (external)       | https://ux-prototype-tau.vercel.app/       | Password-protected (HTTP Basic Auth) | CLI deploy (`vercel --prod`) |
+| Environment                 | URL                                        | Access              | Deploys on                   |
+| --------------------------- | ------------------------------------------ | ------------------- | ---------------------------- |
+| **Vercel** (external)       | https://ux-prototype-tau.vercel.app/       | Public (no auth)    | CLI deploy (`vercel --prod`) |
 | **GitHub Pages** (internal) | https://arda-cards.github.io/ux-prototype/ | Repo collaborators via GitHub login  | Push to `main`               |
 
-**Vercel** is the primary site for sharing with stakeholders. Credentials are stored in **1Password** under the **Arda-SystemsOAM** vault.
+**Vercel** is the primary site for sharing with stakeholders.
 
 **GitHub Pages** is for team-internal use. Access is restricted to repository collaborators who authenticate with their GitHub account (Settings > Pages > visibility).
 
@@ -57,7 +57,7 @@ make check            # Run all checks (lint + typecheck)
 make test             # Run unit tests
 make test-coverage    # Run unit tests with coverage
 make test-storybook   # Run Storybook interaction tests
-make serve            # Serve built Storybook with basic auth
+make serve            # Serve built Storybook locally
 make preview          # Build then serve Storybook
 make publish          # Build library and publish to GitHub Packages
 make clean            # Remove build artifacts and node_modules

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,24 +1,31 @@
-const SECRET = process.env.SHARED_SECRET || 'ArdaSecretPrototypes';
-const REALM = 'Arda Prototypes';
+// Basic auth middleware — DISABLED.
+// To re-enable, uncomment the body and remove the pass-through return.
+
+// const SECRET = process.env.SHARED_SECRET || 'ArdaSecretPrototypes';
+// const REALM = 'Arda Prototypes';
 
 export default function middleware(request: Request): Response {
-  const header = request.headers.get('authorization');
+  // Pass through all requests without authentication
+  return new Response(null, { status: 200, headers: { 'x-middleware-next': '1' } });
 
-  if (header) {
-    const [scheme, encoded] = header.split(' ');
-    if (scheme === 'Basic' && encoded) {
-      const decoded = atob(encoded);
-      const pass = decoded.includes(':') ? decoded.split(':').slice(1).join(':') : decoded;
-      if (pass === SECRET) {
-        return new Response(null, { status: 200, headers: { 'x-middleware-next': '1' } });
-      }
-    }
-  }
-
-  return new Response('Access denied', {
-    status: 401,
-    headers: {
-      'WWW-Authenticate': `Basic realm="${REALM}"`,
-    },
-  });
+  // --- Basic auth (commented out) ---
+  // const header = request.headers.get('authorization');
+  //
+  // if (header) {
+  //   const [scheme, encoded] = header.split(' ');
+  //   if (scheme === 'Basic' && encoded) {
+  //     const decoded = atob(encoded);
+  //     const pass = decoded.includes(':') ? decoded.split(':').slice(1).join(':') : decoded;
+  //     if (pass === SECRET) {
+  //       return new Response(null, { status: 200, headers: { 'x-middleware-next': '1' } });
+  //     }
+  //   }
+  // }
+  //
+  // return new Response('Access denied', {
+  //   status: 401,
+  //   headers: {
+  //     'WWW-Authenticate': `Basic realm="${REALM}"`,
+  //   },
+  // });
 }

--- a/src/docs/personas/alan-account-admin.mdx
+++ b/src/docs/personas/alan-account-admin.mdx
@@ -1,0 +1,122 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Personas/Alan &#8212; Account Admin" />
+
+# Alan the Account Admin
+
+> &#8220;I need the system configured right so my team can focus on their jobs,
+> not on fighting the tools.&#8221;
+
+**Name:** Alan Adminson
+
+## Professional Background
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Job Title</td>
+      <td>
+        Administrator (decision-maker, system owner). Sometimes the owner, plant
+        manager, or office manager in smaller operations.
+      </td>
+    </tr>
+    <tr>
+      <td>Company</td>
+      <td>
+        Small to mid-size manufacturing or healthcare supply operation
+        (10&#8211;200 employees).
+      </td>
+    </tr>
+    <tr>
+      <td>Experience</td>
+      <td>
+        5&#8211;12 years in operations and SaaS platform management. Often the
+        person who evaluated Arda against alternatives and championed the
+        purchase.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+In small operations, this person signed up for Arda, created the initial item
+catalog, and invited the team. They often wear a second hat as the Inventory
+Manager (Arda Manager). In medium to large operations, it may be a dedicated IT
+coordinator or operations manager with admin-level access.
+
+**Responsibilities:** Setting up and configuring the Arda account, managing user
+accounts and permissions, maintaining company information (legal name, address,
+tax IDs, Registration ID, NAICS codes), overseeing subscription and billing, and
+ensuring the system meets compliance requirements. Responsible for driving the
+organization from &#8220;no system&#8221; to &#8220;world-class&#8221;
+operations by establishing ownership, aligning the team around a vision, running a
+focused pilot, and reinforcing behavior until compliance is easier than shortcuts.
+
+## Goals and Motivations
+
+- Keep the Arda account configured correctly so the operational personas can do
+  their jobs without friction.
+- Workers can sign in without issues. Company information is accurate on purchase
+  orders. New hires get access within their first day.
+- Set it up correctly once and not have to think about it. Reactive account
+  management is the worst outcome.
+- Maintaining compliance with healthcare industry regulations (accurate company
+  records, audit trails).
+- Seeing measurable results: fewer emergency orders, less waste, less downtime,
+  reduced stress for the team.
+
+## Challenges and Pain Points
+
+- Onboarding new team members requires setting up accounts, assigning roles, and
+  providing initial training on the card-based workflow.
+- Company information changes must be propagated accurately across the platform
+  for compliance and PO generation.
+- Managing multiple settings pages (Settings hub with Account/Companies/Appearance/
+  Notifications/Display tabs, Company Settings with Company Info/Users/Subscription/
+  Billing tabs, Account Profile) with related but distinct functionality.
+- No dedicated admin dashboard for monitoring system health and user activity.
+- Infrequent use means they must re-orient each time they return to admin screens.
+- Managing change deliberately: acknowledging the effort of changing habits,
+  explaining cost savings, highlighting the reduction in stress for the team.
+
+## Typical Day
+
+1. **Weekly:** Review company settings, check for pending user invitations or
+   access requests.
+2. **Monthly:** Review subscription status, check billing, update company
+   information if needed.
+3. **Ad hoc:** Onboard new team members (Company Settings &#8594; Users, invite
+   with role, guide through signup). Troubleshoot user issues. Adjust notification
+   preferences. Set up Quickstart Kit hardware (printer, laminator, scanner).
+4. **Occasionally:** Check dashboard KPIs (Total Orders, Orders Placed, Growth
+   Rate) to understand platform usage and order volumes.
+5. **Strategically:** Evaluate the organization&#8217;s position on the &#8220;no
+   system to world-class&#8221; journey. Decide when to expand from pilot teams to
+   full rollout.
+
+**Session pattern:** Infrequent, purposeful sessions. Comes into Arda to do
+something specific (add a user, update company address, check subscription) and
+leaves. Not a daily user in the Admin role, though they may use Arda daily in a
+secondary role.
+
+## Technology and Environment
+
+- Office desktop or laptop, dedicated workstation (not shared).
+- Full browser access (Chrome, 1920&#215;1080).
+- High technical proficiency relative to other Arda users.
+- Comfortable with SaaS administration consoles, multi-tab workflows, and
+  settings interfaces.
+- No scanning or printing requirements in the Admin role.
+
+## Personality
+
+Organized, cautious about changes, thorough in documentation. Prefers clear
+confirmation before applying system-wide settings. Wants structured pages with
+clear descriptions of what each option controls. Thinks strategically about
+adoption: technology alone does not solve the problem; success comes from habit,
+not features. Uses team rituals (huddles, reviews) to maintain system discipline.

--- a/src/docs/personas/david-purchasing-manager.mdx
+++ b/src/docs/personas/david-purchasing-manager.mdx
@@ -1,0 +1,120 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Personas/David &#8212; Purchasing Manager" />
+
+# David the Purchasing Manager
+
+> &#8220;If the queue is empty by noon, it&#8217;s been a good day.&#8221;
+
+**Name:** David Dealsworth
+
+## Professional Background
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Job Title</td>
+      <td>
+        Purchasing Manager (end-user, order executor). Also called Procurement
+        Coordinator.
+      </td>
+    </tr>
+    <tr>
+      <td>Company</td>
+      <td>
+        Small to mid-size manufacturing or healthcare supply operation. Sits at
+        the boundary between internal operations and external suppliers.
+      </td>
+    </tr>
+    <tr>
+      <td>Experience</td>
+      <td>
+        Procurement or operations background. Comfortable with purchasing
+        workflows and vendor portals.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+In small operations, this is the same person as the Inventory Manager. In medium
+to large operations, they are distinct roles: the Inventory Manager decides what
+needs to be ordered (by managing cards and reorder points), and the Purchasing
+Manager decides how and when to place those orders.
+
+**Responsibilities:** Executing purchase orders across four fulfillment
+workflows: Online (supplier portal checkout), In-Store (physical pickup with
+mobile recording), Email/Purchase Order (pre-filled email drafts or generated PDF
+POs), and RFQ (Request for Quote for items requiring supplier pricing before
+ordering). Tracks order status through the card lifecycle states:
+AVAILABLE &#8594; REQUESTED &#8594; INPROCESS &#8594; FULFILLING &#8594;
+DELIVERED.
+
+## Goals and Motivations
+
+- Execute purchase orders efficiently. Get items from &#8220;needs
+  ordering&#8221; to &#8220;supplier has the PO&#8221; as fast as possible.
+- The Order Queue is empty by noon. Every item that workers scanned in the
+  previous 24 hours has been ordered.
+- Supplier confirmations are on file. Items in transit are visible so receiving
+  can be scheduled.
+- A single queue grouped by supplier, with all ordering details attached,
+  replacing the email chaos of manual purchasing.
+- Eliminating duplicate orders and items falling through the cracks.
+- Fast lookup when a supplier calls about a price change or backorder.
+
+## Challenges and Pain Points
+
+- Items missing supplier URLs: the &#8220;Start order&#8221; button is disabled,
+  forcing manual ordering outside the system.
+- Items without supplier configuration require editing the item record (adding
+  Primary Supplier, SKU, supplier URL, Order Method) before the order can be
+  placed.
+- Distinguishing between &#8220;Ready to order&#8221; (REQUESTED state) and
+  &#8220;Recent orders&#8221; (INPROCESS state) tabs requires understanding the
+  card state model.
+- Phone-only suppliers cannot be integrated into the digital workflow; the
+  Purchasing Manager must manually advance card states after placing verbal orders.
+- Items bypassing the card system (&#8220;ordered without a card&#8221;) create
+  blind spots: broken kanban loops, lost inventory visibility, and vanished
+  accountability.
+
+## Typical Day
+
+1. **8:45am:** Open Order Queue. Review items grouped by supplier. Start with
+   suppliers that have configured URLs (one-click to open supplier portal).
+2. **9:00am&#8211;10:30am:** Work through the queue supplier by supplier. Open
+   portal, place order, return to Arda, advance card states from REQUESTED to
+   INPROCESS. For Email/PO suppliers: use pre-filled email draft or generate PDF
+   Purchase Order. For RFQ items: generate Request for Quote, send to suppliers.
+3. **Handle problem items:** suppliers without URLs, phone-only vendors, items
+   with missing data.
+4. **2:30pm:** Respond to supplier calls about backorders or delivery changes.
+   Update card notes, notify the Inventory Manager about delays.
+5. **End of day:** Quick check that the queue is clear. Remaining items flagged
+   for tomorrow.
+
+**Session pattern:** One longer working session per morning (20&#8211;45 minutes)
+to process the day&#8217;s orders, then shorter return visits (2&#8211;5 minutes)
+to check on in-progress items. May have Order Queue open in a pinned tab.
+
+## Technology and Environment
+
+- Office desktop or laptop, dedicated workstation (not shared).
+- Moderate to high technical proficiency. Comfortable with web interfaces and
+  multi-tab workflows.
+- Browser-based supplier portals are a core part of the workflow.
+- Will try to use keyboard shortcuts.
+- Scanner within reach for occasional ad-hoc scans.
+
+## Personality
+
+Efficient, process-driven, comfortable with multi-system workflows, focused on
+throughput and clearing the queue. Values shared standards: everyone follows the
+same process. Appreciates when the Inventory Manager enforces card discipline,
+because every order that bypasses the card creates work and risk downstream.

--- a/src/docs/personas/index.mdx
+++ b/src/docs/personas/index.mdx
@@ -1,0 +1,80 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Personas/Overview" />
+
+# Domain Personas
+
+Five personas represent the distinct users of the Arda inventory management
+platform. Together they form the **kanban replenishment loop** &#8212; a relay
+that spans the shop floor, the office, and the receiving dock.
+
+## Personas
+
+<table>
+  <thead>
+    <tr>
+      <th>Persona</th>
+      <th>Role in the Loop</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Irene Itemsworth</strong> &#8212; Inventory Manager</td>
+      <td>
+        Arda Manager. Owns the loop end to end: item setup, card creation,
+        printing, floor walks, cultural enforcement, and receiving.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Sam Scansworth</strong> &#8212; Shop Floor Worker</td>
+      <td>
+        Triggers the loop by consuming supplies and scanning (or dropping) the
+        kanban card at the reorder point.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>David Dealsworth</strong> &#8212; Purchasing Manager</td>
+      <td>
+        Executes the loop by placing orders with suppliers and advancing card
+        states through the procurement lifecycle.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Keisha Clerkson</strong> &#8212; Receiving Clerk</td>
+      <td>
+        Closes the loop by receiving deliveries, marking cards fulfilled, and
+        returning cards to their shelf positions.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Alan Adminson</strong> &#8212; Account Admin</td>
+      <td>
+        Configures the platform, manages users, and drives organizational
+        adoption &#8212; the infrastructure that makes the loop possible.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## The Kanban Loop
+
+The loop is a relay across all five personas:
+
+1. **Setup** (Irene): Creates items, prints cards, laminates them, places them
+   at reorder points on the shelf. Prints shelf labels and breadcrumbs. Card
+   state: AVAILABLE.
+2. **Consumption and Trigger** (Sam): Uses supplies until the front bin empties.
+   Picks up the visible kanban card. Scans it at the workstation or drops it in
+   the &#8220;To Order&#8221; bin. Card state: REQUESTED.
+3. **Order Processing** (David): Reviews the Order Queue grouped by supplier.
+   Places orders via supplier portals, email/PO, phone, or RFQ. Advances card
+   states. Card state: INPROCESS.
+4. **Receipt** (Keisha): Receives the delivery at the dock. Marks items received
+   in Arda. Returns physical cards to their shelf positions using breadcrumbs
+   for location guidance. Card state: FULFILLED / SHELVED.
+5. **Loop Closed**: Card is back at the reorder point, item is restocked, system
+   is ready for the next cycle.
+
+The loop breaks in three predictable places: the worker does not scan the card,
+the card is missing or damaged, or the delivery is received but not logged. All
+five personas have responsibilities that address these failure modes.

--- a/src/docs/personas/irene-inventory-manager.mdx
+++ b/src/docs/personas/irene-inventory-manager.mdx
@@ -1,0 +1,129 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Personas/Irene &#8212; Inventory Manager" />
+
+# Irene the Inventory Manager
+
+> &#8220;If I can&#8217;t find it in two clicks, it&#8217;s costing us money.&#8221;
+
+**Name:** Irene Itemsworth
+
+## Professional Background
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Job Title</td>
+      <td>
+        Inventory Manager (end-user, daily operator). Also called
+        &#8220;Arda Manager&#8221; in Arda&#8217;s own documentation.
+      </td>
+    </tr>
+    <tr>
+      <td>Company</td>
+      <td>
+        Small to mid-size manufacturing or healthcare supply operation
+        (10&#8211;200 employees).
+      </td>
+    </tr>
+    <tr>
+      <td>Experience</td>
+      <td>5&#8211;10 years in supply chain or manufacturing operations.</td>
+    </tr>
+  </tbody>
+</table>
+
+The Arda Manager owns the replenishment loop: from the moment a card is scanned
+to the moment the item is received and restocked. They are the connective tissue
+between the people who use supplies and the people who buy them.
+
+In smaller operations (10&#8211;50 people), this person is often the shop
+manager, office manager, or operations lead who took on inventory responsibility
+because no one else did. They are not a software specialist; they are an
+operations person who uses Arda daily as part of their job.
+
+**Responsibilities:** Maintains accurate inventory records, creates and updates
+item entries, manages kanban card lifecycle (print, distribute, scan, reorder),
+processes the order queue, receives inbound shipments, trains shop floor workers
+on the card system, and enforces &#8220;no card, no order&#8221; discipline.
+Categorizes items using the Three Types of Inventory model: Type 1 (Always in
+Stock, ~80% of items, managed with Kanban cards), Type 2 (Infrequent but
+reliable, managed via binder-based or project-based ordering), and Type 3
+(One-off orders, tracked in the Order Archive without a card).
+
+## Goals and Motivations
+
+- **&#8220;Never Run Out.&#8221;** The primary fear is a stockout: when a worker
+  cannot find a critical supply and has to stop work or improvise.
+- Items arrive before the shop runs out. Cards are always visible at the reorder
+  point. Workers can scan and move on without help.
+- The Order Queue is empty or near-empty at the end of each week.
+- Gradually push more items from Type 2 to Type 1 as consumption patterns become
+  clearer, increasing the fraction of inventory on automatic replenishment.
+- Making every order traceable and every reorder point observable.
+- Training and cultural enforcement: convincing shop floor workers to scan cards
+  instead of calling directly, reinforcing the card-based workflow.
+
+## Challenges and Pain Points
+
+- Managing a catalog of 50+ items with multiple attributes (Title, SKU, Minimum
+  Quantity, Order Unit, Primary Supplier, Unit Price, Image URL, Order Method)
+  and categorization fields (Item Type, Subtype, Use Case, Location/Sub-Location).
+- Sizing minimum quantities correctly: must account for consumption during lead
+  time plus a safety buffer.
+- Switching between item list view, item detail, kanban cards, and order queue to
+  complete a single reorder workflow.
+- Print workflow reliability: kanban cards, shelf labels, and breadcrumbs open
+  PDFs in new browser tabs via popup windows. Popup blockers silently suppress
+  the tab &#8212; the most common real-world failure for this persona.
+- Shared workstations mean another user may navigate away mid-batch.
+- USB scanner disconnection or battery death requires fallback to manual text
+  entry.
+
+## Typical Day
+
+1. **7:15am:** Open Arda, check Order Queue badge count. Process cards workers
+   scanned overnight. Group by supplier, start orders, advance card states:
+   AVAILABLE &#8594; REQUESTED &#8594; INPROCESS.
+2. **8:30am:** Walk the floor (weekly ritual). Check card condition, verify cards
+   are in correct positions, look for items without cards that should have them.
+3. **10:00am:** Handle ad-hoc requests. Add new items, set categorization, publish,
+   create and print cards (PDF to Tray 2), laminate, place on shelves. Print shelf
+   labels and breadcrumbs (Avery 8.5&#215;11, Tray 1).
+4. **2:00pm:** Receive deliveries. Open Receiving page, mark items received, return
+   physical cards to shelf positions.
+5. **Throughout the day:** Quick checks on item details, print replacement cards,
+   adjust minimum quantities.
+
+**Session pattern:** Two to three shorter sessions per day: a morning processing
+session (15&#8211;30 minutes), a midday check (5&#8211;10 minutes), and an
+end-of-day verification (5&#8211;10 minutes).
+
+## Technology and Environment
+
+- Dedicated or semi-dedicated desktop at a desk in a supply room or at the
+  boundary between the office and shop floor.
+- Always browser-based (Chrome/Edge on a 1080p or 1440p display).
+- USB QR scanner plugged into the same workstation.
+- Comfortable with web applications but not a power user. Relies on visual cues
+  (colors, icons) rather than keyboard shortcuts.
+
+**Physical artifacts:**
+- **Kanban cards:** Laminated index cards with QR codes, printed from Arda.
+- **Shelf labels:** Avery stickers fixed to shelves/bins identifying what belongs there.
+- **Breadcrumbs:** Restocking pointers placed near the receiving dock.
+- **&#8220;To Order&#8221; and &#8220;Ordered&#8221; physical bins:** Central
+  collection points for cards in transit through the loop.
+
+## Personality
+
+Detail-oriented, methodical, pragmatic, slightly impatient with slow or
+confusing interfaces. Prioritizes reliability and speed over configurability.
+Leads by example: scans their own cards, follows the process visibly. Embeds
+Arda into team rhythms: daily huddles, weekly reviews, monthly analysis.

--- a/src/docs/personas/keisha-receiving-clerk.mdx
+++ b/src/docs/personas/keisha-receiving-clerk.mdx
@@ -1,0 +1,130 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Personas/Keisha &#8212; Receiving Clerk" />
+
+# Keisha the Receiving Clerk
+
+> &#8220;If it&#8217;s not checked in by end of shift, it might as well not
+> have arrived.&#8221;
+
+**Name:** Keisha Clerkson
+
+## Professional Background
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Job Title</td>
+      <td>
+        Receiving Clerk (end-user, physical operations). Also called Receiving
+        Associate, Warehouse Associate.
+      </td>
+    </tr>
+    <tr>
+      <td>Company</td>
+      <td>
+        Small to mid-size manufacturing or healthcare supply operation. Works
+        at the receiving dock or warehouse area where deliveries arrive.
+      </td>
+    </tr>
+    <tr>
+      <td>Experience</td>
+      <td>
+        2&#8211;5 years of warehouse operations experience in dedicated roles.
+        In small operations, the Inventory Manager or a general shop worker does
+        receiving as part of their routine.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+The Receiving Clerk works at the physical end of the Kanban loop. Their job is to
+close both the digital and physical loops: mark items as received in Arda and
+return kanban cards to their shelf positions.
+
+**Responsibilities:** Unpacking deliveries, counting items, verifying against
+packing slips, restocking shelves at the correct Location and Sub-Location,
+closing the digital loop by marking items as received (transitioning card state
+through DELIVERED &#8594; RECEIVED &#8594; SHELVED, or directly to FULFILLED in
+streamlined flow), and physically returning kanban cards to their shelf positions.
+Uses breadcrumbs (restocking pointers printed by the Inventory Manager) to know
+exactly where items go.
+
+## Goals and Motivations
+
+- Process every delivery same-day. The Receiving page is empty at end of shift.
+- Cards are back on the shelves before end of day, closing the physical and
+  digital kanban loop.
+- Accurate receipt records so the Order Queue reflects reality: no ghost inventory
+  from unlogged deliveries.
+- Speed and simplicity: the receive action must be fast enough to complete at the
+  dock before moving to the next box.
+- Knowing where to put things: breadcrumbs and shelf labels eliminate the need to
+  call the Inventory Manager for every item.
+
+## Challenges and Pain Points
+
+- Deliveries arrive in bursts (typically morning when trucks come). Processing
+  must happen quickly between physical tasks.
+- The system does not model partial receipt. When a delivery is short, the clerk
+  marks it received anyway and handles the discrepancy offline.
+- Items that arrive without a corresponding digital record (ordered outside the
+  card system) have no breadcrumb and no shelf assignment.
+- Shared workstations near the dock: another user may navigate away, losing
+  in-progress work.
+- USB scanner connectivity issues require fallback to manual text entry.
+- Missing or damaged breadcrumbs: if the Inventory Manager has not printed a
+  breadcrumb for a recently added item, the clerk does not know where it goes.
+
+## Typical Day
+
+1. **9:30am:** Delivery truck arrives. Sign for boxes, wheel them to receiving
+   area. Open Arda&#8217;s Receiving page on the shared terminal.
+2. **For each item:** Open the box, count, verify against packing slip. Click
+   &#8220;Receive&#8221; in Arda. Card transitions to FULFILLED (streamlined
+   flow) or through DELIVERED &#8594; RECEIVED &#8594; SHELVED (full model). Pick
+   up the physical card from the &#8220;Ordered&#8221; bin, check the breadcrumb
+   for the shelf location, restock the item, place the card back at the shelf
+   position.
+3. **Note discrepancies** (short shipments, unexpected items without cards) on
+   the packing slip. Leave notes for the Purchasing Manager or Inventory Manager.
+4. **Afternoon:** Small packages or late deliveries. May use the USB scanner on
+   the Scan page for quick receive actions.
+5. **End of shift:** Verify the Receiving page is clear. Unprocessed items are
+   flagged.
+
+**Session pattern:** Very short, frequent sessions during receiving hours
+(2&#8211;10 minutes each). Interrupted constantly by physical work. On a heavy
+receiving day, in and out of Arda a dozen times.
+
+## Technology and Environment
+
+- Shared workstation near the receiving dock, or a dedicated terminal in larger
+  operations.
+- USB QR scanner is essential.
+- Variable technical proficiency: may only know the specific screens they use
+  (Receiving tab, Scan page) and be unfamiliar with Items or Order Queue.
+- Frequently arrives at Arda via QR code scan (card detail URL) rather than
+  navigating via the sidebar.
+
+**Physical artifacts:**
+- **Breadcrumbs:** The primary navigation aid. Placed near the receiving dock,
+  tells exactly where each item goes (Location / Sub-Location).
+- **Shelf labels:** Fixed to shelves/bins, confirm the clerk is restocking in the
+  right spot.
+- **Kanban cards:** Picked up from the &#8220;Ordered&#8221; bin and physically
+  returned to the shelf position after restocking.
+
+## Personality
+
+Action-oriented, physical, focused on throughput and accuracy. Prefers the
+simplest possible digital interaction to get back to physical tasks. Values a
+system that is easier to follow than to break. Relies on physical artifacts
+(breadcrumbs, shelf labels) more than the software interface. Flags missing
+breadcrumbs or damaged cards to the Inventory Manager for replacement.

--- a/src/docs/personas/sam-shop-floor-worker.mdx
+++ b/src/docs/personas/sam-shop-floor-worker.mdx
@@ -1,0 +1,125 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Personas/Sam &#8212; Shop Floor Worker" />
+
+# Sam the Shop Floor Worker
+
+> &#8220;Just tell me where to scan it and let me get back to work.&#8221;
+
+**Name:** Sam Scansworth
+
+## Professional Background
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Job Title</td>
+      <td>
+        Shop Floor Worker (end-user, trigger point). Also called Production
+        Worker, Technician, Assembler, or Maintenance Worker.
+      </td>
+    </tr>
+    <tr>
+      <td>Company</td>
+      <td>
+        Small to mid-size manufacturing or healthcare supply operation
+        (10&#8211;200 employees).
+      </td>
+    </tr>
+    <tr>
+      <td>Experience</td>
+      <td>
+        Variable. Career path is in their trade, not in inventory management.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+This is not an Arda-specific role &#8212; it is the person whose primary job is
+production, assembly, maintenance, or fabrication, and who interacts with Arda
+only at the moment they consume a supply and encounter a kanban card. They are
+the most numerous user type in any Arda deployment and the most critical adoption
+risk.
+
+Their Arda responsibility is narrow but essential: when they reach the reorder
+point for a supply (the front bin empties and the kanban card becomes visible),
+they must either scan the card at a nearby workstation or drop it in the
+&#8220;To Order&#8221; bin. This single action triggers the entire replenishment
+loop.
+
+## Goals and Motivations
+
+- Get supplies when they need them without interruption to their primary work.
+- Spend as little time as possible on inventory tasks. Under 30 seconds per card
+  scan is the target.
+- Not get blamed for stockouts that were not their fault.
+- Self-interest: if they scan the card, the item gets reordered automatically and
+  it is on the shelf when they need it next time.
+- Path of least resistance: they will follow the system if it is easier than the
+  alternative.
+- Peer pressure and team norms: once the majority of the team scans cards,
+  holdouts feel social pressure to comply.
+
+## Challenges and Pain Points
+
+- They do not think of themselves as Arda users. Inventory is not their job.
+- Time pressure: they are mid-task when the front bin empties. Stopping to scan a
+  card means breaking flow.
+- Physical environment: gloved or dirty hands make touchscreens and keyboards
+  harder to use.
+- Scanner availability: if the nearest workstation is occupied, across the room,
+  or the scanner is missing/broken, they will default to dropping the card in the
+  bin (acceptable) or ignoring it entirely (the failure mode).
+- Training gaps: new hires may not understand the two-bin system or know where the
+  &#8220;To Order&#8221; bin is. Training must happen live on the floor with real
+  items.
+- Cards that are missing, faded, or improperly placed may not be noticed at all.
+
+## Typical Day
+
+1. **Throughout the day:** Use supplies from the front bin as part of normal
+   production work. Do not think about inventory.
+2. **Trigger moment:** Front bin empties. Reach into the back bin. The kanban card
+   is the first thing they touch &#8212; it physically blocks access to the
+   minimum quantity.
+3. **Option A (preferred):** Walk to the nearby USB scanner workstation (ideally
+   within 20 feet). Scan the QR code. Click &#8220;Add to order queue.&#8221;
+   Done in under 30 seconds. Card state: REQUESTED.
+4. **Option B (acceptable):** Drop the card in the &#8220;To Order&#8221; bin.
+   The Inventory Manager will scan it during the next morning batch.
+5. **Option C (failure):** Ignore the card, set it aside, or lose it. No signal
+   is sent. Stockout.
+
+**Session pattern:** Not sessions in the traditional sense. A single action
+lasting 10&#8211;30 seconds, happening 0&#8211;5 times per day. They do not log
+in, navigate, or browse. They scan one card and walk away.
+
+## Technology and Environment
+
+- Shared workstation near their work area or at a central supply point.
+- USB QR scanner (pen or gun-shaped, plugs into USB, behaves like a keyboard
+  &#8212; no drivers or camera needed).
+- They do not need to know how the software works. They point the scanner at the
+  QR code and press the trigger. The system handles the rest.
+- May have minimal computer literacy. The interface must require zero navigation
+  and zero typing.
+
+**Physical artifacts:**
+- **Kanban card:** Laminated index card with a QR code, sitting at the reorder
+  point in the two-bin system.
+- **&#8220;To Order&#8221; bin:** Physical tray at a central location for card
+  drop-off.
+
+## Personality
+
+Practical, hands-on, focused on their primary trade. Impatient with anything that
+slows down production. Skeptical of new processes until they see personal benefit.
+Responds to demonstrated results, not explanations. Responds to visual cues: a
+brightly colored card at the reorder point, a clearly labeled bin, a scanner
+sitting on the counter ready to use.

--- a/src/use-cases/procurement/context.mdx
+++ b/src/use-cases/procurement/context.mdx
@@ -1,0 +1,112 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Use Cases/Procurement/Context" />
+
+# Procurement Context
+
+## Goal
+
+The use cases under the **Procurement** section define the end-to-end workflows
+that Arda users follow to order materials from vendors and receive them into
+their facilities. Procurement in Arda spans two major operational areas:
+
+- **Orders** &#8212; Creating, editing, approving, and submitting Purchase Orders
+  (POs) that formalize material requests to vendors. Orders originate from the
+  Kanban Card Order Queue, from a list of Items, from a blank form, or as copies
+  of previous orders. Each order contains a header with vendor and delivery
+  information plus one or more order lines specifying items, quantities, and
+  costs.
+
+- **Receiving** &#8212; Recording the arrival of goods against submitted orders,
+  tracking partial and complete deliveries, and closing orders once all materials
+  are accounted for. Receiving completes the procurement cycle by returning
+  Kanban Cards to the shop-floor inventory pool.
+
+These use cases cover the user-facing workflows and UI interactions. They build
+on the domain concepts of Purchase Orders, Order Lines, Items, Item Supplies,
+Business Affiliates, and Kanban Cards defined in the Arda information model.
+
+## Source Materials
+
+### Demo202509 &#8212; Ordering and Receiving Workflow
+
+<a href="https://docs.google.com/document/d/1PKI1eL1RBl3o7EfDFH65_LNm7HRTQL5TXIuqelJjs7w/edit?tab=t.0#heading=h.6edukkvb57br" target="_blank">Google Doc</a>
+
+Defines the procurement workflow from both user-centric and card-centric
+perspectives. Describes the four-step cycle: a card is added to the Order Queue,
+ordering starts (In Progress), ordering completes (Ordered), and materials are
+received (Fulfilled). Includes an alternate flow where ordering and receiving are
+collapsed into a single step for companies without a formal receiving process.
+Documents the required changes to the front-end and back-end to support these
+state transitions, including the mapping of user actions to Kanban Card lifecycle
+events.
+
+### Purchase Order Management
+
+<a href="https://docs.google.com/document/d/1NlEP-G6zJ2fSB5okdBXFKyfxObpjAR34w9_AFa9udk0/edit?tab=t.0#heading=h.nbluyjp7tsev" target="_blank">Google Doc</a>
+
+The comprehensive specification for the Purchase Order feature. Defines core
+domain concepts (Organization, Vendor, Customer, Supplier, Consumer), the
+Purchase Order and Order Line information models with full field specifications,
+and the complete order lifecycle with eleven states and twelve signals (including
+composite signals). Covers all creation modes (blank, from Kanban Cards, from
+copy), editing behavior, item reference management (staleness and invalidation),
+receiving, and interactions between POs and Kanban Cards. Also includes draft
+implementation tickets for both Kanban Card modifications and PO CRUD operations.
+
+### Simplified PO Spec V1 (PO-Lite)
+
+<a href="https://docs.google.com/document/d/10kmDva7aiIT1N-x3BAm6fmDOfjZAj1IfWJT1tCtBIeo/edit?tab=t.0#heading=h.y9w9ex5focv5" target="_blank">Google Doc</a>
+
+A scoped-down specification for a fast &#8220;Generate PO from Order Queue&#8221;
+workflow. The user views the Order Queue grouped by Vendor and Order Mechanism,
+opens a side panel to review and edit aggregated PO lines, and generates a
+vendor-ready PDF via the Documint service. Covers the interaction spec
+screen-by-screen (Order Queue grouped view, PO side panel with vendor/header/lines
+sections), data behavior rules (grouping, aggregation, quantity computation,
+editability), backend integration touchpoints, and edge cases. This spec
+represents a simplified first iteration that does not persist POs as first-class
+objects.
+
+### Drafts of PO Use Cases and Requirements
+
+<a href="https://arda-cards.github.io/technical-documentation/1_specifications/mvp2/purchase-orders/" target="_blank">Technical Documentation Site</a>
+
+The authoritative technical specification hosted in the `technical-documentation`
+repository. Contains the master index with the information model (PlantUML class
+diagram), entity field specifications, and lifecycle definitions. Sub-pages cover
+core use cases (listing orders, viewing details, creating from cards, updating
+headers, adding/removing lines, processing orders) and additional use cases
+(create empty, create by copy, order from items, add lines from items, submit).
+Each use case includes API routes, sequence diagrams, field defaults, and
+validation rules. Documents implementation status: creation and line management
+are implemented; submit, receive, complete, and cancel are stubs.
+
+### Information Model Context for Orders
+
+<a href="https://arda-cards.github.io/technical-documentation/2_design/2_functional/information-structure/domain-model/assets/items/R1/" target="_blank">Technical Documentation Site</a>
+
+The R1 domain model for Items and related entities (ItemSupply,
+ItemSupplyReference, ItemClassification). Defines the Item entity fields
+including supply references (primary, secondary, default), the
+`preferredSupply()` and `effectiveSupply()` computed lookups, and the
+OrderMethod enumeration. Also specifies mutation qualifiers (lax, strict, update)
+that govern how fields behave during create and update operations. This model
+underpins the item-to-order-line mapping used when PO lines are populated from
+inventory data.
+
+### Initial Audit Work for PO Use Cases
+
+<a href="https://www.figma.com/board/veCfrdVl1Yos2vacnNCWXv/Arda-Audit?node-id=0-1&p=f&t=omMvxEn18B21W5kO-0" target="_blank">Figma Board</a>
+
+A Figma board capturing the initial audit of the PO workflow, including
+annotations and observations on the current user experience and areas for
+improvement.
+
+### Original Figma Designs for Arda
+
+<a href="https://www.figma.com/design/JJJ5Yb7t8hMe2LfCX0W5gQ/Arda-MVP-2.0---Hi-Fi-Mockups?node-id=61-19170&p=f&t=0TVyIZeFQMRycAg5-0" target="_blank">Figma Design</a>
+
+The high-fidelity mockups for Arda MVP 2.0, including the procurement-related
+screens (order queue, purchase order forms, receiving views) that inform the
+visual design and interaction patterns for the use cases in this section.

--- a/src/use-cases/procurement/orders/orders.mdx
+++ b/src/use-cases/procurement/orders/orders.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Use Cases/Procurement/Orders/Overview" />
+
+# Orders
+
+(Placeholder &#8212; use case entries will be added as separate documents under this section.)

--- a/src/use-cases/procurement/receiving/receiving.mdx
+++ b/src/use-cases/procurement/receiving/receiving.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Use Cases/Procurement/Receiving/Overview" />
+
+# Receiving
+
+(Placeholder &#8212; use case entries will be added as separate documents under this section.)

--- a/src/use-cases/procurement/references.mdx
+++ b/src/use-cases/procurement/references.mdx
@@ -1,0 +1,701 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Use Cases/Procurement/References" />
+
+# Procurement Use Case Reference
+
+This document catalogs the known use cases for the Procurement domain, organized
+by functional area. Each entry links to its authoritative source specification
+and summarizes the user interaction. Use this as an index when planning or
+implementing Storybook use case stories under the **Orders** and **Receiving**
+subsections.
+
+## Source Documents
+
+<table>
+  <thead>
+    <tr>
+      <th>Tag</th>
+      <th>Source</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>D09</strong></td>
+      <td>Demo202509 Ordering Workflow</td>
+      <td>
+        User-centric and card-centric procurement workflow. Defines the four-step
+        cycle (queue &#8594; in progress &#8594; ordered &#8594; received) plus an
+        alternate flow that skips formal receiving.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>MVP2-C</strong></td>
+      <td>Purchase Orders &#8212; Core Use Cases</td>
+      <td>
+        Technical specifications with API routes, sequence diagrams, and field
+        defaults for listing, viewing, creating from cards, updating headers,
+        and adding/removing lines.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>MVP2-A</strong></td>
+      <td>Purchase Orders &#8212; Additional Use Cases</td>
+      <td>
+        Extended creation modes: empty order, copy of existing, from header and
+        lines, from item list. Also covers single-line addition and submission
+        workflow (not yet implemented).
+      </td>
+    </tr>
+    <tr>
+      <td><strong>PO-V1</strong></td>
+      <td>PO V1 Use Cases (Lite + Full)</td>
+      <td>
+        Actor-goal use cases with two scope tiers. Lite covers the simplified
+        &#8220;Generate PO from Order Queue&#8221; flow. Full adds PO management,
+        edit, receiving, and cancellation.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>PO-OQ</strong></td>
+      <td>Order Queue Sequence Diagrams</td>
+      <td>
+        Detailed sequence diagrams for current and proposed Order Queue
+        implementations, including card entry points and API call flows.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>E2E</strong></td>
+      <td>End-to-End Test Use Cases</td>
+      <td>
+        Playwright-level use cases verifying front-end behavior: page loads,
+        card state transitions, tab switching, search/filter, and API call
+        expectations.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Personas
+
+Three primary personas drive the procurement workflows (see
+<a href="?path=/docs/docs-personas-overview--docs">Domain Personas</a> for full
+profiles):
+
+- <a href="?path=/docs/docs-personas-david-purchasing-manager--docs">**David Dealsworth**</a>
+  (Purchasing Manager) &#8212; Processes orders through the queue, creates and
+  submits POs, generates vendor-ready PDFs, and manages the order lifecycle.
+  David is the primary actor for all Order Queue and Orders use cases.
+
+- <a href="?path=/docs/docs-personas-keisha-receiving-clerk--docs">**Keisha Clerkson**</a>
+  (Receiving Clerk) &#8212; Processes deliveries at the dock, marks items received
+  against POs, and transitions cards to FULFILLED. Keisha owns the Receiving
+  workflow.
+
+- <a href="?path=/docs/docs-personas-irene-inventory-manager--docs">**Irene Itemsworth**</a>
+  (Inventory Manager) /
+  <a href="?path=/docs/docs-personas-sam-shop-floor-worker--docs">**Sam Scansworth**</a>
+  (Shop Floor Worker) &#8212; Trigger the procurement loop by adding cards to the
+  Order Queue from the Items page, QR scan, or card detail view.
+
+## Current Scope Constraints
+
+The current release operates under these simplifications:
+
+- **Vendor = Supplier**: The organization that sells goods is also the one that
+  fulfills (ships) them. These are the same entity.
+- **Customer = Consumer = Tenant**: The Arda tenant is both the buyer and the
+  receiver. No separate organizational identities.
+- **No freight operators** or other third parties (insurers, financing) are
+  tracked by the system.
+- **No standalone organization management**: Vendor/supplier information lives
+  only within Item Supply records and PO headers, not as independently managed
+  Business Affiliate entities (though the BA module exists for reference data).
+
+## Domain Concepts
+
+The procurement domain centers on two entity lifecycles that interlock:
+
+### Purchase Order Lifecycle
+
+An order progresses through up to eleven states on the happy path:
+
+`NEW` &#8594; `APPROVED` &#8594; `SUBMITTED` &#8594; `IN_PROCESS` &#8594;
+`PARTIALLY_RECEIVED` &#8594; `RECEIVED` &#8594; `CLOSED`
+
+Non-happy-path states: `CANCELLED`, `REJECTED`, `DISPUTED`.
+
+The lifecycle is driven by **signals** that trigger state transitions:
+
+<table>
+  <thead>
+    <tr>
+      <th>Signal</th>
+      <th>Effect</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>approve</code></td>
+      <td>Fields and lines become fixed and read-only</td>
+    </tr>
+    <tr>
+      <td><code>submit</code></td>
+      <td>Order sent to vendor; triggers order-method-specific actions (open URL, generate email/PDF)</td>
+    </tr>
+    <tr>
+      <td><code>accept</code></td>
+      <td>Vendor has accepted the order</td>
+    </tr>
+    <tr>
+      <td><code>ship</code></td>
+      <td>Vendor has started fulfillment</td>
+    </tr>
+    <tr>
+      <td><code>receive</code></td>
+      <td>Goods received; contains item and quantity parameters recorded against PO lines</td>
+    </tr>
+    <tr>
+      <td><code>complete_receive</code></td>
+      <td>All expected goods received (manual trigger; no automatic reconciliation in this release)</td>
+    </tr>
+    <tr>
+      <td><code>complete</code></td>
+      <td>Order closed from a material flow perspective</td>
+    </tr>
+    <tr>
+      <td><code>cancel</code></td>
+      <td>Order cancelled; no future goods expected</td>
+    </tr>
+    <tr>
+      <td><code>reject</code></td>
+      <td>Customer rejects delivered goods (records event only in this release)</td>
+    </tr>
+    <tr>
+      <td><code>dispute</code></td>
+      <td>Business issue requiring vendor resolution; prevents closing</td>
+    </tr>
+  </tbody>
+</table>
+
+**Composite signals** allow shortcuts from any state. For example, `submit` from
+`NEW` is equivalent to `[approve, submit]`. `complete` from any state executes
+the shortest signal sequence to reach `CLOSED`.
+
+### Kanban Card Lifecycle (Procurement Segment)
+
+A Kanban Card represents a quantity of work-in-progress inventory. In the
+procurement workflow, a card traverses:
+
+`AVAILABLE`/`FULFILLED` &#8594; `REQUESTING` &#8594; `REQUESTED` &#8594;
+`IN_PROCESS` &#8594; `FULFILLED`
+
+Each transition maps to a user action:
+
+- **Add to Cart** &#8594; card fires `request` event &#8594; `REQUESTING`
+- **Start Order** (or PO `accept`) &#8594; card fires `accept` event &#8594; `REQUESTED`
+- **Submit PO** &#8594; card fires `start-processing` event &#8594; `IN_PROCESS`
+- **Receive** &#8594; card fires `receive` event &#8594; `FULFILLED`
+
+Cards are attached to PO lines via the `servicedCards` array, which tracks which
+cards contribute to each line and their individual quantities.
+
+**Important**: A card is always associated with exactly one Item, but an Item may
+have zero, one, or many cards. When ordering &#8220;from the Items page,&#8221;
+the system finds the first card associated with the item that is not already in
+the Order Queue.
+
+### Key Entities
+
+**Purchase Order** &#8212; The central document. Contains a header with vendor,
+delivery, and financial information plus an ordered list of lines.
+
+**Order Line (PoLine)** &#8212; One line per item being purchased. Tracks
+quantity ordered, unit cost, total cost, and quantity received. Lines can be
+linked to catalog items or free-form (no item reference).
+
+**Item** &#8212; Reference data describing a material. Contains name,
+description, SKU, classification, and supply references (primary, secondary,
+default). The `preferredSupply()` lookup returns the most relevant supply record.
+
+**ItemSupply** &#8212; Links an Item to a vendor with ordering details: supplier
+name, SKU, order method, URL, order quantity, unit cost, and average lead time.
+
+**BusinessAffiliate** &#8212; An organization (vendor, customer, carrier) with
+contact, address, and legal information. Referenced indirectly through ItemSupply
+vendor fields.
+
+**KanbanCard** &#8212; Represents a physical card on the shop floor. Carries a
+serial number, item reference, quantity, and lifecycle state.
+
+### Order Method
+
+The method used to place an order with a vendor. Determines what happens at
+submit time:
+
+`UNKNOWN` | `PURCHASE_ORDER` | `EMAIL` | `PHONE` | `IN_STORE` | `ONLINE` |
+`RFQ` | `PRODUCTION` | `TASK` | `THIRD_PARTY` | `OTHER`
+
+### Purchase Order Fields
+
+**Header fields:**
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>orderNumber</code></td>
+      <td>String</td>
+      <td>System-generated (<code>PO-000001</code>). Read-only.</td>
+    </tr>
+    <tr>
+      <td><code>status</code></td>
+      <td>Enum</td>
+      <td>Current lifecycle state. Read-only.</td>
+    </tr>
+    <tr>
+      <td><code>orderDate</code></td>
+      <td>Date</td>
+      <td>Set when the order is submitted. Editable with special permissions.</td>
+    </tr>
+    <tr>
+      <td><code>allowPartial</code></td>
+      <td>Boolean</td>
+      <td>Whether partial deliveries are accepted. Default: <code>true</code>.</td>
+    </tr>
+    <tr>
+      <td><code>deliverBy</code></td>
+      <td>Date</td>
+      <td>Expected complete delivery date. Default: now + 7 days.</td>
+    </tr>
+    <tr>
+      <td><code>deliveryAddress</code></td>
+      <td>Address</td>
+      <td>Ship-to address (line1, line2, city, state, postal code, country).</td>
+    </tr>
+    <tr>
+      <td><code>supplierName</code></td>
+      <td>String</td>
+      <td>Vendor name. Required for submission.</td>
+    </tr>
+    <tr>
+      <td><code>supplierAddress</code></td>
+      <td>Address</td>
+      <td>Vendor postal address.</td>
+    </tr>
+    <tr>
+      <td><code>orderMethod</code></td>
+      <td>OrderMethod</td>
+      <td>How the order is placed with the vendor.</td>
+    </tr>
+    <tr>
+      <td><code>procurement</code></td>
+      <td>Contact</td>
+      <td>Customer-side contact (name, job title, email, phone, address).</td>
+    </tr>
+    <tr>
+      <td><code>sales</code></td>
+      <td>Contact</td>
+      <td>Vendor-side contact.</td>
+    </tr>
+    <tr>
+      <td><code>goodsValue</code></td>
+      <td>Money</td>
+      <td>Sum of all line costs. Computed, read-only.</td>
+    </tr>
+    <tr>
+      <td><code>taxesAndFees</code></td>
+      <td>Map</td>
+      <td>Named charges (e.g., &#8220;Sales Tax&#8221;, &#8220;Shipping&#8221;).</td>
+    </tr>
+    <tr>
+      <td><code>totalAmount</code></td>
+      <td>Money</td>
+      <td><code>goodsValue</code> + sum of <code>taxesAndFees</code>. Computed.</td>
+    </tr>
+    <tr>
+      <td><code>termsAndConditions</code></td>
+      <td>String</td>
+      <td>Free-form T&#38;C text.</td>
+    </tr>
+    <tr>
+      <td><code>notes</code></td>
+      <td>String</td>
+      <td>Visible to vendor. Remains editable after submission.</td>
+    </tr>
+    <tr>
+      <td><code>privateNotes</code></td>
+      <td>String</td>
+      <td>Internal only. Remains editable after submission.</td>
+    </tr>
+  </tbody>
+</table>
+
+**Line fields:**
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>item</code></td>
+      <td>Reference</td>
+      <td>Item eId, name, and version rId. Blank for free-form lines.</td>
+    </tr>
+    <tr>
+      <td><code>title</code></td>
+      <td>String</td>
+      <td>Display name; defaults to supplier SKU or item name.</td>
+    </tr>
+    <tr>
+      <td><code>supplierSku</code></td>
+      <td>String</td>
+      <td>Vendor&#8217;s catalog number for the item.</td>
+    </tr>
+    <tr>
+      <td><code>quantity</code></td>
+      <td>Quantity</td>
+      <td>Amount + unit of measure. Required for submission.</td>
+    </tr>
+    <tr>
+      <td><code>unitCost</code></td>
+      <td>Money</td>
+      <td>Cost per unit. Populated from ItemSupply if available.</td>
+    </tr>
+    <tr>
+      <td><code>cost</code></td>
+      <td>Money</td>
+      <td>Total line cost (<code>quantity &#215; unitCost</code>).</td>
+    </tr>
+    <tr>
+      <td><code>received</code></td>
+      <td>Quantity</td>
+      <td>Amount received so far. Editable after submission.</td>
+    </tr>
+    <tr>
+      <td><code>notes</code></td>
+      <td>String</td>
+      <td>Per-line instructions to vendor.</td>
+    </tr>
+    <tr>
+      <td><code>servicedCards</code></td>
+      <td>Array</td>
+      <td>Kanban Cards contributing to this line, with per-card quantities.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Order Line Sub-Lifecycle
+
+Lines have their own states tracking the freshness of their item reference:
+
+- **BLANK** &#8212; No item assigned to the line.
+- **CURRENT** &#8212; Item reference is up to date.
+- **STALE** &#8212; The referenced item has been edited since the line was created.
+  The system auto-refreshes on inspection, preserving user edits to quantity and
+  notes.
+- **INVALID** &#8212; The referenced item has been deleted. The line must be
+  edited (assign a new item) or removed before the PO can be approved.
+
+---
+
+## Order Queue
+
+The Order Queue collects Kanban Cards in `REQUESTING` state as procurement
+demand signals, grouped by Vendor + Order Mechanism. It is the entry point for
+creating Purchase Orders.
+
+### Adding Cards to the Queue
+
+Cards enter the queue from multiple entry points. In all cases the card
+transitions from `FULFILLED`/`AVAILABLE` to `REQUESTING`:
+
+<table>
+  <thead>
+    <tr>
+      <th>Use Case</th>
+      <th>Entry Point</th>
+      <th>Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Add Card via Item List</td>
+      <td>Click item row on <code>/items</code>, then &#8220;Add to cart&#8221; in the detail panel</td>
+      <td>PO-OQ, E2E</td>
+    </tr>
+    <tr>
+      <td>Add Card via QR Scan</td>
+      <td>Scan QR code on <code>/scan</code>, then &#8220;Add to order queue&#8221;</td>
+      <td>PO-OQ, D09</td>
+    </tr>
+    <tr>
+      <td>Add Card via Card Detail Page</td>
+      <td>Navigate to <code>/kanban/cards/&lt;eId&gt;?view=card</code>, then &#8220;Add to order queue&#8221;</td>
+      <td>PO-OQ</td>
+    </tr>
+    <tr>
+      <td>Add Card via Cart Icon</td>
+      <td>Click cart icon in Items grid Quick Actions column</td>
+      <td>E2E</td>
+    </tr>
+  </tbody>
+</table>
+
+Common behavior: the system fires `POST event/request`, the Order Queue sidebar
+badge increments, and a confirmation toast or fly animation is shown.
+
+### Viewing and Filtering the Queue
+
+<a href="?path=/docs/docs-personas-david-purchasing-manager--docs">David</a> opens the Order Queue page to see two tabs:
+
+- **Ready to Order** &#8212; Cards in `REQUESTING` state, grouped by Vendor +
+  Order Mechanism. Groups with missing vendor/mechanism are labeled
+  &#8220;Unassigned&#8221;/&#8220;Unknown&#8221; with ordering disabled.
+- **Recent Orders** &#8212; Cards in `REQUESTED` and `IN_PROCESS` states.
+
+The user can switch groupings (by Supplier or by Order Method), search/filter by
+item name, SKU, or vendor, and collapse/expand groups.
+
+### Creating Orders from the Queue
+
+Two creation flows originate from the Order Queue:
+
+**Simplified flow (Lite)** &#8212; The user selects cards in a vendor group and
+clicks &#8220;Order All&#8221; (or &#8220;Order Selected&#8221;). A PO side panel
+opens with vendor section (name, contact, address), PO header (number, date,
+delivery address, terms), and aggregated lines (one per unique item, quantities
+summed from contributing cards). The user edits fields and clicks &#8220;Generate
+PO&#8221; to produce a PDF via Documint and copy the vendor email body to clipboard.
+Cards transition from `REQUESTING` to `REQUESTED`.
+
+**Full flow** &#8212; Similar to Lite but creates a persistent PO entity in `NEW`
+state. The user can save, continue editing, add more cards later, and submit when
+ready. Cards transition through `accept` events to `REQUESTED`, then via `submit`
+to `IN_PROCESS`.
+
+---
+
+## Orders (Purchase)
+
+### Creating Purchase Orders
+
+<table>
+  <thead>
+    <tr>
+      <th>Use Case</th>
+      <th>Description</th>
+      <th>Source</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>From Order Queue</td>
+      <td>Create PO draft from selected cards in a vendor group</td>
+      <td>PO-V1</td>
+      <td>Specified</td>
+    </tr>
+    <tr>
+      <td>From Kanban Cards</td>
+      <td>Validate card compatibility, group by item+UOM, create with aggregated lines</td>
+      <td>MVP2-C</td>
+      <td>Implemented</td>
+    </tr>
+    <tr>
+      <td>Empty Order</td>
+      <td>Blank form, persist header in NEW state with no lines</td>
+      <td>MVP2-A</td>
+      <td>Implemented</td>
+    </tr>
+    <tr>
+      <td>Copy of Existing</td>
+      <td>Duplicate existing PO, reset history and card attachments</td>
+      <td>MVP2-A</td>
+      <td>Not implemented</td>
+    </tr>
+    <tr>
+      <td>From Header and Lines</td>
+      <td>Programmatic creation with prescribed data, enriched from item supply</td>
+      <td>MVP2-A</td>
+      <td>Implemented</td>
+    </tr>
+    <tr>
+      <td>From List of Items</td>
+      <td>Select items sharing a compatible supplier, create PO with one line per item</td>
+      <td>MVP2-A</td>
+      <td>Implemented</td>
+    </tr>
+  </tbody>
+</table>
+
+### Viewing Purchase Orders
+
+POs are categorized into three list views by status:
+
+- **Draft** &#8212; Orders in `NEW` state. Editable.
+- **Receiving** &#8212; Orders in `SUBMITTED`, `IN_PROCESS`, or `PARTIALLY_RECEIVED` state.
+- **Completed** &#8212; Orders in `RECEIVED`, `CLOSED`, `ARCHIVED`, or `CANCELLED` state.
+
+All lists support filtering by header fields (order number, date, supplier name,
+goods value, address fields), filtering by item name of PoLines, sorting, and
+pagination. API endpoint: `POST /v1/order/order/query`.
+
+### Editing Purchase Orders
+
+Only POs in `NEW` state are editable. Editing includes:
+
+- **Header** &#8212; Vendor info, delivery address, payment terms, notes.
+  System-managed fields (`orderNumber`, `status`, `goodsValue`) are read-only.
+- **Add lines** &#8212; From Kanban Cards (merged with existing lines for same
+  item+UOM), blank lines with item typeahead selector, or bulk CSV upload.
+- **Remove lines** &#8212; Select and remove individual lines from the order.
+
+After submission, the PO becomes a frozen snapshot. Only `privateNotes` and
+`received` quantities remain writable.
+
+### Submitting and Generating POs
+
+<table>
+  <thead>
+    <tr>
+      <th>Use Case</th>
+      <th>Description</th>
+      <th>Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Submit PO</td>
+      <td>
+        Validate (vendor name, at least one line with title+quantity), send
+        <code>start-processing</code> events to cards, advance PO to SUBMITTED
+      </td>
+      <td>PO-V1</td>
+    </tr>
+    <tr>
+      <td>Submit and Release</td>
+      <td>
+        Submit and immediately transition cards to FULFILLED, skipping formal
+        receiving. For in-store pickups or direct-to-floor items.
+      </td>
+      <td>PO-V1</td>
+    </tr>
+    <tr>
+      <td>Generate PO PDF</td>
+      <td>
+        Assemble PO payload, send to Documint, open PDF in new tab, copy email
+        body to clipboard. Fallback button on clipboard failure.
+      </td>
+      <td>PO-V1</td>
+    </tr>
+    <tr>
+      <td>Send Order via Email</td>
+      <td>
+        Pre-populated email panel with supplier contact, item list, and template.
+        Cards advance to REQUESTED.
+      </td>
+      <td>E2E</td>
+    </tr>
+  </tbody>
+</table>
+
+### Cancelling Orders
+
+The user opens a PO in `NEW` or `SUBMITTED` state and clicks &#8220;Cancel.&#8221;
+Cards in `REQUESTED` state receive `shelve` events, reverting them to
+`REQUESTING` so they reappear in the Order Queue. Rollback behavior for cards
+already in `IN_PROCESS` is TBD.
+
+### Data Rules
+
+- **Line Aggregation** &#8212; Like items (same eId or SKU) are combined into
+  single PO lines. Quantity = sum of reorder quantities across contributing cards.
+- **Vendor Compatibility** &#8212; POs are scoped to a single vendor. Cards added
+  to an existing PO must have an ItemSupply matching the PO&#8217;s vendor.
+- **PO Number** &#8212; Auto-generated via `ScopedSequenceService`
+  (format `PO-000001`) in Full scope; user-entered in Lite.
+- **Free-Form Lines** &#8212; Lines not linked to any catalog item or card. All
+  fields are free text. No card state transitions.
+- **Snapshot Validation** &#8212; At submit time, all contributing cards must
+  still be in `REQUESTED` state. If changed, the system shows an error and
+  refreshes while preserving header edits.
+- **Update Propagation** &#8212; While in `NEW` state, supplier renames, item
+  name changes, and supply price changes propagate to PO fields. Submitted POs
+  are frozen.
+
+---
+
+## Receiving
+
+### Receiving Against Purchase Orders
+
+<a href="?path=/docs/docs-personas-keisha-receiving-clerk--docs">Keisha</a> navigates to the Receiving page. POs/cards in `IN_PROCESS` state are
+displayed grouped by supplier. She selects a PO or individual lines and clicks
+&#8220;Receive.&#8221; The system sends `receive` events, transitioning cards from
+`IN_PROCESS` to `FULFILLED`. If all lines are received, the PO advances to
+`RECEIVED`; if partial, it remains in `PARTIALLY_RECEIVED` or `IN_PROCESS`.
+
+An alternate &#8220;Release Card to Production&#8221; action transitions cards
+directly to `FULFILLED` without formal per-line receiving &#8212; used when
+materials go straight to the shop floor.
+
+### Receiving Page Views
+
+The `/receiving` page has two tabs:
+
+- **Receiving** &#8212; Items in transit (`REQUESTED`/`IN_PROCESS` cards), grouped
+  by supplier. Each row shows a status dropdown to mark items received
+  (`POST event/fulfill`).
+- **Recently Received** &#8212; `FULFILLED` cards within the last 24 hours, grouped
+  by supplier. Shows item name, SKU, receipt date, and quantity.
+
+Tab switching preserves any active search filter.
+
+### Completing Orders
+
+After all lines are received, the PO can be marked complete (`CLOSED` state).
+This is the final step of the procurement lifecycle. Detailed flows and API
+routes are not yet defined &#8212; this remains a lifecycle stub in the
+specifications.
+
+---
+
+## End-to-End Integration
+
+The **Order Lifecycle End-to-End** scenario verifies the complete procurement
+cycle. A card traverses `AVAILABLE` &#8594; `REQUESTING` &#8594; `REQUESTED`
+&#8594; `IN_PROCESS` &#8594; `FULFILLED` across three pages (Items, Order Queue,
+Receiving). Two personas collaborate:
+<a href="?path=/docs/docs-personas-david-purchasing-manager--docs">David</a>
+processes the order through the queue and advances card states;
+<a href="?path=/docs/docs-personas-keisha-receiving-clerk--docs">Keisha</a>
+receives the delivery and closes the loop. The
+scenario confirms sidebar badge counts update at each transition.
+
+---
+
+## Implementation Gaps
+
+The following areas are specified but not yet implemented in the backend:
+
+- **Submit Order** &#8212; Status transitions and vendor communication triggers
+  are not wired into the `operations` service.
+- **Process Order (Receive, Complete, Cancel)** &#8212; Core lifecycle stubs only;
+  no API routes or business logic.
+- **Create by Copy** &#8212; No service exists; callers must manually orchestrate.
+
+These gaps affect which use cases can be demonstrated as fully interactive
+Storybook stories versus documentation-only entries.

--- a/storybook-instructions.md
+++ b/storybook-instructions.md
@@ -4,8 +4,7 @@
 
 The prototype environment is live at: https://ux-prototype-tau.vercel.app/
 
-- **User:** `arda`
-- **Password:** `ArdaSecretPrototypes`
+No authentication is required — the site is publicly accessible.
 
 ## Leaving Feedback with the Commenting Tool
 

--- a/tools/server.js
+++ b/tools/server.js
@@ -1,23 +1,24 @@
-// server.js - serves built storybook with basic auth
+// server.js - serves built storybook (basic auth disabled)
 import express from 'express';
-import basicAuth from 'express-basic-auth';
+// import basicAuth from 'express-basic-auth';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 8080;
-const SECRET = process.env.STORYBOOK_SECRET || 'ArdaSecretPrototypes';
+// const SECRET = process.env.STORYBOOK_SECRET || 'ArdaSecretPrototypes';
 
 const app = express();
 
-app.use(
-  basicAuth({
-    users: { arda: SECRET },
-    challenge: true,
-    realm: 'Arda Prototypes',
-  }),
-);
+// Basic auth — disabled. Uncomment to re-enable.
+// app.use(
+//   basicAuth({
+//     users: { arda: SECRET },
+//     challenge: true,
+//     realm: 'Arda Prototypes',
+//   }),
+// );
 
 app.use(express.static(path.join(__dirname, '..', 'storybook-static')));
 

--- a/tools/watch-rebuild.js
+++ b/tools/watch-rebuild.js
@@ -86,7 +86,7 @@ ${SEPARATOR}
   Storybook Preview Server
 ${SEPARATOR}
 
-  Server:    http://localhost:${PORT}  (basic-auth: arda / <secret>)
+  Server:    http://localhost:${PORT}
   Watching:  src/**/*.{ts,tsx,mdx,css,json}
   Debounce:  ${DEBOUNCE_MS / 1000}s after last file change
 


### PR DESCRIPTION
## Summary

- Commented out HTTP Basic Auth in Vercel Edge middleware, Express server, and Storybook dev middleware so the site is publicly accessible
- Commented out `SHARED_SECRET` / `STORYBOOK_SECRET` in `.env`
- Removed basic-auth references from `watch-rebuild.js` output, Makefile target descriptions, README, and stakeholder instructions
- Auth code is preserved as comments for easy re-enablement

## Post-merge

- Remove `SHARED_SECRET` and `STORYBOOK_SECRET` from Vercel project environment variables
- Redeploy with `vercel --prod`

## Test plan

- [x] Storybook build succeeds
- [x] ESLint passes (zero warnings)
- [x] TypeScript type-check passes
- [x] 731 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)