### PR TITLE
fix: resolve GitHub Pages deployment broken by subpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,14 @@ jobs:
           npx concurrently -k -s first -n "SB,TEST" \
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on http://127.0.0.1:6006 && npm run test:storybook"
+      # Rebuild with subpath base and verify deployment works under /ux-prototype/
+      - run: npm run build-storybook
+        env:
+          STORYBOOK_BASE: /ux-prototype/
+      - run: |
+          npx concurrently -k -s first -n "SB,TEST" \
+            "node tests/smoke/subpath-server.mjs 6007 /ux-prototype/" \
+            "npx wait-on http://127.0.0.1:6007/ux-prototype/ && npx playwright test --project=subpath-deployment"
 
   vrt:
     if: ${{ ! github.event.pull_request.draft }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build-storybook
+        env:
+          STORYBOOK_BASE: /ux-prototype/
       - uses: actions/upload-pages-artifact@v4
         with:
           path: storybook-static

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -33,6 +33,13 @@ const config: StorybookConfig = {
     options: {},
   },
   viteFinal: async (config) => {
+    // Allow overriding the base path for subpath deployments (e.g., GitHub Pages).
+    // Set STORYBOOK_BASE=/ux-prototype/ in the build environment to serve
+    // all assets relative to that path. Defaults to '/' for local development.
+    if (process.env.STORYBOOK_BASE) {
+      config.base = process.env.STORYBOOK_BASE;
+    }
+
     const { resolve } = await import('node:path');
 
     config.resolve = config.resolve || {};
@@ -73,6 +80,26 @@ const config: StorybookConfig = {
     // for SSR-safe lazy loading, but Vite (ESM-only) cannot handle require().
     // This transform rewrites it at build time without modifying files on disk.
     config.plugins = config.plugins || [];
+
+    // Workaround for @storybook/builder-vite bug: the vite-inject-mocker
+    // plugin hardcodes `src="/vite-inject-mocker-entry.js"` in the HTML
+    // without respecting Vite's `base` config. When deployed under a subpath
+    // (e.g., /ux-prototype/), this causes a 404. This plugin rewrites the
+    // path to include the base prefix.
+    if (config.base && config.base !== '/') {
+      const base = config.base;
+      config.plugins.push({
+        name: 'fix-mocker-entry-base-path',
+        enforce: 'post' as const,
+        transformIndexHtml(html) {
+          return html.replace(
+            'src="/vite-inject-mocker-entry.js"',
+            `src="${base}vite-inject-mocker-entry.js"`,
+          );
+        },
+      });
+    }
+
     config.plugins.push({
       name: 'vendored-cjs-to-esm',
       enforce: 'pre' as const,

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -7,8 +7,18 @@ import { handlers } from '@frontend/mocks/handlers';
 import '../src/styles/globals.css';
 import '../src/styles/ag-theme-arda.css';
 
-// MSW initialization — runs once before any story mounts
-initialize({ onUnhandledRequest: 'bypass' });
+// MSW initialization — runs once before any story mounts.
+// When Storybook is built with a non-root base path (e.g., /ux-prototype/ on
+// GitHub Pages), Vite sets import.meta.env.BASE_URL accordingly. MSW must
+// register its service worker at the correct path — otherwise the browser
+// rejects the registration because the default `/mockServiceWorker.js` falls
+// outside the deployment scope.
+initialize({
+  onUnhandledRequest: 'bypass',
+  serviceWorker: {
+    url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
+  },
+});
 
 const preview: Preview = {
   decorators: [withAgentation, withFullAppProviders],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,9 +46,21 @@ export default defineConfig({
     {
       name: 'smoke',
       testDir: './tests/smoke',
+      testIgnore: ['**/subpath-deployment*'],
       timeout: 600000, // 10 min per batch — stories are split into batches of ~20
       use: {
         ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 900 },
+      },
+    },
+    {
+      name: 'subpath-deployment',
+      testDir: './tests/smoke',
+      testMatch: ['**/subpath-deployment*'],
+      timeout: 60000,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:6007',
         viewport: { width: 1280, height: 900 },
       },
     },

--- a/tests/smoke/subpath-deployment.spec.ts
+++ b/tests/smoke/subpath-deployment.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Subpath Deployment Smoke Test — verifies Storybook works when served under
+ * a URL prefix (e.g., /ux-prototype/ on GitHub Pages).
+ *
+ * This catches the class of bugs where:
+ *   - MSW's service worker registration fails because `mockServiceWorker.js`
+ *     is requested at the root instead of under the subpath
+ *   - Asset references use root-relative paths instead of base-relative paths
+ *     (e.g., /vite-inject-mocker-entry.js instead of /ux-prototype/...)
+ *   - Storybook renders an error overlay instead of the story
+ *
+ * Prerequisites:
+ *   - Storybook must be built with `STORYBOOK_BASE=/ux-prototype/`
+ *   - The subpath server must be running (see subpath-deployment project in
+ *     playwright.config.ts)
+ *
+ * Usage:
+ *   STORYBOOK_BASE=/ux-prototype/ npm run build-storybook
+ *   npx playwright test --project=subpath-deployment
+ */
+
+const SUBPATH = '/ux-prototype';
+
+// A handful of representative stories to verify. We don't need to test every
+// story — just enough to confirm that the Storybook shell, MSW service worker,
+// and asset loading all work under the subpath.
+const STORIES = [
+  {
+    name: 'Suppliers List (MSW-dependent)',
+    id: 'use-cases-reference-business-affiliates-ba-0001-browse-and-search-0001-view-suppliers-list--default',
+  },
+];
+
+test.describe('Subpath deployment', () => {
+  for (const story of STORIES) {
+    test(`${story.name}: renders without errors under ${SUBPATH}/`, async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on('pageerror', (err) => pageErrors.push(err.message));
+
+      // Track network failures (404s) for Storybook infrastructure resources.
+      // Exclude: external resources, API calls (MSW intercepts at runtime),
+      // and app-level image/asset paths from vendored code.
+      const failedRequests: { url: string; status: number }[] = [];
+      page.on('response', (response) => {
+        const url = response.url();
+        if (response.status() >= 400 && url.includes('localhost')) {
+          // Skip API calls (MSW), app images, and vendored assets
+          if (url.includes('/api/') || url.includes('/images/') || url.includes('/vendored/'))
+            return;
+          failedRequests.push({ url, status: response.status() });
+        }
+      });
+
+      // Navigate to the story iframe directly (same as the smoke tests do)
+      await page.goto(`${SUBPATH}/iframe.html?id=${story.id}&viewMode=story`, {
+        waitUntil: 'networkidle',
+        timeout: 30_000,
+      });
+
+      // 1. No failed network requests for local resources
+      expect(
+        failedRequests,
+        `Failed resource requests:\n${failedRequests.map((r) => `  ${r.status} ${r.url}`).join('\n')}`,
+      ).toHaveLength(0);
+
+      // 2. No Storybook error overlay
+      const errorOverlay = page.locator('.sb-errordisplay');
+      const overlayVisible = await errorOverlay.isVisible().catch(() => false);
+      if (overlayVisible) {
+        const errorText = await errorOverlay.textContent();
+        expect(overlayVisible, `Storybook error overlay shown: ${errorText}`).toBe(false);
+      }
+
+      // 3. No uncaught errors related to ServiceWorker
+      const swErrors = pageErrors.filter(
+        (msg) => msg.includes('ServiceWorker') || msg.includes('mockServiceWorker'),
+      );
+      expect(swErrors, `ServiceWorker errors: ${swErrors.join('; ')}`).toHaveLength(0);
+    });
+  }
+});

--- a/tests/smoke/subpath-server.mjs
+++ b/tests/smoke/subpath-server.mjs
@@ -1,0 +1,77 @@
+/**
+ * Minimal HTTP server that serves storybook-static under a configurable subpath.
+ *
+ * Usage:
+ *   node tests/smoke/subpath-server.mjs [port] [prefix]
+ *
+ * Defaults: port=6007, prefix=/ux-prototype/
+ *
+ * Requests to /ux-prototype/... are mapped to storybook-static/...
+ * All other requests get a 404. The server prints "READY" to stdout
+ * when it's listening, so callers can wait for that signal.
+ */
+import { createServer } from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { resolve, join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(__dirname, '../../storybook-static');
+
+const PORT = parseInt(process.argv[2] || '6007', 10);
+const PREFIX = process.argv[3] || '/ux-prototype/';
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json',
+};
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  let pathname = url.pathname;
+
+  // Only serve files under the prefix
+  if (!pathname.startsWith(PREFIX)) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not Found');
+    return;
+  }
+
+  // Strip prefix to get the relative file path
+  let relPath = pathname.slice(PREFIX.length);
+  if (relPath === '' || relPath.endsWith('/')) {
+    relPath += 'index.html';
+  }
+
+  const filePath = join(ROOT, relPath);
+
+  // Prevent directory traversal
+  if (!filePath.startsWith(ROOT)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not Found');
+    return;
+  }
+
+  const ext = extname(filePath);
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': contentType });
+  createReadStream(filePath).pipe(res);
+});
+
+server.listen(PORT, () => {
+  console.log(`READY — serving ${ROOT} at http://localhost:${PORT}${PREFIX}`);
+});


### PR DESCRIPTION
## Summary

- **Set Vite `base` path** via `STORYBOOK_BASE` env var in `deploy-pages.yml` so all asset references use `/ux-prototype/` prefix on GitHub Pages
- **Fix MSW service worker URL** in `.storybook/preview.ts` — compute from `import.meta.env.BASE_URL` instead of defaulting to root
- **Work around `@storybook/builder-vite` bug** — the `vite-inject-mocker` plugin hardcodes `src="/vite-inject-mocker-entry.js"` without respecting Vite's `base` config; added a post-process HTML transform to rewrite the path
- **Add `subpath-deployment` Playwright smoke test** that serves the built Storybook under `/ux-prototype/` and verifies no 404s or render errors — runs in CI to prevent regression

## Root cause

GitHub Pages serves at `https://arda-cards.github.io/ux-prototype/` but Storybook was built with root-relative paths. This caused:
1. `vite-inject-mocker-entry.js` → 404 (hardcoded `/` path)
2. MSW `ServiceWorkerRegistration` failure (wrong scope)
3. Story render errors (MSW never initialized)

## Test plan

- [x] New `subpath-deployment` test **fails** against root-built Storybook (catches the 404)
- [x] New `subpath-deployment` test **passes** against `STORYBOOK_BASE=/ux-prototype/` build
- [x] Existing smoke tests (24 batches) still pass — no regression
- [x] Lint, TypeScript, unit tests (731) all pass
- [x] 3 pre-existing `layout-integrity` failures confirmed on `main` baseline (not related)
- [ ] CI checks pass on this PR
- [ ] Verify GitHub Pages deployment works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)