### PR TITLE
feat: integrate Agentation with Hypothesis for persistent threaded annotations

### DIFF
--- a/.storybook/addons/agentation-toggle/with-agentation.tsx
+++ b/.storybook/addons/agentation-toggle/with-agentation.tsx
@@ -1,8 +1,92 @@
 import React from 'react';
 import type { DecoratorFunction } from 'storybook/internal/types';
 import type { ReactRenderer } from '@storybook/react-vite';
-import { Agentation } from 'agentation';
+import { Agentation, loadAnnotations, saveAnnotations } from 'agentation';
+import type { Annotation } from 'agentation';
 import { PARAM_KEY } from './constants';
+import type { AgentationAnnotation } from '../hypothesis-bridge/transform';
+import { transformAnnotations } from '../hypothesis-bridge/transform';
+import { postAnnotation } from '../hypothesis-bridge/client';
+
+// Track annotation IDs that have already been posted to prevent duplicates
+const postedIds = new Set<string>();
+
+async function postToHypothesis(): Promise<void> {
+  const pathname = window.location.pathname;
+  const annotations = loadAnnotations<Annotation>(pathname);
+
+  // Filter out already-posted annotations
+  const newAnnotations = annotations.filter((a) => !postedIds.has(a.id));
+  if (newAnnotations.length === 0) {
+    console.info('[hypothesis-bridge] No new annotations to post');
+    return;
+  }
+
+  // Clear localStorage IMMEDIATELY to prevent Agentation from re-persisting
+  // before the async POST completes. Mark IDs as posted.
+  for (const a of newAnnotations) postedIds.add(a.id);
+  saveAnnotations(pathname, []);
+
+  const storyUrl = window.location.href;
+
+  // Enrich each annotation with live DOM text for Hypothesis anchoring.
+  // Hypothesis requires a TextQuoteSelector to display annotations in the
+  // sidebar — without it, annotations are orphaned and hidden.
+  //
+  // IMPORTANT: Only use text from the story content (#storybook-root),
+  // not from Storybook UI (controls panel, toolbars, etc.) which may
+  // not be present after reload.
+  const enriched = (newAnnotations as unknown as AgentationAnnotation[]).map((a) => {
+    if (a.selectedText) return a;
+    if (a.nearbyText && a.nearbyText.trim()) return a;
+
+    try {
+      const el = a.elementPath ? document.querySelector(a.elementPath) : null;
+      if (!el) return a;
+
+      // Only use text from inside the story root, not Storybook UI
+      const storyRoot = document.getElementById('storybook-root');
+      if (!storyRoot || !storyRoot.contains(el)) return a;
+
+      // Walk up from element to storyRoot looking for visible text
+      let current: Element | null = el;
+      while (current && storyRoot.contains(current)) {
+        const text = current.textContent?.trim();
+        if (text) return { ...a, nearbyText: text.slice(0, 200) };
+        current = current.parentElement;
+      }
+    } catch {
+      // querySelector may throw on invalid selectors; ignore
+    }
+    return a;
+  });
+  const payloads = transformAnnotations(enriched, storyUrl);
+
+  try {
+    await Promise.all(payloads.map((p) => postAnnotation(p)));
+    // Trigger highlight layer refresh
+    window.dispatchEvent(new CustomEvent('hypothesis-annotations-updated'));
+    console.info(`[hypothesis-bridge] Posted ${payloads.length} annotation(s) to Hypothesis`);
+    // Cycle the Agentation overlay off then on to clear badges and React state.
+    // The brief unmount/remount resets the component without losing the toolbar toggle.
+    try {
+      const channel = (window as unknown as Record<string, unknown>)
+        .__STORYBOOK_ADDONS_CHANNEL__ as
+        | { emit: (event: string, data: unknown) => void }
+        | undefined;
+      if (channel) {
+        channel.emit('updateGlobals', { globals: { [PARAM_KEY]: false } });
+        setTimeout(() => {
+          channel.emit('updateGlobals', { globals: { [PARAM_KEY]: true } });
+        }, 300);
+      }
+    } catch {
+      // Channel may not be available; ignore
+    }
+  } catch (err) {
+    console.error('[hypothesis-bridge] Failed to post to Hypothesis:', err);
+  }
+}
 
 export const withAgentation: DecoratorFunction<ReactRenderer> = (StoryFn, context) => {
   const isActive = !!context.globals[PARAM_KEY];
@@ -12,12 +96,10 @@ export const withAgentation: DecoratorFunction<ReactRenderer> = (StoryFn, contex
       <StoryFn />
       {isActive && (
         <Agentation
-          submitLabel="Copy JSON"
-          onSubmit={(json) => navigator.clipboard.writeText(json)}
-          onCopy={(markdown) => navigator.clipboard.writeText(markdown)}
+          onCopy={() => {
+            void postToHypothesis();
+          }}
           copyToClipboard
-          // endpoint="http://localhost:4747"  // future MCP integration
-          // sessionId=""                       // future MCP integration
         />
       )}
     </>

--- a/.storybook/addons/hypothesis-bridge/__tests__/client.test.ts
+++ b/.storybook/addons/hypothesis-bridge/__tests__/client.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { postAnnotation, searchAnnotations } from '../client';
+import { PROXY_BASE } from '../constants';
+import type { HypothesisAnnotationPayload } from '../transform';
+
+const mockPayload: HypothesisAnnotationPayload = {
+  uri: 'http://localhost:6006/iframe.html?id=use-cases--story',
+  text: 'Test annotation',
+  tags: ['Forensic', 'agentation', 'selector:div.test'],
+  group: 'e4e5jGAx',
+  target: [
+    {
+      source: 'http://localhost:6006/iframe.html?id=use-cases--story',
+      selector: [{ type: 'CssSelector', value: 'div.test' }],
+    },
+  ],
+};
+
+const mockCreatedAnnotation = {
+  id: 'abc123',
+  uri: mockPayload.uri,
+  text: mockPayload.text,
+  tags: mockPayload.tags,
+  group: mockPayload.group,
+  created: '2024-01-01T00:00:00Z',
+  updated: '2024-01-01T00:00:00Z',
+  target: mockPayload.target,
+};
+
+describe('postAnnotation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('sends a POST request to the proxy annotations endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCreatedAnnotation),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postAnnotation(mockPayload);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${PROXY_BASE}/annotations`);
+    expect(options.method).toBe('POST');
+    expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(options.body).toBe(JSON.stringify(mockPayload));
+  });
+
+  it('returns the created annotation with id assigned by Hypothesis', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockCreatedAnnotation),
+      }),
+    );
+
+    const result = await postAnnotation(mockPayload);
+    expect(result.id).toBe('abc123');
+    expect(result.uri).toBe(mockPayload.uri);
+  });
+
+  it('throws on non-2xx HTTP responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: () => Promise.resolve({ reason: 'Invalid token' }),
+      }),
+    );
+
+    await expect(postAnnotation(mockPayload)).rejects.toThrow('401');
+  });
+});
+
+describe('searchAnnotations', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('sends a GET request to the proxy search endpoint with query params', async () => {
+    const mockResponse = { total: 2, rows: [mockCreatedAnnotation] };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await searchAnnotations({
+      uri: 'http://localhost:6006/iframe.html?id=story',
+      tag: 'agentation',
+      group: 'e4e5jGAx',
+      limit: 50,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain(`${PROXY_BASE}/search`);
+    expect(url).toContain('uri=');
+    expect(url).toContain('tag=agentation');
+    expect(url).toContain('group=e4e5jGAx');
+    expect(url).toContain('limit=50');
+  });
+
+  it('returns parsed total and rows from the response', async () => {
+    const mockResponse = { total: 1, rows: [mockCreatedAnnotation] };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }),
+    );
+
+    const result = await searchAnnotations({ uri: mockPayload.uri });
+    expect(result.total).toBe(1);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.id).toBe('abc123');
+  });
+
+  it('URL-encodes special characters in URI and tag parameters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ total: 0, rows: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const uriWithSpecialChars = 'http://localhost:6006/iframe.html?id=story&args=foo%3Dbar';
+    await searchAnnotations({ uri: uriWithSpecialChars, tag: 'selector:div > span' });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    // The URL must not contain raw & in the uri value or unencoded > in the tag
+    const parsedUrl = new URL(url, 'http://localhost');
+    expect(parsedUrl.searchParams.get('uri')).toBe(uriWithSpecialChars);
+    expect(parsedUrl.searchParams.get('tag')).toBe('selector:div > span');
+  });
+});

--- a/.storybook/addons/hypothesis-bridge/__tests__/highlight-utils.test.ts
+++ b/.storybook/addons/hypothesis-bridge/__tests__/highlight-utils.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSelectorTag,
+  getSeverityColor,
+  getIntent,
+  getSeverity,
+  filterAgentationAnnotations,
+  parseElementPathFromComment,
+  normalizeStoryUrl,
+} from '../highlight-utils';
+import type { HypothesisAnnotation } from '../client';
+
+function makeAnnotation(tags: string[], text = ''): HypothesisAnnotation {
+  return {
+    id: 'ann_test',
+    uri: 'http://localhost:6006/iframe.html?id=story',
+    text,
+    tags,
+    group: 'e4e5jGAx',
+    created: '2024-01-01T00:00:00Z',
+    updated: '2024-01-01T00:00:00Z',
+    target: [{ source: 'http://localhost:6006/iframe.html?id=story' }],
+  };
+}
+
+describe('parseSelectorTag', () => {
+  it('extracts the CSS selector from a selector: tag', () => {
+    const tags = ['Forensic', 'agentation', 'selector:div.container > form > button'];
+    expect(parseSelectorTag(tags)).toBe('div.container > form > button');
+  });
+
+  it('returns null when no selector: tag is present', () => {
+    const tags = ['Forensic', 'agentation', 'blocking'];
+    expect(parseSelectorTag(tags)).toBeNull();
+  });
+});
+
+describe('getSeverityColor', () => {
+  it('maps blocking to red', () => {
+    expect(getSeverityColor(['blocking'])).toBe('#ef4444');
+  });
+
+  it('maps important to orange', () => {
+    expect(getSeverityColor(['important'])).toBe('#f97316');
+  });
+
+  it('maps suggestion to blue', () => {
+    expect(getSeverityColor(['suggestion'])).toBe('#3b82f6');
+  });
+
+  it('returns default gray for unrecognized severity', () => {
+    const color = getSeverityColor(['Forensic', 'agentation', 'fix']);
+    expect(color).toBe('#6b7280');
+  });
+});
+
+describe('filterAgentationAnnotations', () => {
+  it('keeps only annotations that have the agentation tag', () => {
+    const annotations: HypothesisAnnotation[] = [
+      makeAnnotation(['Forensic', 'agentation', 'blocking']),
+      makeAnnotation(['Forensic', 'manually-created']),
+      makeAnnotation(['agentation', 'suggestion']),
+    ];
+
+    const filtered = filterAgentationAnnotations(annotations);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every((a) => a.tags.includes('agentation'))).toBe(true);
+  });
+});
+
+describe('getSeverity', () => {
+  it('extracts severity from a mixed tag array', () => {
+    expect(getSeverity(['Forensic', 'agentation', 'fix', 'important'])).toBe('important');
+    expect(getSeverity(['Forensic', 'agentation', 'blocking'])).toBe('blocking');
+    expect(getSeverity(['Forensic', 'agentation', 'suggestion', 'change'])).toBe('suggestion');
+  });
+
+  it('returns null when no severity tag is present', () => {
+    expect(getSeverity(['Forensic', 'agentation', 'fix'])).toBeNull();
+  });
+});
+
+describe('getIntent', () => {
+  it('extracts intent from a mixed tag array', () => {
+    expect(getIntent(['Forensic', 'agentation', 'fix', 'important'])).toBe('fix');
+    expect(getIntent(['change', 'suggestion'])).toBe('change');
+    expect(getIntent(['question'])).toBe('question');
+    expect(getIntent(['approve', 'important'])).toBe('approve');
+  });
+
+  it('returns null when no intent tag is present', () => {
+    expect(getIntent(['Forensic', 'agentation', 'blocking'])).toBeNull();
+  });
+});
+
+describe('normalizeStoryUrl', () => {
+  it('strips volatile params and retains id', () => {
+    const url =
+      'http://localhost:6006/iframe.html?id=use-cases-receiving--stepwise&viewMode=story&args={}';
+    const normalized = normalizeStoryUrl(url);
+    expect(normalized).toBe(
+      'http://localhost:6006/iframe.html?id=use-cases-receiving--stepwise&viewMode=story',
+    );
+  });
+});
+
+describe('parseElementPathFromComment', () => {
+  it('extracts elementPath from an HTML comment in the annotation text', () => {
+    const text =
+      '<!-- agentation:elementPath=div.container > form > button.primary-action -->\n\nComment text';
+    expect(parseElementPathFromComment(text)).toBe('div.container > form > button.primary-action');
+  });
+
+  it('returns null when no HTML comment is present', () => {
+    const text = 'Plain annotation without a comment';
+    expect(parseElementPathFromComment(text)).toBeNull();
+  });
+});

--- a/.storybook/addons/hypothesis-bridge/__tests__/transform.test.ts
+++ b/.storybook/addons/hypothesis-bridge/__tests__/transform.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  transformAnnotation,
+  transformAnnotations,
+  normalizeStoryUrl,
+  type AgentationAnnotation,
+} from '../transform';
+import { DEFAULT_TAG, ORIGIN_TAG, SELECTOR_TAG_PREFIX, HYPOTHESIS_GROUP } from '../constants';
+
+const baseAnnotation: AgentationAnnotation = {
+  id: 'ann_abc123',
+  comment: 'The button text is truncated on narrow viewports',
+  elementPath: 'div.container > form > button.primary-action',
+  timestamp: 1711000000000,
+  x: 50,
+  y: 200,
+  element: 'button',
+  url: 'http://localhost:6006/iframe.html?id=use-cases-receiving--stepwise&viewMode=story',
+  reactComponents: 'App > Dashboard > ActionPanel > SubmitButton',
+  cssClasses: 'primary-action btn-lg',
+  intent: 'fix',
+  severity: 'important',
+  selectedText: 'Subm...',
+};
+
+const storyUrl =
+  'http://localhost:6006/iframe.html?id=use-cases-receiving--stepwise&viewMode=story&args={}';
+
+describe('normalizeStoryUrl', () => {
+  it('strips volatile query params and retains id and viewMode', () => {
+    const result = normalizeStoryUrl(storyUrl);
+    expect(result).toBe(
+      'http://localhost:6006/iframe.html?id=use-cases-receiving--stepwise&viewMode=story',
+    );
+    expect(result).not.toContain('args');
+  });
+
+  it('handles URLs without id param gracefully', () => {
+    const result = normalizeStoryUrl('http://localhost:6006/iframe.html?viewMode=story');
+    expect(result).toBe('http://localhost:6006/iframe.html');
+  });
+
+  it('returns the url unchanged when it cannot be parsed', () => {
+    const malformed = 'not-a-url';
+    const result = normalizeStoryUrl(malformed);
+    expect(result).toBe(malformed);
+  });
+});
+
+describe('transformAnnotation', () => {
+  it('maps all required fields to the Hypothesis payload', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+
+    expect(payload.uri).toBe(
+      'http://localhost:6006/iframe.html?id=use-cases-receiving--stepwise&viewMode=story',
+    );
+    expect(payload.group).toBe(HYPOTHESIS_GROUP);
+    expect(payload.permissions.read).toContain(`group:${HYPOTHESIS_GROUP}`);
+    expect(typeof payload.text).toBe('string');
+    expect(payload.text.length).toBeGreaterThan(0);
+    expect(Array.isArray(payload.tags)).toBe(true);
+    expect(Array.isArray(payload.target)).toBe(true);
+    expect(payload.target.length).toBeGreaterThan(0);
+  });
+
+  it('always includes the Forensic tag', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    expect(payload.tags).toContain(DEFAULT_TAG);
+  });
+
+  it('always includes the agentation origin tag', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    expect(payload.tags).toContain(ORIGIN_TAG);
+  });
+
+  it('generates a selector: tag from elementPath', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    const selectorTag = `${SELECTOR_TAG_PREFIX}${baseAnnotation.elementPath}`;
+    expect(payload.tags).toContain(selectorTag);
+  });
+
+  it('includes intent and severity tags', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    expect(payload.tags).toContain('fix');
+    expect(payload.tags).toContain('important');
+  });
+
+  it('formats the Markdown text body with HTML comment and metadata block', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    expect(payload.text).toContain(`<!-- agentation:elementPath=${baseAnnotation.elementPath} -->`);
+    expect(payload.text).toContain(baseAnnotation.comment);
+    expect(payload.text).toContain('---');
+    expect(payload.text).toContain('**Element:**');
+    expect(payload.text).toContain('**Severity:** important');
+    expect(payload.text).toContain('**Intent:** fix');
+  });
+
+  it('normalizes the story URL in the payload, keeping viewMode', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    expect(payload.uri).toContain('viewMode=story');
+    expect(payload.uri).toContain('id=use-cases-receiving--stepwise');
+    expect(payload.uri).not.toContain('args');
+  });
+
+  it('omits TextQuoteSelector when selectedText is absent', () => {
+    const annotation: AgentationAnnotation = { ...baseAnnotation };
+    delete (annotation as Partial<AgentationAnnotation>).selectedText;
+    // Also remove nearbyText to trigger page note fallback
+    delete (annotation as Partial<AgentationAnnotation>).nearbyText;
+    const payload = transformAnnotation(annotation, storyUrl);
+    // Without text, this becomes a page note (target with source but no selectors)
+    const selectors = payload.target[0]?.selector ?? [];
+    const tqSelectors = selectors.filter((s) => s.type === 'TextQuoteSelector');
+    expect(tqSelectors).toHaveLength(0);
+  });
+
+  it('includes TextQuoteSelector when selectedText is present', () => {
+    const payload = transformAnnotation(baseAnnotation, storyUrl);
+    const selectors = payload.target[0]?.selector ?? [];
+    const tqSelector = selectors.find((s) => s.type === 'TextQuoteSelector');
+    expect(tqSelector).toBeDefined();
+    expect((tqSelector as { type: string; exact?: string }).exact).toBe(
+      baseAnnotation.selectedText,
+    );
+  });
+
+  it('creates a page note when no anchorable text is available', () => {
+    const minimalAnnotation: AgentationAnnotation = {
+      id: 'ann_min',
+      comment: 'Minimal annotation',
+      elementPath: 'div',
+      timestamp: 1711000000000,
+      x: 0,
+      y: 0,
+      element: 'div',
+    };
+
+    const payload = transformAnnotation(minimalAnnotation, storyUrl);
+    expect(payload.tags).toContain(DEFAULT_TAG);
+    expect(payload.tags).toContain(ORIGIN_TAG);
+    // No intent or severity tags
+    expect(payload.tags).not.toContain('fix');
+    expect(payload.tags).not.toContain('blocking');
+    expect(payload.text).not.toContain('**Component:**');
+    expect(payload.text).not.toContain('**CSS Classes:**');
+    // Page note: target has source but no selectors
+    expect(payload.target.length).toBe(1);
+    expect(payload.target[0]?.selector).toBeUndefined();
+  });
+
+  it('transforms multiple annotations as a batch', () => {
+    const secondAnnotation: AgentationAnnotation = {
+      ...baseAnnotation,
+      id: 'ann_def456',
+      comment: 'Second annotation',
+      elementPath: 'header > nav > a',
+      element: 'a',
+    };
+
+    const payloads = transformAnnotations([baseAnnotation, secondAnnotation], storyUrl);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.tags).toContain(`${SELECTOR_TAG_PREFIX}${baseAnnotation.elementPath}`);
+    expect(payloads[1]?.tags).toContain(`${SELECTOR_TAG_PREFIX}${secondAnnotation.elementPath}`);
+  });
+});

--- a/.storybook/addons/hypothesis-bridge/client.ts
+++ b/.storybook/addons/hypothesis-bridge/client.ts
@@ -1,0 +1,83 @@
+import { PROXY_BASE } from './constants';
+import type { HypothesisAnnotationPayload } from './transform';
+
+export interface HypothesisAnnotation {
+  id: string;
+  uri: string;
+  text: string;
+  tags: string[];
+  group: string;
+  created: string;
+  updated: string;
+  target: Array<{
+    source: string;
+    selector?: Array<{ type: string; value?: string; exact?: string }>;
+  }>;
+}
+
+export interface SearchResult {
+  total: number;
+  rows: HypothesisAnnotation[];
+}
+
+export interface SearchParams {
+  uri: string;
+  tag?: string;
+  group?: string;
+  limit?: number;
+}
+
+async function assertOk(response: Response): Promise<void> {
+  if (!response.ok) {
+    let message = response.statusText;
+    try {
+      const body = (await response.json()) as { reason?: string };
+      if (body.reason) {
+        message = body.reason;
+      }
+    } catch {
+      // Ignore JSON parse errors; use status text
+    }
+    throw new Error(`Hypothesis proxy error ${response.status}: ${message}`);
+  }
+}
+
+/**
+ * Post an annotation to the Hypothesis API via the local proxy.
+ * Returns the created annotation (with `id` assigned by Hypothesis).
+ */
+export async function postAnnotation(
+  payload: HypothesisAnnotationPayload,
+): Promise<HypothesisAnnotation> {
+  const response = await fetch(`${PROXY_BASE}/annotations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  await assertOk(response);
+  return response.json() as Promise<HypothesisAnnotation>;
+}
+
+/**
+ * Search for annotations via the local proxy.
+ * Returns `{ total, rows }` from the Hypothesis search API.
+ */
+export async function searchAnnotations(params: SearchParams): Promise<SearchResult> {
+  const query = new URLSearchParams();
+  query.set('uri', params.uri);
+  if (params.tag !== undefined) {
+    query.set('tag', params.tag);
+  }
+  if (params.group !== undefined) {
+    query.set('group', params.group);
+  }
+  if (params.limit !== undefined) {
+    query.set('limit', String(params.limit));
+  }
+
+  const response = await fetch(`${PROXY_BASE}/search?${query.toString()}`);
+
+  await assertOk(response);
+  return response.json() as Promise<SearchResult>;
+}

--- a/.storybook/addons/hypothesis-bridge/constants.ts
+++ b/.storybook/addons/hypothesis-bridge/constants.ts
@@ -1,0 +1,5 @@
+export const HYPOTHESIS_GROUP = 'e4e5jGAx';
+export const PROXY_BASE = '/hypothesis-proxy';
+export const DEFAULT_TAG = 'Forensic';
+export const ORIGIN_TAG = 'agentation';
+export const SELECTOR_TAG_PREFIX = 'selector:';

--- a/.storybook/addons/hypothesis-bridge/highlight-layer.tsx
+++ b/.storybook/addons/hypothesis-bridge/highlight-layer.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { searchAnnotations } from './client';
+import type { HypothesisAnnotation } from './client';
+import {
+  parseSelectorTag,
+  getSeverityColor,
+  getSeverity,
+  getIntent,
+  filterAgentationAnnotations,
+} from './highlight-utils';
+
+interface BadgePosition {
+  top: number;
+  left: number;
+}
+
+interface BadgeInfo {
+  annotation: HypothesisAnnotation;
+  position: BadgePosition;
+  index: number;
+  selector: string;
+}
+
+interface TooltipState {
+  visible: boolean;
+  badgeIndex: number;
+  x: number;
+  y: number;
+}
+
+interface HighlightLayerProps {
+  storyUrl: string;
+}
+
+// Annotation cache keyed by normalized URL to avoid redundant fetches
+const annotationCache = new Map<string, HypothesisAnnotation[]>();
+
+/**
+ * Compute badge positions for all annotations that can be resolved to DOM elements.
+ */
+function computeBadges(annotations: HypothesisAnnotation[]): BadgeInfo[] {
+  const badges: BadgeInfo[] = [];
+  let index = 1;
+
+  for (const annotation of annotations) {
+    const selector = parseSelectorTag(annotation.tags);
+    if (!selector) continue;
+
+    const element = document.querySelector(selector);
+    if (!element) continue;
+
+    const rect = element.getBoundingClientRect();
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+
+    badges.push({
+      annotation,
+      position: {
+        top: rect.top + scrollTop,
+        left: rect.left + scrollLeft + rect.width - 12, // top-right corner
+      },
+      index,
+      selector,
+    });
+    index++;
+  }
+
+  return badges;
+}
+
+/**
+ * HighlightLayer renders numbered badge overlays for annotations sourced from Hypothesis.
+ * It is rendered by the `withHighlights` Storybook decorator on every story.
+ * When no annotations exist for the current story URL, nothing is rendered.
+ */
+export function HighlightLayer({ storyUrl }: HighlightLayerProps): React.ReactElement | null {
+  const normalizedUrl = storyUrl;
+  const [badges, setBadges] = useState<BadgeInfo[]>([]);
+  const [tooltip, setTooltip] = useState<TooltipState>({
+    visible: false,
+    badgeIndex: -1,
+    x: 0,
+    y: 0,
+  });
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const mutationObserverRef = useRef<MutationObserver | null>(null);
+  const annotationsRef = useRef<HypothesisAnnotation[]>([]);
+
+  const refreshBadges = useCallback(() => {
+    setBadges(computeBadges(annotationsRef.current));
+  }, []);
+
+  const fetchAndRender = useCallback(async () => {
+    let annotations: HypothesisAnnotation[];
+
+    const cached = annotationCache.get(normalizedUrl);
+    if (cached) {
+      annotations = cached;
+    } else {
+      try {
+        const result = await searchAnnotations({ uri: normalizedUrl, tag: 'agentation' });
+        annotations = filterAgentationAnnotations(result.rows);
+        annotationCache.set(normalizedUrl, annotations);
+      } catch {
+        // Silently fail — Hypothesis may not be configured in all environments
+        return;
+      }
+    }
+
+    annotationsRef.current = annotations;
+    refreshBadges();
+  }, [normalizedUrl, refreshBadges]);
+
+  // Initial fetch and event listener for updates
+  useEffect(() => {
+    void fetchAndRender();
+
+    const handleUpdate = () => {
+      // Clear cache for current URL so we get fresh data
+      annotationCache.delete(normalizedUrl);
+      void fetchAndRender();
+    };
+
+    // Refresh when the bridge posts new annotations
+    window.addEventListener('hypothesis-annotations-updated', handleUpdate);
+
+    // Refresh when the page becomes visible again (e.g., after using the
+    // Hypothesis sidebar to delete or reply to annotations). This picks up
+    // deletions without requiring a full page reload.
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        handleUpdate();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    // Also refresh on focus (covers switching between sidebar iframe and page)
+    window.addEventListener('focus', handleUpdate);
+
+    return () => {
+      window.removeEventListener('hypothesis-annotations-updated', handleUpdate);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleUpdate);
+    };
+  }, [fetchAndRender, normalizedUrl]);
+
+  // ResizeObserver to reposition badges when viewport changes
+  useEffect(() => {
+    resizeObserverRef.current = new ResizeObserver(() => {
+      refreshBadges();
+    });
+    resizeObserverRef.current.observe(document.body);
+
+    return () => {
+      resizeObserverRef.current?.disconnect();
+    };
+  }, [refreshBadges]);
+
+  // MutationObserver to reposition badges when DOM changes
+  useEffect(() => {
+    mutationObserverRef.current = new MutationObserver(() => {
+      refreshBadges();
+    });
+    mutationObserverRef.current.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+    });
+
+    return () => {
+      mutationObserverRef.current?.disconnect();
+    };
+  }, [refreshBadges]);
+
+  if (badges.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        zIndex: 100000,
+      }}
+    >
+      {badges.map((badge) => {
+        const color = getSeverityColor(badge.annotation.tags);
+        const severity = getSeverity(badge.annotation.tags);
+        const intent = getIntent(badge.annotation.tags);
+        const isTooltipVisible = tooltip.visible && tooltip.badgeIndex === badge.index;
+
+        return (
+          <React.Fragment key={badge.annotation.id}>
+            <div
+              style={{
+                position: 'absolute',
+                top: badge.position.top,
+                left: badge.position.left,
+                width: 24,
+                height: 24,
+                borderRadius: '50%',
+                backgroundColor: color,
+                color: '#ffffff',
+                fontSize: '11px',
+                fontWeight: 'bold',
+                fontFamily: 'sans-serif',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                pointerEvents: 'auto',
+                cursor: 'pointer',
+                zIndex: 100000,
+                boxShadow: '0 2px 4px rgba(0,0,0,0.3)',
+                userSelect: 'none',
+              }}
+              onMouseEnter={(e) => {
+                setTooltip({
+                  visible: true,
+                  badgeIndex: badge.index,
+                  x: e.clientX + 8,
+                  y: e.clientY + 8,
+                });
+              }}
+              onMouseMove={(e) => {
+                setTooltip((prev) => ({ ...prev, x: e.clientX + 8, y: e.clientY + 8 }));
+              }}
+              onMouseLeave={() => {
+                setTooltip({ visible: false, badgeIndex: -1, x: 0, y: 0 });
+              }}
+            >
+              {badge.index}
+            </div>
+            {isTooltipVisible && (
+              <div
+                style={{
+                  position: 'fixed',
+                  top: tooltip.y,
+                  left: tooltip.x,
+                  maxWidth: 300,
+                  backgroundColor: '#1e1e2e',
+                  color: '#cdd6f4',
+                  fontSize: '12px',
+                  fontFamily: 'sans-serif',
+                  lineHeight: '1.5',
+                  padding: '8px 10px',
+                  borderRadius: 6,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+                  pointerEvents: 'none',
+                  zIndex: 100001,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {severity && (
+                  <div style={{ marginBottom: 4 }}>
+                    <span
+                      style={{
+                        backgroundColor: color,
+                        color: '#fff',
+                        borderRadius: 3,
+                        padding: '1px 6px',
+                        fontSize: '10px',
+                        fontWeight: 'bold',
+                        textTransform: 'uppercase',
+                        marginRight: 6,
+                      }}
+                    >
+                      {severity}
+                    </span>
+                    {intent && <span style={{ fontSize: '10px', opacity: 0.7 }}>{intent}</span>}
+                  </div>
+                )}
+                <div>
+                  {badge.annotation.text
+                    .split('---')[0]
+                    ?.replace(/<!--.*?-->/gs, '')
+                    .trim()}
+                </div>
+              </div>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/.storybook/addons/hypothesis-bridge/highlight-utils.ts
+++ b/.storybook/addons/hypothesis-bridge/highlight-utils.ts
@@ -1,0 +1,80 @@
+import { ORIGIN_TAG, SELECTOR_TAG_PREFIX } from './constants';
+import { normalizeStoryUrl } from './transform';
+import type { HypothesisAnnotation } from './client';
+
+// Re-export for use in tests and other modules
+export { normalizeStoryUrl };
+
+/**
+ * Severity-to-color mapping for badge rendering.
+ */
+const SEVERITY_COLORS: Record<string, string> = {
+  blocking: '#ef4444', // red-500
+  important: '#f97316', // orange-500
+  suggestion: '#3b82f6', // blue-500
+};
+
+const DEFAULT_BADGE_COLOR = '#6b7280'; // gray-500
+
+/**
+ * Extract the CSS selector from a `selector:<path>` tag, or return null if absent.
+ */
+export function parseSelectorTag(tags: string[]): string | null {
+  const tag = tags.find((t) => t.startsWith(SELECTOR_TAG_PREFIX));
+  if (!tag) return null;
+  return tag.slice(SELECTOR_TAG_PREFIX.length);
+}
+
+/**
+ * Map severity tags to a CSS color string.
+ * Returns the default gray color if no recognized severity tag is present.
+ */
+export function getSeverityColor(tags: string[]): string {
+  for (const tag of tags) {
+    if (tag in SEVERITY_COLORS) {
+      return SEVERITY_COLORS[tag] as string;
+    }
+  }
+  return DEFAULT_BADGE_COLOR;
+}
+
+/**
+ * Extract the intent value from a tags array.
+ * Recognized intents: fix, change, question, approve.
+ */
+export function getIntent(tags: string[]): string | null {
+  const intents = new Set(['fix', 'change', 'question', 'approve']);
+  return tags.find((t) => intents.has(t)) ?? null;
+}
+
+/**
+ * Extract the severity value from a tags array.
+ * Recognized severities: blocking, important, suggestion.
+ */
+export function getSeverity(tags: string[]): string | null {
+  const severities = new Set(['blocking', 'important', 'suggestion']);
+  return tags.find((t) => severities.has(t)) ?? null;
+}
+
+/**
+ * Filter annotations to only those created by the Agentation bridge
+ * (those with the `agentation` origin tag).
+ */
+export function filterAgentationAnnotations(
+  annotations: HypothesisAnnotation[],
+): HypothesisAnnotation[] {
+  return annotations.filter((a) => a.tags.includes(ORIGIN_TAG));
+}
+
+/**
+ * Extract the elementPath value from an HTML comment embedded in the
+ * annotation text body: `<!-- agentation:elementPath=<path> -->`.
+ * Returns null if the comment is not present.
+ */
+export function parseElementPathFromComment(text: string): string | null {
+  // Match <!-- agentation:elementPath=<path> --> where <path> may contain '>'
+  // (e.g., CSS combinators). We capture everything up to the closing ' -->'.
+  const match = /<!--\s*agentation:elementPath=(.*?)\s*-->/.exec(text);
+  if (!match) return null;
+  return match[1]?.trim() ?? null;
+}

--- a/.storybook/addons/hypothesis-bridge/transform.ts
+++ b/.storybook/addons/hypothesis-bridge/transform.ts
@@ -1,0 +1,209 @@
+import { HYPOTHESIS_GROUP, DEFAULT_TAG, ORIGIN_TAG, SELECTOR_TAG_PREFIX } from './constants';
+
+/**
+ * Agentation annotation schema v2 fields relevant to the bridge transform.
+ */
+export interface AgentationAnnotation {
+  id: string;
+  comment: string;
+  elementPath: string;
+  timestamp: number;
+  x: number;
+  y: number;
+  element: string;
+  url?: string;
+  reactComponents?: string;
+  cssClasses?: string;
+  computedStyles?: string;
+  accessibility?: string;
+  nearbyText?: string;
+  selectedText?: string;
+  intent?: 'fix' | 'change' | 'question' | 'approve';
+  severity?: 'blocking' | 'important' | 'suggestion';
+  status?: string;
+  thread?: Array<{ author: string; content: string; timestamp: number }>;
+}
+
+interface CssSelector {
+  type: 'CssSelector';
+  value: string;
+}
+
+interface TextQuoteSelector {
+  type: 'TextQuoteSelector';
+  exact: string;
+}
+
+type AnnotationSelector = CssSelector | TextQuoteSelector;
+
+export interface HypothesisAnnotationPayload {
+  uri: string;
+  text: string;
+  tags: string[];
+  group: string;
+  permissions: {
+    read: string[];
+  };
+  target: Array<{
+    source: string;
+    selector?: AnnotationSelector[];
+  }>;
+  references?: string[];
+}
+
+/**
+ * Normalize a Storybook iframe URL by stripping volatile query parameters
+ * (globals, args) while preserving stable ones (id, viewMode).
+ *
+ * The Hypothesis sidebar resolves the document URI from the canonical link
+ * or the page URL. We must ensure the URI we post matches what the sidebar
+ * resolves. Storybook appends `globals=` when toggling addons like Agentation,
+ * so we strip that. We keep `viewMode` because it's always present.
+ */
+export function normalizeStoryUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const storyId = parsed.searchParams.get('id');
+    if (!storyId) {
+      return `${parsed.origin}${parsed.pathname}`;
+    }
+    // Rebuild with only stable params
+    const clean = new URL(parsed.origin + parsed.pathname);
+    clean.searchParams.set('id', storyId);
+    const viewMode = parsed.searchParams.get('viewMode');
+    if (viewMode) {
+      clean.searchParams.set('viewMode', viewMode);
+    }
+    return clean.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Build the Markdown text body for a Hypothesis annotation.
+ */
+function buildTextBody(annotation: AgentationAnnotation): string {
+  const lines: string[] = [];
+
+  // HTML comment for machine parsing by the highlight layer
+  lines.push(`<!-- agentation:elementPath=${annotation.elementPath} -->`);
+  lines.push('');
+  lines.push(annotation.comment);
+  lines.push('');
+  lines.push('---');
+
+  // Human-readable metadata block
+  lines.push(`**Element:** \`${annotation.element}\``);
+
+  if (annotation.reactComponents) {
+    lines.push(`**Component:** \`${annotation.reactComponents}\``);
+  }
+
+  if (annotation.cssClasses) {
+    lines.push(`**CSS Classes:** \`${annotation.cssClasses}\``);
+  }
+
+  const severityStr = annotation.severity ?? '';
+  const intentStr = annotation.intent ?? '';
+
+  const metaParts: string[] = [];
+  if (severityStr) metaParts.push(`**Severity:** ${severityStr}`);
+  if (intentStr) metaParts.push(`**Intent:** ${intentStr}`);
+  if (metaParts.length > 0) {
+    lines.push(metaParts.join(' | '));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the tags array for a Hypothesis annotation.
+ */
+function buildTags(annotation: AgentationAnnotation): string[] {
+  const tags: string[] = [DEFAULT_TAG, ORIGIN_TAG];
+
+  // CSS selector tag for machine parsing
+  tags.push(`${SELECTOR_TAG_PREFIX}${annotation.elementPath}`);
+
+  if (annotation.intent) {
+    tags.push(annotation.intent);
+  }
+
+  if (annotation.severity) {
+    tags.push(annotation.severity);
+  }
+
+  return tags;
+}
+
+/**
+ * Build the target array for a Hypothesis annotation.
+ */
+function buildTarget(
+  annotation: AgentationAnnotation,
+  uri: string,
+): HypothesisAnnotationPayload['target'] {
+  // A TextQuoteSelector is required for Hypothesis to anchor the annotation
+  // and display it in the "Annotations" tab of the sidebar. Without it,
+  // annotations are classified as "orphaned" and hidden.
+  //
+  // When anchorable text exists (selectedText or nearbyText), we create a
+  // full target with both CssSelector (for our highlight layer) and
+  // TextQuoteSelector (for Hypothesis anchoring).
+  //
+  // When no anchorable text exists, we create a page note (empty target)
+  // which shows in the "Page Notes" tab of the sidebar. This is preferable
+  // to creating an orphaned annotation that Hypothesis hides entirely.
+  const quoteText = annotation.selectedText || annotation.nearbyText || '';
+  if (quoteText) {
+    const selectors: AnnotationSelector[] = [
+      { type: 'CssSelector', value: annotation.elementPath },
+      { type: 'TextQuoteSelector', exact: quoteText },
+    ];
+    return [{ source: uri, selector: selectors }];
+  }
+
+  // No anchorable text — create a page note (target with source, no selectors).
+  // Page notes show in the "Page Notes" tab of the Hypothesis sidebar.
+  // The element path is still available in the text body and tags for our highlight layer.
+  return [{ source: uri }];
+}
+
+/**
+ * Transform a single Agentation annotation into a Hypothesis annotation payload.
+ */
+export function transformAnnotation(
+  annotation: AgentationAnnotation,
+  storyUrl: string,
+): HypothesisAnnotationPayload {
+  const uri = normalizeStoryUrl(storyUrl);
+
+  const payload: HypothesisAnnotationPayload = {
+    uri,
+    text: buildTextBody(annotation),
+    tags: buildTags(annotation),
+    group: HYPOTHESIS_GROUP,
+    permissions: {
+      read: [`group:${HYPOTHESIS_GROUP}`],
+    },
+    target: buildTarget(annotation, uri),
+  };
+
+  // Include thread references if the annotation is a reply
+  if (annotation.thread && annotation.thread.length > 0) {
+    payload.references = annotation.thread.map((msg) => msg.author);
+  }
+
+  return payload;
+}
+
+/**
+ * Transform multiple Agentation annotations into Hypothesis annotation payloads.
+ */
+export function transformAnnotations(
+  annotations: AgentationAnnotation[],
+  storyUrl: string,
+): HypothesisAnnotationPayload[] {
+  return annotations.map((annotation) => transformAnnotation(annotation, storyUrl));
+}

--- a/.storybook/addons/hypothesis-bridge/with-highlights.tsx
+++ b/.storybook/addons/hypothesis-bridge/with-highlights.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { DecoratorFunction } from 'storybook/internal/types';
+import type { ReactRenderer } from '@storybook/react-vite';
+import { HighlightLayer } from './highlight-layer';
+import { normalizeStoryUrl } from './transform';
+
+export const withHighlights: DecoratorFunction<ReactRenderer> = (StoryFn) => {
+  // Use the same normalized URL that the bridge posts with, so the search matches.
+  const storyUrl = normalizeStoryUrl(window.location.href);
+  return (
+    <>
+      <StoryFn />
+      <HighlightLayer storyUrl={storyUrl} />
+    </>
+  );
+};

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 // This file has been automatically migrated to valid ESM format by Storybook.
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
@@ -90,6 +91,61 @@ const config: StorybookConfig = {
           return { code: transformed, map: null };
         }
         return null;
+      },
+    });
+
+    // Vite plugin to proxy Hypothesis API requests.
+    const HYPOTHESIS_API_BASE = 'https://hypothes.is/api';
+    config.plugins.push({
+      name: 'hypothesis-api-proxy',
+      configureServer(server) {
+        server.middlewares.use('/hypothesis-proxy', (req, res) => {
+          const token = process.env['HYPOTHESIS_API_TOKEN'];
+          if (!token) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'HYPOTHESIS_API_TOKEN not set' }));
+            return;
+          }
+
+          const chunks: Buffer[] = [];
+          req.on('data', (chunk: Buffer) => chunks.push(chunk));
+          req.on('end', async () => {
+            const body = Buffer.concat(chunks).toString('utf-8');
+            const url = req.url || '';
+            const method = req.method || 'GET';
+
+            let hypothesisUrl: string;
+            if (url.startsWith('/search')) {
+              hypothesisUrl = `${HYPOTHESIS_API_BASE}${url}`;
+            } else if (url.startsWith('/annotations')) {
+              hypothesisUrl = `${HYPOTHESIS_API_BASE}${url}`;
+            } else {
+              res.writeHead(404, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: 'Not found' }));
+              return;
+            }
+
+            try {
+              const fetchOpts: RequestInit = {
+                method,
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                  'Content-Type': 'application/json',
+                },
+              };
+              if (method === 'POST' || method === 'PATCH') {
+                fetchOpts.body = body;
+              }
+              const upstream = await fetch(hypothesisUrl, fetchOpts);
+              const responseBody = await upstream.text();
+              res.writeHead(upstream.status, { 'Content-Type': 'application/json' });
+              res.end(responseBody);
+            } catch (err) {
+              res.writeHead(502, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: String(err) }));
+            }
+          });
+        });
       },
     });
 

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,28 @@
+<script>
+  // Dynamically generate Hypothesis config with normalized document URI.
+  (function() {
+    var config = {
+      openSidebar: false,
+      showHighlights: "whenSidebarOpen",
+      branding: { appBackgroundColor: "#f5f5f5" }
+    };
+    try {
+      var url = new URL(window.location.href);
+      var id = url.searchParams.get('id');
+      if (id) {
+        var clean = url.origin + url.pathname + '?id=' + encodeURIComponent(id);
+        var viewMode = url.searchParams.get('viewMode');
+        if (viewMode) {
+          clean += '&viewMode=' + encodeURIComponent(viewMode);
+        }
+        config.document = { uri: clean };
+      }
+    } catch(e) {}
+    var script = document.createElement('script');
+    script.type = 'application/json';
+    script.className = 'js-hypothesis-config';
+    script.textContent = JSON.stringify(config);
+    document.head.appendChild(script);
+  })();
+</script>
+<script src="https://hypothes.is/embed.js" async></script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,21 @@
+<script>
+  // Normalize Storybook iframe URL for Hypothesis annotation matching.
+  // Strip volatile params (globals, args) keeping id and viewMode.
+  (function() {
+    try {
+      var url = new URL(window.location.href);
+      var id = url.searchParams.get('id');
+      if (id) {
+        var clean = url.origin + url.pathname + '?id=' + encodeURIComponent(id);
+        var viewMode = url.searchParams.get('viewMode');
+        if (viewMode) {
+          clean += '&viewMode=' + encodeURIComponent(viewMode);
+        }
+        var link = document.createElement('link');
+        link.rel = 'canonical';
+        link.href = clean;
+        document.head.appendChild(link);
+      }
+    } catch(e) {}
+  })();
+</script>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/react-vite';
 import { withAgentation } from './addons/agentation-toggle/with-agentation';
