### PR TITLE
docs: clarify StaticConfig vs InitConfig distinction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.4.1] - 2026-03-27
+
+### Changed
+
+- Clarify StaticConfig vs InitConfig distinction in Component Guidelines (Section
+  4.1): StaticConfig is system-level and release-gated; InitConfig carries
+  user/tenant-configurable properties stable for the session. Added decision test
+  and tenant-configurable examples (locale, displayName).
+
 ## [4.4.0] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 
 ## [4.4.1] - 2026-03-27
 
-### Changed
+### Fixed
 
 - Clarify StaticConfig vs InitConfig distinction in Component Guidelines (Section
   4.1): StaticConfig is system-level and release-gated; InitConfig carries

--- a/src/docs/components/guidelines.mdx
+++ b/src/docs/components/guidelines.mdx
@@ -297,7 +297,7 @@ export interface ArdaWidgetStaticConfig extends VariantProps<typeof widgetVarian
 }
 ```
 
-Includes: labels, titles, variant/size, structural variations, accessibility identifiers, viewport sizes, accepted file types, aspect ratios.
+Includes: fixed UI labels (hardcoded in JSX, not tenant-overridable), titles, variant/size, structural variations, accessibility identifiers, viewport sizes, accepted file types, aspect ratios. For tenant/user-overridable display names, use InitConfig instead.
 
 #### RuntimeConfig (Dynamic)
 

--- a/src/docs/components/guidelines.mdx
+++ b/src/docs/components/guidelines.mdx
@@ -31,7 +31,7 @@ Always check the [shadcn/ui component catalog](https://ui.shadcn.com/docs/compon
 - **Accessibility first.** Use Radix UI primitives for complex interactive patterns (dialogs, selects, popovers, tooltips). Never hand-roll focus traps, ARIA state management, or keyboard navigation when a Radix primitive exists.
 - **Token-driven styling.** All colors, spacing, and typography reference design tokens from `globals.css`. No hardcoded hex values.
 - **Type-safe variants.** Use CVA (class-variance-authority) for components with variant dimensions. Export `VariantProps` for consumer type safety.
-- **Separated lifecycle interfaces.** Split props by when they change: StaticConfig (design-time), RuntimeConfig (dynamic), InitConfig (mount-time, optional).
+- **Separated lifecycle interfaces.** Split props by when they change: StaticConfig (system-level, release-gated), RuntimeConfig (dynamic), InitConfig (user/tenant-configurable, optional).
 
 ---
 
@@ -280,12 +280,14 @@ For AG Grid wrappers, note the AG Grid features used:
 
 Split component props into distinct TypeScript interfaces based on **when they change**. Only include interfaces that are relevant to the component.
 
-#### StaticConfig (Design Time)
+#### StaticConfig (System Design)
 
-Properties chosen when the component is placed in a layout. These never change after composition.
+Properties determined by the **system design** that cannot be changed by user or tenant settings without a code release. These are fixed at composition time and never change after that.
+
+**Decision test:** *Can a tenant admin or user setting change this value without a code release?* If **no** &#8594; StaticConfig.
 
 ```tsx
-/** Design-time configuration for ArdaWidget. */
+/** System-level configuration for ArdaWidget (release-gated). */
 export interface ArdaWidgetStaticConfig extends VariantProps<typeof widgetVariants> {
   /* --- View / Layout / Controller --- */
   /** Display label shown above the widget. */
@@ -295,7 +297,7 @@ export interface ArdaWidgetStaticConfig extends VariantProps<typeof widgetVarian
 }
 ```
 
-Includes: labels, titles, variant/size, structural variations, accessibility identifiers.
+Includes: labels, titles, variant/size, structural variations, accessibility identifiers, viewport sizes, accepted file types, aspect ratios.
 
 #### RuntimeConfig (Dynamic)
 
@@ -320,13 +322,19 @@ export interface ArdaWidgetRuntimeConfig {
 
 Includes: dynamic state (loading, disabled, active), event handlers, controlled values, validation errors, conditional rendering flags.
 
-#### InitConfig (Mount Time) -- Optional
+#### InitConfig (User/Tenant Configuration) -- Optional
 
-Properties that execute once when the component mounts. **Only include when the component actually has mount-time behavior** (async data fetching, one-time computations). Most components do not need this.
+Properties determined at mount time by **user or tenant configuration** that remain stable for the session. **Only include when the component accepts configuration that varies by user or tenant context** (locale, timezone, visible columns, column order, field visibility, display names, preferred renderers) or has mount-time side effects (async data fetching). Most components do not need this.
+
+**Decision test:** *Can a tenant admin or user setting change this value without a code release?* If **yes** &#8594; InitConfig.
 
 ```tsx
-/** Mount-time configuration for ArdaWidget. */
+/** User/tenant configuration for ArdaWidget (session-stable). */
 export interface ArdaWidgetInitConfig {
+  /** Locale for number/date formatting, resolved from tenant or user settings. */
+  locale?: string;
+  /** Display name override from tenant configuration. */
+  displayName?: string;
   /** Fetches initial data when the widget mounts. */
   getInitialData?: () => Promise<WidgetData>;
   /** Initial value for uncontrolled mode. */
@@ -349,7 +357,7 @@ Guidelines:
 - Export all sub-interfaces so consumers can use them for partial typing.
 - Add JSDoc comments to every interface and every property.
 - Purely presentational components (e.g., Badge) may only need `StaticConfig`.
-- Omit `InitConfig` if the component has no mount-time behavior.
+- Omit `InitConfig` if the component has no user/tenant-configurable properties or mount-time behavior.
 
 ### 4.2 Model/Data vs. View/Controller Separation
 


### PR DESCRIPTION
> [!note]
> Authored by Claude Code for jmpicnic

## Summary
- **StaticConfig** description updated to emphasize system-level, release-gated properties that require a code release to change
- **InitConfig** description updated to emphasize user/tenant-configurable properties (locale, timezone, visible columns, etc.) that are stable for the session
- Added a **decision test** to both sections: "Can a tenant admin or user setting change this value without a code release?"
- Updated **ArdaWidget example** with tenant-configurable `locale` and `displayName` InitConfig properties

Closes #62

## Test plan
- [ ] Verify MDX renders correctly in Storybook (Section 4.1)
- [ ] Confirm decision test language is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)