### PR TITLE
Add color swatch picker and polish image upload UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,29 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.6.0] - 2026-04-06
+
+### Added
+
+- `ImageDropZone` redesign: upload icon, "Select file" outline button, simplified
+  URL input, gray-50 background, and passive copyright subtext replacing the
+  checkbox in `ImageUploadDialog`.
+- HEIC-to-JPEG client-side conversion via `heic2any` — Apple photos now preview
+  and store correctly across all browsers.
+- `ItemCardEditor` organism: reusable WYSIWYG card editor with inline image
+  upload (no dialog for new images, crop dialog for editing existing).
+- Loading spinner on "Select file" button during HEIC conversion.
+- Color swatch picker for `ItemCardEditor` — accent color selection for card
+  dividers and branding elements.
+
+### Fixed
+
+- `ImageUploadDialog` too wide on mobile — responsive `max-w`, removed fixed
+  `min-width` on crop area, wrapping action buttons.
+- 14 Storybook play functions updated for redesigned `ImageDropZone` selectors.
+- Global `heic2any` mock added to fix 6 test suite failures in jsdom.
+- Flaky VRT timeout resolved by using `waitUntil: 'load'`.
+
 ## [4.5.0] - 2026-03-31
 
 ### Added

--- a/src/components/canary/atoms/color-swatch-picker/color-swatch-picker.tsx
+++ b/src/components/canary/atoms/color-swatch-picker/color-swatch-picker.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import { DEFAULT_COLOR_MAP } from '@/components/canary/atoms/grid/color/color-cell-display';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/canary/primitives/popover';
+
+// --- Interfaces ---
+
+export interface ColorSwatchPickerProps {
+  /** Selected color key (e.g. "GRAY"). */
+  value: string;
+  /** Called when a color is selected. */
+  onChange: (color: string) => void;
+  /** Custom color map. Defaults to the standard 10-color palette. */
+  colors?: Record<string, { hex: string; name: string }>;
+}
+
+// --- Component ---
+
+/**
+ * ColorSwatchPicker — compact color selector with a popover palette.
+ *
+ * Default state shows a small swatch + accent bar. Clicking opens a popover
+ * overlay with the full palette.
+ */
+export function ColorSwatchPicker({
+  value,
+  onChange,
+  colors = DEFAULT_COLOR_MAP,
+}: ColorSwatchPickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const selectedHex = colors[value]?.hex ?? colors.GRAY?.hex ?? '#6B7280';
+  const colorEntries = Object.entries(colors);
+
+  const handleSelect = (key: string) => {
+    onChange(key);
+    setOpen(false);
+  };
+
+  return (
+    <div className="flex items-center gap-[8px] w-full">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="flex-shrink-0 cursor-pointer rounded-[8px] border border-input bg-white p-[7px] shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Color: ${colors[value]?.name ?? value}. Click to change.`}
+          >
+            <div
+              className="size-[22px] rounded-[2px] shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)]"
+              style={{ backgroundColor: selectedHex }}
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={-38}
+          className="flex gap-[6px] items-center w-auto p-[7px] rounded-[8px] border border-border bg-white"
+        >
+          {colorEntries.map(([key, { hex, name }]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => handleSelect(key)}
+              className={
+                key === value
+                  ? 'size-[22px] rounded-[2px] shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] border-2 border-[#9ca3af] cursor-pointer'
+                  : 'size-[22px] rounded-[2px] shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] cursor-pointer'
+              }
+              style={{ backgroundColor: hex }}
+              aria-label={name}
+              aria-pressed={key === value}
+            />
+          ))}
+        </PopoverContent>
+      </Popover>
+
+      {/* Color bar */}
+      <div className="flex-1 h-[10px] transition-colors" style={{ backgroundColor: selectedHex }} />
+    </div>
+  );
+}
+
+/** Lookup a swatch hex by key. */
+export function getSwatchHex(key: string, colors = DEFAULT_COLOR_MAP): string {
+  return colors[key]?.hex ?? '#6B7280';
+}

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
@@ -15,7 +15,7 @@ function ItemCardEditorDemo({ initialFields }: { initialFields?: Partial<ItemCar
   });
 
   return (
-    <div className="flex items-center justify-center p-8 bg-muted/30 min-h-[600px]">
+    <div className="flex items-center justify-center p-4 sm:p-8 bg-muted/30 min-h-[600px]">
       <ItemCardEditor imageConfig={ITEM_IMAGE_CONFIG} fields={fields} onChange={setFields} />
     </div>
   );

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
@@ -53,6 +53,7 @@ export const EditExisting: StoryObj = {
         orderQty: '500',
         orderUnit: 'each',
         imageUrl: MOCK_ITEM_IMAGE,
+        accentColor: 'BLUE',
       }}
     />
   ),

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { PackageMinus, Package, Crop } from 'lucide-react';
 