+import { withHighlights } from './addons/hypothesis-bridge/with-highlights';
 import { withFullAppProviders } from '../src/decorators/with-full-app-providers';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { handlers } from '@frontend/mocks/handlers';
@@ -35,7 +36,7 @@ const safeMswLoader: typeof mswLoader = async (context) => {
 };
 
 const preview: Preview = {
-  decorators: [withAgentation, withFullAppProviders],
+  decorators: [withAgentation, withHighlights, withFullAppProviders],
   loaders: [safeMswLoader],
   initialGlobals: {
     agentationEnabled: false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.3.0] - 2026-03-25
+
+### Added
+
+- Agentation → Hypothesis bridge: the Copy feedback button now posts annotations to the
+  Hypothesis API for persistent storage and threaded discussion in the `arda-products` group
+- Hypothesis sidebar embedded in the Storybook preview iframe with per-story URL scoping
+- Highlight layer renders numbered grey badges on elements with existing Hypothesis annotations
+- Page notes fallback for annotations on elements without visible text content
+- Vite server plugin proxying Hypothesis API requests with server-side token injection
+- Agentation `onCopy` handler now posts to Hypothesis, clears localStorage, and resets
+  the overlay in addition to copying markdown to clipboard
+- Badges refresh on window focus to reflect deletions made in the Hypothesis sidebar
+- Unit tests for annotation transform, HTTP client, and highlight utilities (34 tests)
+- Workflow documentation page: Docs/Workflows/Providing Feedback
+
 ## [4.2.0] - 2026-03-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "heic2any": "^0.0.4",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react-easy-crop": "^5.5.7",
         "tailwind-merge": "^3.4.0"
@@ -13077,6 +13078,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "heic2any": "^0.0.4",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react-easy-crop": "^5.5.7",
     "tailwind-merge": "^3.4.0"

--- a/src/docs/workflows/providing-feedback.mdx
+++ b/src/docs/workflows/providing-feedback.mdx
@@ -1,0 +1,204 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Workflows/Providing Feedback" />
+
+# Providing Feedback on Stories and Components
+
+This guide covers the end-to-end workflow for reviewing UI components and stories using **Agentation** (DOM-level annotation) and **Hypothesis** (persistent threaded discussion). The two tools are integrated: Agentation captures feedback on specific elements, and Hypothesis persists it for team discussion.
+
+> **Prerequisites.** You need a [Hypothesis account](https://hypothes.is/signup) and membership in the `arda-products` group. See the [documentation site commenting guide](https://arda-cards.github.io/documentation/about/commenting/) for setup instructions.
+
+## Quick Reference
+
+<table>
+  <thead>
+    <tr>
+      <th>Action</th>
+      <th>Tool</th>
+      <th>How</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Annotate a specific DOM element</td>
+      <td>Agentation</td>
+      <td>Toggle overlay, click element, write comment</td>
+    </tr>
+    <tr>
+      <td>Persist annotations for team discussion</td>
+      <td>Hypothesis (via bridge)</td>
+      <td>Click <strong>Copy feedback</strong> in the Agentation toolbar</td>
+    </tr>
+    <tr>
+      <td>Reply to or discuss an annotation</td>
+      <td>Hypothesis sidebar</td>
+      <td>Open the <code>&lt;</code> tab on the right edge of the story</td>
+    </tr>
+    <tr>
+      <td>File GitHub issues from annotations</td>
+      <td>Claude Code skill</td>
+      <td>Paste the clipboard JSON into <code>/agentation-feedback</code></td>
+    </tr>
+  </tbody>
+</table>
+
+## Step-by-Step Workflow
+
+### 1. Enable Agentation
+
+- Click the **chat bubble icon** in the Storybook toolbar, or press **Ctrl+Shift+A**.
+- The overlay appears. You can now click any element to annotate it.
+
+### 2. Create Annotations
+
+- **Click** an element in the story to select it.
+- A comment dialog appears. Write your feedback.
+- Set the **intent** (`fix`, `change`, `question`, or `approve`) and **severity** (`blocking`, `important`, `suggestion`).
+- Click **Save** to store the annotation locally.
+- Repeat for all elements you want to review.
+
+> Annotations are stored in your browser&#8217;s localStorage with a 7-day TTL. They are **not** shared with the team until you post them to Hypothesis.
+
+### 3. Post to Hypothesis
+
+When you&#8217;re ready to share your feedback:
+
+1. Click the **Copy feedback** button (clipboard icon) in the Agentation toolbar.
+2. The bridge automatically:
+   - Posts each annotation to Hypothesis in the `arda-products` group with the `Forensic` tag
+   - Clears the annotations from Agentation
+   - Copies the raw annotation JSON to your clipboard (for the Claude Code skill)
+   - Briefly resets the Agentation overlay so you can continue annotating
+
+You will see a console message: `[hypothesis-bridge] Posted N annotation(s) to Hypothesis`.
+
+### 4. View and Discuss in Hypothesis
+
+After posting, open the **Hypothesis sidebar** by clicking the `<` tab on the right edge of the story viewport.
+
+- Make sure you are **logged in** and the **arda-products** group is selected.
+- Your annotations appear in the sidebar, ready for threaded replies and discussion.
+
+### 5. (Optional) File GitHub Issues
+
+The clipboard still contains the Agentation JSON from Step 3. You can paste it into Claude Code:
+
+```
+/agentation-feedback [paste JSON]
+```
+
+This creates prioritized GitHub issues in `Arda-cards/management` with the reviewer&#8217;s comment, component path, and suggested approach.
+
+## Where Annotations Appear in Hypothesis
+
+Annotations show up in different places depending on whether the annotated element has visible text content:
+
+<table>
+  <thead>
+    <tr>
+      <th>Scenario</th>
+      <th>Hypothesis location</th>
+      <th>Badge on page?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Element has visible text (e.g., a button label, a heading)</td>
+      <td><strong>Annotations</strong> tab &#8212; anchored to the element&#8217;s text, with a yellow highlight</td>
+      <td>Yes &#8212; a numbered grey badge appears on the element after page reload</td>
+    </tr>
+    <tr>
+      <td>Element has no visible text (e.g., an empty container, a spacer, a background area)</td>
+      <td><strong>Page Notes</strong> tab &#8212; attached to the page but not anchored to specific text</td>
+      <td>No &#8212; no badge is shown because the element cannot be reliably located after reload</td>
+    </tr>
+  </tbody>
+</table>
+
+> **Tip.** To ensure your annotation gets a badge and text highlight, annotate elements that contain visible text &#8212; buttons, labels, headings, table cells, etc. If you need to comment on a layout or spacing issue in an empty area, the annotation will still be visible in the **Page Notes** tab of the Hypothesis sidebar.
+
+### Understanding the Sidebar Tabs
+
+The Hypothesis sidebar has two tabs:
+
+- **Annotations** &#8212; Shows annotations anchored to specific text on the page. These have a yellow highlight on the story content and a grey numbered badge from the highlight layer.
+- **Page Notes** &#8212; Shows annotations attached to the page but not anchored to specific text. These are used when the annotated element had no visible text content.
+
+Both tabs support **threaded replies**. Click the reply icon on any annotation to start a discussion.
+
+## Tags on Hypothesis Annotations
+
+Every annotation posted through the bridge carries these tags:
+
+<table>
+  <thead>
+    <tr>
+      <th>Tag</th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Forensic</code></td>
+      <td>Identifies annotations created through the Agentation &#8594; Hypothesis bridge</td>
+    </tr>
+    <tr>
+      <td><code>agentation</code></td>
+      <td>Origin marker &#8212; distinguishes bridge annotations from manually created Hypothesis annotations</td>
+    </tr>
+    <tr>
+      <td><code>selector:&lt;cssPath&gt;</code></td>
+      <td>The CSS selector of the annotated element, used by the highlight badge layer</td>
+    </tr>
+    <tr>
+      <td>Intent tag (e.g., <code>fix</code>)</td>
+      <td>The reviewer&#8217;s intent classification, if set</td>
+    </tr>
+    <tr>
+      <td>Severity tag (e.g., <code>blocking</code>)</td>
+      <td>The reviewer&#8217;s severity classification, if set</td>
+    </tr>
+  </tbody>
+</table>
+
+You can use these tags to filter annotations in the Hypothesis sidebar search or in the [Hypothesis Notebook](https://hypothes.is/notebook).
+
+## The Grey Badge Overlay
+
+After a page reload, the **highlight layer** fetches all `agentation`-tagged annotations from Hypothesis for the current story and renders grey numbered badges on elements that have a valid CSS selector.
+
+- Badges are **color-coded by severity**: red (blocking), orange (important), blue (suggestion), grey (no severity).
+- **Hover** over a badge to see a tooltip with the annotation comment.
+- Badges **reposition automatically** when the viewport resizes or the DOM changes.
+- Badges appear only for annotations with a non-empty `selector:` tag &#8212; page notes do not generate badges.
+
+## Troubleshooting
+
+**Annotations don&#8217;t appear in the sidebar after Copy**
+- Hard-reload the page (Cmd+Shift+R / Ctrl+Shift+R).
+- Ensure you are logged in to Hypothesis and have `arda-products` selected.
+- Check the browser console for `[hypothesis-bridge]` error messages.
+
+**The Hypothesis sidebar shows &#8220;no annotations&#8221; but the Notebook has them**
+- The annotation&#8217;s URI may not match the current page. This can happen if Storybook&#8217;s URL changed between when the annotation was created and when you&#8217;re viewing.
+
+**Badges don&#8217;t appear after reload**
+- The annotation&#8217;s CSS selector may be empty (annotated the root `html` element) or the DOM structure may have changed since the annotation was created.
+- Check that the `HYPOTHESIS_API_TOKEN` environment variable is set when starting Storybook.
+
+**Copy button doesn&#8217;t seem to do anything**
+- Open the browser console (F12) and look for `[hypothesis-bridge]` messages.
+- Ensure Storybook was started with `HYPOTHESIS_API_TOKEN` set:
+  ```bash
+  HYPOTHESIS_API_TOKEN=$(op read 'op://Private/Hypothesis-API/credential') npx storybook dev
+  ```
+
+## Environment Setup
+
+The Hypothesis bridge requires an API token to post annotations. Start Storybook with:
+
+```bash
+HYPOTHESIS_API_TOKEN=$(op read 'op://Private/Hypothesis-API/credential') npx storybook dev
+```
+
+Without the token, annotation posting will fail with a 500 error. The Hypothesis sidebar (for reading and replying) works without the token &#8212; it uses your browser login session.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', '.storybook/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['src/vendored/**', 'node_modules/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
> [!note]
> Authored by Claude Code for jmpicnic

## Summary
- Bridges Agentation DOM-level annotations to Hypothesis for persistent storage and threaded discussion
- The Copy feedback button in Agentation now posts annotations to the Hypothesis API via a Vite server proxy
- Hypothesis sidebar embedded in the Storybook preview iframe with per-story URL scoping
- Highlight layer renders numbered grey badges on elements with existing annotations
- Page notes fallback for elements without visible text content
- Badges refresh on window focus to reflect deletions made in the Hypothesis sidebar
- Unit tests for transform, client, and highlight-utils (34 tests)
- Workflow documentation: Docs/Workflows/Providing Feedback

## Test plan
- [x] Create Agentation annotation on element with text → Click Copy → appears in Hypothesis sidebar Annotations tab with text highlight
- [x] Create Agentation annotation on empty area → Click Copy → appears in Hypothesis sidebar Page Notes tab
- [x] Click Copy twice → second click logs "No new annotations to post" (no duplicates)
- [x] Agentation overlay resets after Copy (badges clear, widget remounts)
- [x] Hard reload shows grey numbered badges on annotated elements
- [x] Delete annotation in Hypothesis sidebar → click back to story → badge disappears
- [x] Hypothesis threaded replies work on bridge-created annotations
- [x] `/agentation-feedback` skill still works (JSON copied to clipboard)
- [x] `npm run lint` passes (our files)
- [x] `npx tsc --noEmit` passes (our files)
- [x] Unit tests pass (34/34)

## Environment requirement
Start Storybook with `HYPOTHESIS_API_TOKEN` for the bridge to work:
```bash
HYPOTHESIS_API_TOKEN=$(op read 'op://Private/Hypothesis-API/credential') npx storybook dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)