### PR TITLE
Fix MSW service worker on GitHub Pages

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -7,7 +7,10 @@ import { handlers } from '@frontend/mocks/handlers';
 import '../src/styles/globals.css';
 import '../src/styles/ag-theme-arda.css';
 
-initialize({ onUnhandledRequest: 'bypass' });
+initialize({
+  onUnhandledRequest: 'bypass',
+  serviceWorker: { url: './mockServiceWorker.js' },
+});
 
 const preview: Preview = {
   decorators: [withAgentation, withFullAppProviders],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.0.1] - 2026-03-24
+
+### Fixed
+
+- MSW service worker registration on GitHub Pages: use relative URL (`./mockServiceWorker.js`)
+  instead of default absolute (`/mockServiceWorker.js`) so the worker resolves correctly under
+  the `/ux-prototype/` base path. Fixes all stories with per-story MSW handlers (Business
+  Affiliates, Dev Witness Items Grid, etc.) that showed `InvalidStateError` on the published site.
+
 ## [4.0.0] - 2026-03-20
 
 ### Added


### PR DESCRIPTION
> [!note]
> Authored by Claude Code for jmpicnic

## Summary

- Fix MSW service worker registration failing on GitHub Pages due to base path mismatch
- The `msw-storybook-addon` `initialize()` call used the default absolute URL `/mockServiceWorker.js`, which resolves to `https://arda-cards.github.io/mockServiceWorker.js` instead of `https://arda-cards.github.io/ux-prototype/mockServiceWorker.js`
- Changed to relative URL `./mockServiceWorker.js` which resolves correctly in both local and GH Pages environments
- This caused `InvalidStateError: Failed to get ServiceWorkerRegistration objects` for all stories with per-story MSW handlers (Business Affiliates, Dev Witness Items Grid, etc.)

## Changes

- `.storybook/preview.ts`: Add `serviceWorker: { url: './mockServiceWorker.js' }` to `initialize()` options
- `CHANGELOG.md`: Add 4.0.1 entry

## Test plan

- [x] `npm run lint` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npm run test` — 1047 tests pass
- [ ] After merge, verify stories load on GH Pages without `InvalidStateError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)