+import {
+  ColorSwatchPicker,
+  getSwatchHex,
+} from '@/components/canary/atoms/color-swatch-picker/color-swatch-picker';
 import { ImageDropZone } from '@/components/canary/molecules/image-drop-zone/image-drop-zone';
 import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog';
 import { Input } from '@/components/canary/primitives/input';
@@ -20,6 +24,7 @@ export interface ItemCardFields {
   orderQty: string;
   orderUnit: string;
   imageUrl: string | null;
+  accentColor: string;
 }
 
 /** Init configuration for ItemCardEditor. */
@@ -138,7 +143,10 @@ export function ItemCardEditor({
         </div>
 
         {/* Accent Divider */}
-        <div className="w-full h-1 rounded-full bg-muted" />
+        <div
+          className="w-full h-[4px] transition-colors"
+          style={{ backgroundColor: getSwatchHex(fields.accentColor) }}
+        />
 
         {/* Attribute Blocks — editable inputs */}
         <div className="space-y-2">
@@ -198,8 +206,11 @@ export function ItemCardEditor({
           )}
         </div>
 
-        {/* Bottom accent */}
-        <div className="w-full h-1.5 rounded-full bg-muted" />
+        {/* Color Swatch Picker + accent bar */}
+        <ColorSwatchPicker
+          value={fields.accentColor}
+          onChange={(color) => updateField('accentColor', color)}
+        />
 
         {/* Footer Branding */}
         <div className="text-center pb-1">
@@ -227,4 +238,5 @@ export const EMPTY_ITEM_CARD_FIELDS: ItemCardFields = {
   orderQty: '',
   orderUnit: '',
   imageUrl: null,
+  accentColor: 'GRAY',
 };

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -8,6 +8,7 @@ import {
 import { ImageDropZone } from '@/components/canary/molecules/image-drop-zone/image-drop-zone';
 import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog';
 import { ArdaConfirmDialog } from '@/components/canary/atoms/confirm-dialog/confirm-dialog';
+import { Button } from '@/components/canary/primitives/button';
 import { Input } from '@/components/canary/primitives/input';
 import type {
   ImageFieldConfig,
@@ -147,7 +148,7 @@ export function ItemCardEditor({
     <>
       <div
         data-slot="item-card-editor"
-        className="relative w-[348px] max-w-full rounded-xl border border-border bg-card text-card-foreground shadow-sm px-5 py-4 flex flex-col gap-3 font-sans"
+        className="relative w-full sm:w-[348px] rounded-xl border border-border bg-card text-card-foreground shadow-sm px-4 sm:px-5 py-4 flex flex-col gap-3 font-sans"
       >
         {/* Header — editable title + QR code */}
         <div className="flex items-start justify-between gap-3">
@@ -169,7 +170,7 @@ export function ItemCardEditor({
 
         {/* Accent Divider */}
         <div
-          className="w-full h-[4px] transition-colors"
+          className="w-full h-1 transition-colors"
           style={{ backgroundColor: getSwatchHex(fields.accentColor) }}
         />
 
@@ -213,15 +214,16 @@ export function ItemCardEditor({
                 alt={fields.title || 'Product'}
                 className="w-full h-full object-cover"
               />
-              {/* Delete image button — top-left */}
-              <button
+              <Button
                 type="button"
-                className="absolute top-1.5 left-1.5 z-10 bg-black/50 hover:bg-destructive text-white rounded-full p-2.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                variant="ghost"
+                size="icon"
+                className="absolute top-1.5 left-1.5 z-10 rounded-full bg-black/50 hover:bg-destructive text-white hover:text-white"
                 onClick={() => setConfirmRemoveOpen(true)}
                 aria-label="Remove image"
               >
                 <Trash2 className="w-4 h-4" />
-              </button>
+              </Button>
               {/* Edit/replace overlay */}
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- Add `ColorSwatchPicker` atom and integrate into `ItemCardEditor` for accent color selection
- Merge in image upload redesign improvements: remove dead `onDismiss` prop, add clipboard error handling, fix object URL memory leak, add `InputGroup` Go button for mobile URL submission, add trash button with `ArdaConfirmDialog` for image removal
- Correct `--primary` oklch token from hue 29 (red) to hue 36.4 (#FF4A00 orange) across all token files
- Port `ArdaConfirmDialog` from extras to canary, replace raw buttons with `Button` component, use semantic `bg-background` instead of `bg-white`
- Make card editor responsive: full-width on mobile with tighter padding
- Clean up redundant className overrides on dialog buttons, fix arbitrary Tailwind values

## Test plan
- [x] Verify color swatch picker renders and updates accent divider in Storybook
- [x] Verify image drop zone Go button works for URL submission
- [x] Verify trash button opens confirm dialog before removing image
- [x] Verify primary color renders as Arda orange (#FF4A00), not red
- [x] Verify card editor is full-width on mobile viewport
- [x] Run `make ci` — lint, typecheck, unit tests, Storybook build, play functions, VRT all pass (2 pre-existing timezone-dependent failures in extras excluded)

> [!note]
> Authored by Claude Code for sebrandwarren

🤖 Generated with [Claude Code](https://claude.com/claude-code)