### PR TITLE
Add CLAUDE.md for AI agent context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.4.3] - 2026-03-31
+
+### Added
+
+- `CLAUDE.md` quick-reference guide for Claude Code agents.
+
 ## [4.4.2] - 2026-03-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [4.4.3] - 2026-03-31
+## [4.5.0] - 2026-03-31
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+Storybook component library (`@arda-cards/design-system`) — React components built with Vite, Tailwind CSS v4, and Storybook 10.
+
+## Commands
+
+```bash
+# Development
+make dev                   # start Storybook dev server (port 6006)
+
+# Build
+make build                 # build Storybook for static hosting
+make build-lib             # build component library to dist/
+
+# Checks (run before pushing)
+make lint                  # ESLint (zero warnings allowed)
+make typecheck             # tsc --noEmit
+make check                 # lint + typecheck
+
+# Tests
+make test                  # run unit tests (Vitest)
+make test-coverage         # run with coverage thresholds
+make ci                    # full CI pipeline: lint, typecheck, unit tests, Storybook build, play functions, VRT
+
+# Publishing
+make publish               # build library and publish to GitHub Packages
+```
+
+## Architecture
+
+### Key concepts
+
+- Storybook 10, Vite, React 19, Tailwind CSS v4, TypeScript 5.9
+- Atomic design hierarchy: atoms, molecules, organisms (in `src/components/`)
+- Factory pattern: component factories return `{ Component }` (not a bare component) — see `createArdaEntityDataGrid`
+- `exactOptionalPropertyTypes: true` — omit keys entirely rather than passing `undefined`
+- Vitest for unit tests — import `@testing-library/jest-dom/vitest` (not `@testing-library/jest-dom`)
+- `eslint-plugin-react-hooks` is not installed — do not add `react-hooks/exhaustive-deps` disable comments
+- VRT (visual regression tests) use Playwright against built Storybook
+
+### Exports
+
+The library has three entry points: main (`index.ts`), `canary` (experimental), and `extras` (supplementary). Types mirror this split.
+
+## Key directories
+
+| Path | Purpose |
+|---|---|
+| `src/components/atoms/` | Atomic-level UI primitives |
+| `src/components/molecules/` | Composed components |
+| `src/components/organisms/` | Complex feature-level components |
+| `src/components/canary/` | Experimental components not yet in main |
+| `src/components/extras/` | Supplementary components |
+| `src/types/` | Shared TypeScript types |
+| `src/styles/` | Global CSS and Tailwind config |
+| `src/use-cases/` | Use-case stories and MDX documentation |
+| `src/docs/` | MDX documentation pages |
+| `tools/` | Build scripts and helpers |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,11 @@ The library has three entry points: main (`index.ts`), `canary` (experimental), 
 | `src/use-cases/` | Use-case stories and MDX documentation |
 | `src/docs/` | MDX documentation pages |
 | `tools/` | Build scripts and helpers |
+
+
+## Knowledge base
+
+The `knowledge-base/` directory contains repository-specific knowledge — recommended practices, patterns, insights, and lessons learned that are useful for working in this repo. Agents should:
+
+- **Read** relevant files before starting work to understand repo-specific conventions.
+- **Write** new insights discovered during implementation (patterns, gotchas, decisions) as Markdown files in this directory for future reference.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with build commands, architecture overview, key directories, and testing conventions for AI coding agents
- Update CHANGELOG.md

> [!note]
> Authored by Claude Code for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)