### PR TITLE
Fix image dropzone drag-and-drop from Google Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.7.0] - 2026-04-06
+
+### Added
+
+- `TypeaheadInput` molecule: standalone async typeahead with debounced search,
+  keyboard navigation, allow-create, and MSW-backed unit lookup matching the
+  production API. Wired into `ItemCardEditor` units fields.
+
 ## [4.6.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.7.1] - 2026-04-07
+
+### Fixed
+
+- Drag-and-drop from Google Images now works — extracts image data from the
+  HTML data URI the browser provides instead of using the unusable Google
+  search result URL.
+- Deferred file rejection errors in `ImageDropZone` to allow URL/data URI
+  fallback path before showing an error.
+
+### Added
+
+- `focus-ring` Tailwind utility in `globals.css` for consistent focus styling
+  across components.
+- Clickable focus state on `ImageDropZone` to signal paste readiness.
+- PR workflow rule in `CLAUDE.md`: always ask about changelog before PRs.
+
 ## [4.7.0] - 2026-04-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ The library has three entry points: main (`index.ts`), `canary` (experimental), 
 | `tools/` | Build scripts and helpers |
 
 
+## PR workflow
+
+Before creating a pull request, always ask the user if they want to add a new CHANGELOG version entry. Each PR should have its own version bump — do not add entries to an existing version that belongs to a different PR. Follow the categories in `.github/clq/changemap.json` (`Added` = minor, `Fixed` = patch, `Changed`/`Removed` = major).
+
 ## Knowledge base
 
 The `knowledge-base/` directory contains repository-specific knowledge — recommended practices, patterns, insights, and lessons learned that are useful for working in this repo. Agents should:

--- a/docs/plan-typeahead-input.md
+++ b/docs/plan-typeahead-input.md
@@ -1,0 +1,91 @@
+# Plan: Add TypeaheadInput molecule and wire into ItemCardEditor units fields
+
+## Context
+The `ItemCardEditor` currently uses plain `<Input>` for the units fields (minUnit, orderUnit). In the production frontend app, these are `UnitTypeahead` components — async typeaheads that search an API, show filtered results, and allow creating new units. We need a canary molecule that replicates this behavior standalone (no AG Grid dependency), then swap the units inputs in `ItemCardEditor`.
+
+## Reference implementations
+- **Vendored**: `vendored/arda-frontend/components/items/UnitTypeahead.tsx` — production implementation, tightly coupled to Arda API
+- **Callil's branch**: `canary/molecules/item-grid/typeahead-cell-editor.tsx` — clean implementation but coupled to AG Grid's `useGridCellEditor` hook
+
+## Approach: Build a standalone `TypeaheadInput` molecule
+
+Take the UI/behavior from Callil's `TypeaheadCellEditor` (debounced async search, keyboard nav, create option, loading/error states) but remove the AG Grid dependency so it works as a regular form input.
+
+### Phase 1: Create `TypeaheadInput` molecule
+**New file:** `src/components/canary/molecules/typeahead-input/typeahead-input.tsx`
+
+**Props interface:**
+```typescript
+interface TypeaheadOption {
+  label: string;
+  value: string;
+}
+
+interface TypeaheadInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  allowCreate?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+```
+
+**Behavior (matching vendored UnitTypeahead):**
+- Debounced search (150ms) on input change
+- Dropdown shows up to 8 results
+- "New: {typed value}" option when `allowCreate=true` and no exact match
+- Arrow Up/Down to navigate, Enter to select, Escape to close dropdown
+- AbortController for request cancellation
+- Loading spinner during fetch, error state with retry
+- Uses Arda design tokens (`bg-popover`, `border-input`, `text-muted-foreground`, etc.)
+- Renders as a Popover-style dropdown below the input (no AG Grid popup)
+
+**Reuse from existing codebase:**
+- `Input` primitive from `@/components/canary/primitives/input`
+- `Loader2`, `Plus`, `AlertCircle` icons from `lucide-react`
+- `cn()` utility for class merging
+
+### Phase 2: Create stories
+**New file:** `src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx`
+
+Stories:
+- **Default** — mock async lookup with unit options (each, case, box, pallet, pair, kg, lb, oz)
+- **AllowCreate** — same but with `allowCreate={true}`
+- **Loading** — slow lookup to show spinner
+- **PrePopulated** — starts with a value
+
+### Phase 3: Wire into ItemCardEditor
+**File:** `src/components/canary/organisms/item-card-editor/item-card-editor.tsx`
+
+- Add `unitLookup` prop to `ItemCardEditorInitProps` — the async lookup function
+- Replace the units `<Input>` fields (lines ~185-190) with `<TypeaheadInput>`
+- Pass `allowCreate={true}` so users can add custom units
+
+**Updated props:**
+```typescript
+interface ItemCardEditorInitProps {
+  imageConfig: ImageFieldConfig;
+  unitLookup: (search: string) => Promise<TypeaheadOption[]>;
+}
+```
+
+### Phase 4: Update stories with mock lookup
+**File:** `src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx`
+
+- Create a `mockUnitLookup` function that filters a static list (matching vendored mock data)
+- Pass it to `ItemCardEditor` in both stories
+
+## Files to create/modify
+1. **Create** `src/components/canary/molecules/typeahead-input/typeahead-input.tsx`
+2. **Create** `src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx`
+3. **Modify** `src/components/canary/organisms/item-card-editor/item-card-editor.tsx` — add `unitLookup` prop, swap Input → TypeaheadInput for unit fields
+4. **Modify** `src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx` — add mock lookup
+5. **Modify** `src/use-cases/reference/items/create-item/0010-set-image/during-creation-inline.stories.tsx` — add mock lookup
+
+## Verification
+1. Storybook: TypeaheadInput stories — type to search, select, create new, keyboard nav
+2. Storybook: ItemCardEditor stories — units fields show typeahead dropdown
+3. Type check: `npx tsc --noEmit`
+4. Tests: `npx vitest run src/components/canary/`

--- a/src/components/canary/__mocks__/handlers/unit-lookup.ts
+++ b/src/components/canary/__mocks__/handlers/unit-lookup.ts
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from 'msw';
+
+export const MOCK_UNITS = [
+  { eId: 'unit-001', name: 'each' },
+  { eId: 'unit-002', name: 'case' },
+  { eId: 'unit-003', name: 'box' },
+  { eId: 'unit-004', name: 'pallet' },
+  { eId: 'unit-005', name: 'pair' },
+  { eId: 'unit-006', name: 'kg' },
+  { eId: 'unit-007', name: 'lb' },
+  { eId: 'unit-008', name: 'oz' },
+  { eId: 'unit-009', name: 'liter' },
+  { eId: 'unit-010', name: 'gallon' },
+];
+
+export const unitLookupHandler = http.get('/api/arda/items/lookup-units', ({ request }) => {
+  const url = new URL(request.url);
+  const name = url.searchParams.get('name') || '';
+
+  const filtered = name
+    ? MOCK_UNITS.filter((u) => u.name.toLowerCase().includes(name.toLowerCase()))
+    : MOCK_UNITS;
+
+  return HttpResponse.json({ ok: true, status: 200, data: filtered });
+});

--- a/src/components/canary/__mocks__/unit-lookup.ts
+++ b/src/components/canary/__mocks__/unit-lookup.ts
@@ -1,0 +1,13 @@
+import type { TypeaheadOption } from '@/components/canary/molecules/typeahead-input/typeahead-input';
+
+/**
+ * Lookup function that calls the MSW-mocked unit endpoint.
+ * Matches the vendored `ardaClient.lookupUnits()` API shape.
+ */
+export async function lookupUnits(search: string): Promise<TypeaheadOption[]> {
+  const params = new URLSearchParams({ name: search });
+  const res = await fetch(`/api/arda/items/lookup-units?${params}`);
+  const json = await res.json();
+  const data: { eId: string; name: string }[] = json.data ?? [];
+  return data.map((d) => ({ label: d.name, value: d.name }));
+}

--- a/src/components/canary/molecules/image-drop-zone/image-drop-zone.test.tsx
+++ b/src/components/canary/molecules/image-drop-zone/image-drop-zone.test.tsx
@@ -106,7 +106,7 @@ describe('ImageDropZone', () => {
     });
   });
 
-  it('shows error for invalid file type', async () => {
+  it('defers error for invalid file type to allow URL fallback', async () => {
     const { onInput } = renderDropZone();
     const file = new File(['content'], 'document.pdf', { type: 'application/pdf' });
 
@@ -116,7 +116,10 @@ describe('ImageDropZone', () => {
       onDrop!([], [{ file, errors: [{ code: 'file-invalid-type' }] }]);
     });
 
-    expect(onInput).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    // onDrop no longer emits error directly — it defers to handleDrop
+    // so the URL fallback (e.g. Google Images drag) can be attempted first.
+    // The error is shown by handleDrop when no URL fallback is available.
+    expect(onInput).not.toHaveBeenCalled();
   });
 
   it('does not render a dismiss button (parent handles dismissal)', () => {

--- a/src/components/canary/molecules/image-drop-zone/image-drop-zone.tsx
+++ b/src/components/canary/molecules/image-drop-zone/image-drop-zone.tsx
@@ -47,34 +47,29 @@ export function ImageDropZone({ acceptedFormats, onInput }: ImageDropZoneProps) 
   const [urlValue, setUrlValue] = React.useState('');
   const [error, setError] = React.useState<string | null>(null);
   const [converting, setConverting] = React.useState(false);
+  // Tracks drop outcome — read by handleDrop to decide URL fallback behavior.
+  const dropResultRef = React.useRef<string>('none');
 
   // --- File drop handler ---
   const onDrop = React.useCallback(
     async (acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
       setError(null);
+      dropResultRef.current = 'none';
 
-      if (rejectedFiles.length > 0) {
-        const rejected = rejectedFiles[0];
-        if (rejected !== undefined) {
-          const mimeError = rejected.errors.find((e) => e.code === 'file-invalid-type');
-          if (mimeError) {
-            const formats = acceptedFormats.join(', ');
-            setError(`Invalid file type. Accepted formats: ${formats}`);
-            onInput({ type: 'error', message: `Invalid file type. Accepted formats: ${formats}` });
-            return;
-          }
-        }
+      if (rejectedFiles.length > 0 && acceptedFiles.length === 0) {
+        // All files rejected — defer to handleDrop for URL fallback or error.
+        dropResultRef.current = 'rejected';
+        return;
       }
 
       if (acceptedFiles.length > 0) {
         const file = acceptedFiles[0];
         if (file !== undefined) {
           if (!acceptedFormats.includes(file.type as ImageMimeType)) {
-            const formats = acceptedFormats.join(', ');
-            setError(`Invalid file type. Accepted formats: ${formats}`);
-            onInput({ type: 'error', message: `Invalid file type. Accepted formats: ${formats}` });
+            dropResultRef.current = 'rejected';
             return;
           }
+          dropResultRef.current = 'handled';
           setConverting(true);
           try {
             const converted = await maybeConvertHeic(file);
@@ -193,7 +188,7 @@ export function ImageDropZone({ acceptedFormats, onInput }: ImageDropZoneProps) 
   const rootProps = getRootProps();
   const dropzoneOnDrop = rootProps.onDrop;
   const handleDrop = React.useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
+    async (e: React.DragEvent<HTMLDivElement>) => {
       // Capture URL data before any handler can alter the event.
       // text/uri-list (RFC 2483) may have comment lines (#…) and multiple URLs.
       const parseFirstUrl = (raw: string): string | undefined =>
@@ -202,27 +197,82 @@ export function ImageDropZone({ acceptedFormats, onInput }: ImageDropZoneProps) 
           .map((l) => l.trim())
           .find((l) => l.length > 0 && !l.startsWith('#'));
 
+      // Extract the best image URL from the drop data.
+      // Priority: 1) data URI from text/html, 2) imgurl param from Google URLs,
+      // 3) direct image URL from text/uri-list or text/plain.
+      const html = e.dataTransfer?.getData('text/html') ?? '';
+      const uriList = e.dataTransfer?.getData('text/uri-list') ?? '';
+      const plainText = e.dataTransfer?.getData('text/plain') ?? '';
+
+      // Try to extract a data URI or src from an <img> tag in the HTML
+      const imgSrcMatch = html.match(/<img[^>]+src="([^"]+)"/);
+      const imgSrc = imgSrcMatch?.[1];
+
+      // Try to extract imgurl param from Google Images search URL
+      const extractImgUrl = (url: string): string | undefined => {
+        try {
+          const parsed = new URL(url);
+          const imgurl = parsed.searchParams.get('imgurl');
+          return imgurl ?? undefined;
+        } catch {
+          return undefined;
+        }
+      };
+
+      const rawUrl = parseFirstUrl(uriList) || parseFirstUrl(plainText);
+
+      // Pick the best source: data URI > extracted Google imgurl > direct URL
       const droppedUrl =
-        parseFirstUrl(e.dataTransfer?.getData('text/uri-list') ?? '') ||
-        parseFirstUrl(e.dataTransfer?.getData('text/plain') ?? '');
+        (imgSrc?.startsWith('data:image/') ? imgSrc : undefined) ||
+        (rawUrl ? extractImgUrl(rawUrl) : undefined) ||
+        (rawUrl?.match(/\.(jpg|jpeg|png|gif|webp|svg)(\?|$)/i) ? rawUrl : undefined) ||
+        (imgSrc?.startsWith('https://') ? imgSrc : undefined);
 
       // Let react-dropzone process file drops first.
+      dropResultRef.current = 'none';
       dropzoneOnDrop?.(e as unknown as React.DragEvent<HTMLElement>);
 
-      // When no files are present (URL-only drop from another browser window),
-      // populate the field and auto-submit valid HTTPS URLs.  The user already
-      // expressed intent by dragging-and-dropping, so there is no reason to make
-      // them also click "Go".
-      if ((e.dataTransfer?.files.length ?? 0) === 0 && droppedUrl) {
+      // Read result after react-dropzone's synchronous onDrop callback ran.
+      const result = dropResultRef.current;
+
+      // If a file was successfully handled, we're done.
+      if (result === 'handled') return;
+
+      // Fall back to extracted image data when react-dropzone had no valid file
+      // (URL-only drag, or files rejected due to wrong MIME like Google Images).
+      if (droppedUrl) {
         e.preventDefault();
         setError(null);
-        setUrlValue(droppedUrl);
 
+        // Data URIs (from Google Images drag) — convert to File
+        if (droppedUrl.startsWith('data:image/')) {
+          try {
+            const res = await fetch(droppedUrl);
+            const blob = await res.blob();
+            const ext = blob.type.split('/')[1] ?? 'jpg';
+            const file = new File([blob], `dropped-image.${ext}`, { type: blob.type });
+            onInput({ type: 'file', file });
+          } catch {
+            setError('Could not process the dropped image.');
+          }
+          return;
+        }
+
+        // HTTPS URLs — send as URL input
         if (droppedUrl.startsWith('https://')) {
+          setUrlValue(droppedUrl);
           onInput({ type: 'url', url: droppedUrl });
         } else {
           setError('URL must start with https://');
         }
+        return;
+      }
+
+      // No URL fallback and files were rejected — show error.
+      if (result === 'rejected') {
+        const formats = acceptedFormats.join(', ');
+        setError(`Invalid file type. Accepted formats: ${formats}`);
+        onInput({ type: 'error', message: `Invalid file type. Accepted formats: ${formats}` });
       }
     },
     [dropzoneOnDrop, onInput],
@@ -237,8 +287,9 @@ export function ImageDropZone({ acceptedFormats, onInput }: ImageDropZoneProps) 
       {...rootProps}
       onDrop={handleDrop}
       onPaste={handlePaste}
+      tabIndex={0}
       className={cn(
-        'border-2 border-dashed rounded-lg p-8 transition-colors',
+        'border-2 border-dashed rounded-lg p-8 transition-colors focus-ring',
         isDragActive ? 'border-primary bg-accent' : 'border-border bg-muted',
       )}
     >

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TypeaheadInput } from './typeahead-input';
+import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function TypeaheadDemo({
+  initialValue = '',
+  ...props
+}: Omit<React.ComponentProps<typeof TypeaheadInput>, 'value' | 'onChange'> & {
+  initialValue?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <div className="w-64 p-8">
+      <TypeaheadInput value={value} onChange={setValue} {...props} />
+      <p className="mt-2 text-xs text-muted-foreground">
+        Value: <code>{value || '(empty)'}</code>
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta = {
+  title: 'Components/Canary/Molecules/TypeaheadInput',
+  parameters: {
+    msw: { handlers: [unitLookupHandler] },
+  },
+};
+
+export default meta;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+export const Default: StoryObj = {
+  render: () => <TypeaheadDemo lookup={lookupUnits} placeholder="Select unit..." />,
+};
+
+export const AllowCreate: StoryObj = {
+  render: () => (
+    <TypeaheadDemo lookup={lookupUnits} allowCreate placeholder="Type or create unit..." />
+  ),
+};
+
+export const PrePopulated: StoryObj = {
+  render: () => (
+    <TypeaheadDemo lookup={lookupUnits} initialValue="each" placeholder="Select unit..." />
+  ),
+};
+
+export const Disabled: StoryObj = {
+  render: () => (
+    <TypeaheadDemo lookup={lookupUnits} initialValue="kg" disabled placeholder="Select unit..." />
+  ),
+};

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -12,14 +12,14 @@ import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-l
 function TypeaheadDemo({
   initialValue = '',
   ...props
-}: Omit<React.ComponentProps<typeof TypeaheadInput>, 'value' | 'onChange'> & {
+}: Omit<React.ComponentProps<typeof TypeaheadInput>, 'value' | 'onValueChange'> & {
   initialValue?: string;
 }) {
   const [value, setValue] = useState(initialValue);
 
   return (
     <div className="w-64 p-8">
-      <TypeaheadInput value={value} onChange={setValue} {...props} />
+      <TypeaheadInput value={value} onValueChange={setValue} {...props} />
       <p className="mt-2 text-xs text-muted-foreground">
         Value: <code>{value || '(empty)'}</code>
       </p>

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -11,25 +11,36 @@ export interface TypeaheadOption {
   value: string;
 }
 
-export interface TypeaheadInputProps {
+export interface TypeaheadInputProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
   /** Current value. */
   value: string;
   /** Called when the user selects or creates a value. */
-  onChange: (value: string) => void;
+  onValueChange: (value: string) => void;
   /** Async lookup function — receives search text, returns matching options. */
   lookup: (search: string) => Promise<TypeaheadOption[]>;
   /** Allow creating new values not in the lookup results. */
   allowCreate?: boolean;
   /** Input placeholder text. */
   placeholder?: string;
+  /** Accessible label for the input. */
+  'aria-label'?: string;
   /** Disable the input. */
   disabled?: boolean;
-  /** Additional class names for the wrapper. */
-  className?: string;
 }
 
 const MAX_RESULTS = 8;
 const DEBOUNCE_MS = 150;
+const LISTBOX_ID = 'typeahead-listbox';
+
+// Hoisted static JSX — avoids recreation on every render
+const loadingIndicator = (
+  <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+    <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+    Searching&hellip;
+  </div>
+);
+
+const noResults = <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>;
 
 // --- Component ---
 
@@ -41,12 +52,14 @@ const DEBOUNCE_MS = 150;
  */
 export function TypeaheadInput({
   value,
-  onChange,
+  onValueChange,
   lookup,
   allowCreate = false,
   placeholder = 'Search\u2026',
+  'aria-label': ariaLabel,
   disabled = false,
   className,
+  ...rest
 }: TypeaheadInputProps) {
   const [inputValue, setInputValue] = React.useState(value);
   const [options, setOptions] = React.useState<TypeaheadOption[]>([]);
@@ -60,6 +73,16 @@ export function TypeaheadInput({
   const debounceRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const abortRef = React.useRef<AbortController>(undefined);
   const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  // Refs for values used in stable callbacks
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const inputValueRef = React.useRef(inputValue);
+  inputValueRef.current = inputValue;
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+  const highlightedRef = React.useRef(highlightedIndex);
+  highlightedRef.current = highlightedIndex;
 
   // Sync external value changes
   React.useEffect(() => {
@@ -112,11 +135,11 @@ export function TypeaheadInput({
   const selectOption = React.useCallback(
     (opt: TypeaheadOption) => {
       setInputValue(opt.value);
-      onChange(opt.value);
+      onValueChange(opt.value);
       setOpen(false);
       setOptions([]);
     },
-    [onChange],
+    [onValueChange],
   );
 
   const createValue = React.useCallback(
@@ -124,18 +147,17 @@ export function TypeaheadInput({
       const trimmed = val.trim();
       if (!trimmed) return;
       setInputValue(trimmed);
-      onChange(trimmed);
+      onValueChange(trimmed);
       setOpen(false);
       setOptions([]);
     },
-    [onChange],
+    [onValueChange],
   );
 
-  // --- Show "create" option? ---
+  // --- Derived state ---
   const trimmedInput = inputValue.trim();
   const exactMatch = options.some((o) => o.value.toLowerCase() === trimmedInput.toLowerCase());
   const showCreate = allowCreate && trimmedInput.length > 0 && !exactMatch;
-  const totalItems = options.length + (showCreate ? 1 : 0);
 
   // --- Input handlers ---
   const handleInputChange = React.useCallback(
@@ -150,86 +172,81 @@ export function TypeaheadInput({
 
   const handleFocus = React.useCallback(() => {
     setOpen(true);
-    doSearch(inputValue);
-  }, [doSearch, inputValue]);
+    doSearch(inputValueRef.current);
+  }, [doSearch]);
 
-  // Close on outside click
+  // Close on outside click — deps narrowed to [open] via refs
   React.useEffect(() => {
     if (!open) return;
     const handleClickOutside = (e: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
         setOpen(false);
-        // Revert to last confirmed value if input changed
-        if (inputValue.trim() !== value) {
-          setInputValue(value);
+        if (inputValueRef.current.trim() !== valueRef.current) {
+          setInputValue(valueRef.current);
         }
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open, inputValue, value]);
+  }, [open]);
 
-  // --- Keyboard ---
+  // --- Keyboard — uses refs for stable callback ---
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
       if (!open) {
         if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
           e.preventDefault();
           setOpen(true);
-          doSearch(inputValue);
+          doSearch(inputValueRef.current);
         }
         return;
       }
 
+      const opts = optionsRef.current;
+      const hi = highlightedRef.current;
+      const total =
+        opts.length +
+        (allowCreate &&
+        inputValueRef.current.trim().length > 0 &&
+        !opts.some((o) => o.value.toLowerCase() === inputValueRef.current.trim().toLowerCase())
+          ? 1
+          : 0);
+
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
-          setHighlightedIndex((prev) => (prev + 1) % totalItems);
+          setHighlightedIndex((prev) => (prev + 1) % total);
           break;
         case 'ArrowUp':
           e.preventDefault();
-          setHighlightedIndex((prev) => (prev - 1 + totalItems) % totalItems);
+          setHighlightedIndex((prev) => (prev - 1 + total) % total);
           break;
         case 'Enter':
           e.preventDefault();
-          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
-            selectOption(options[highlightedIndex] as TypeaheadOption);
-          } else if (showCreate && highlightedIndex === options.length) {
-            createValue(trimmedInput);
-          } else if (showCreate) {
-            createValue(trimmedInput);
+          if (hi >= 0 && hi < opts.length) {
+            selectOption(opts[hi] as TypeaheadOption);
+          } else if (hi === opts.length && total > opts.length) {
+            createValue(inputValueRef.current.trim());
+          } else if (total > opts.length) {
+            createValue(inputValueRef.current.trim());
           }
           break;
         case 'Escape':
           e.preventDefault();
           setOpen(false);
-          setInputValue(value);
+          setInputValue(valueRef.current);
           break;
         case 'Tab':
-          // Accept current selection or typed value on Tab
-          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
-            selectOption(options[highlightedIndex] as TypeaheadOption);
-          } else if (trimmedInput && allowCreate) {
-            createValue(trimmedInput);
+          if (hi >= 0 && hi < opts.length) {
+            selectOption(opts[hi] as TypeaheadOption);
+          } else if (inputValueRef.current.trim() && allowCreate) {
+            createValue(inputValueRef.current.trim());
           }
           setOpen(false);
           break;
       }
     },
-    [
-      open,
-      totalItems,
-      highlightedIndex,
-      options,
-      showCreate,
-      trimmedInput,
-      selectOption,
-      createValue,
-      value,
-      doSearch,
-      inputValue,
-      allowCreate,
-    ],
+    [open, allowCreate, doSearch, selectOption, createValue],
   );
 
   // Scroll highlighted item into view
@@ -241,8 +258,32 @@ export function TypeaheadInput({
 
   const showDropdown = open && (loading || error || options.length > 0 || showCreate);
 
+  // Live region announcement
+  const statusMessage = loading
+    ? 'Searching'
+    : error
+      ? 'Failed to load results'
+      : options.length > 0
+        ? `${options.length} result${options.length === 1 ? '' : 's'} available`
+        : open && trimmedInput
+          ? 'No results'
+          : '';
+
   return (
-    <div ref={wrapperRef} className={cn('relative', className)} data-slot="typeahead-input">
+    <div
+      ref={wrapperRef}
+      className={cn('relative', className)}
+      data-slot="typeahead-input"
+      data-state={open ? 'open' : 'closed'}
+      data-loading={loading || undefined}
+      data-disabled={disabled || undefined}
+      {...rest}
+    >
+      {/* Live region for screen readers */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {statusMessage}
+      </div>
+
       <Input
         ref={inputRef}
         value={inputValue}
@@ -254,25 +295,23 @@ export function TypeaheadInput({
         role="combobox"
         aria-expanded={showDropdown}
         aria-haspopup="listbox"
+        aria-controls={showDropdown ? LISTBOX_ID : undefined}
         aria-activedescendant={
           highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
         }
+        aria-label={ariaLabel ?? placeholder}
         autoComplete="off"
       />
 
       {showDropdown && (
         <div
           ref={listRef}
+          id={LISTBOX_ID}
           role="listbox"
           className="absolute z-50 top-full left-0 right-0 mt-1 max-h-52 overflow-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md"
         >
           {/* Loading */}
-          {loading && (
-            <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              Searching\u2026
-            </div>
-          )}
+          {loading && loadingIndicator}
 
           {/* Error */}
           {error && (
@@ -281,7 +320,7 @@ export function TypeaheadInput({
               className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
               onClick={() => doSearch(inputValue)}
             >
-              <AlertCircle className="w-4 h-4" />
+              <AlertCircle className="w-4 h-4" aria-hidden="true" />
               Failed to load. Click to retry.
             </button>
           )}
@@ -329,15 +368,13 @@ export function TypeaheadInput({
               }}
               onMouseEnter={() => setHighlightedIndex(options.length)}
             >
-              <Plus className="w-4 h-4" />
+              <Plus className="w-4 h-4" aria-hidden="true" />
               New: {trimmedInput}
             </div>
           )}
 
           {/* Empty state */}
-          {!loading && !error && options.length === 0 && !showCreate && (
-            <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>
-          )}
+          {!loading && !error && options.length === 0 && !showCreate && noResults}
         </div>
       )}
     </div>

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -1,0 +1,345 @@
+import * as React from 'react';
+import { Plus, Loader2, AlertCircle } from 'lucide-react';
+
+import { cn } from '@/types/canary/utilities/utils';
+import { Input } from '@/components/canary/primitives/input';
+
+// --- Types ---
+
+export interface TypeaheadOption {
+  label: string;
+  value: string;
+}
+
+export interface TypeaheadInputProps {
+  /** Current value. */
+  value: string;
+  /** Called when the user selects or creates a value. */
+  onChange: (value: string) => void;
+  /** Async lookup function — receives search text, returns matching options. */
+  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  /** Allow creating new values not in the lookup results. */
+  allowCreate?: boolean;
+  /** Input placeholder text. */
+  placeholder?: string;
+  /** Disable the input. */
+  disabled?: boolean;
+  /** Additional class names for the wrapper. */
+  className?: string;
+}
+
+const MAX_RESULTS = 8;
+const DEBOUNCE_MS = 150;
+
+// --- Component ---
+
+/**
+ * TypeaheadInput — async search input with filtered dropdown.
+ *
+ * Debounces search, shows up to 8 results, supports keyboard navigation
+ * and optional creation of new values. Standalone — no AG Grid dependency.
+ */
+export function TypeaheadInput({
+  value,
+  onChange,
+  lookup,
+  allowCreate = false,
+  placeholder = 'Search\u2026',
+  disabled = false,
+  className,
+}: TypeaheadInputProps) {
+  const [inputValue, setInputValue] = React.useState(value);
+  const [options, setOptions] = React.useState<TypeaheadOption[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortRef = React.useRef<AbortController>(undefined);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  // Sync external value changes
+  React.useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  // --- Search ---
+  const doSearch = React.useCallback(
+    async (search: string) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      setError(false);
+
+      try {
+        const results = await lookup(search);
+        if (controller.signal.aborted) return;
+        setOptions(results.slice(0, MAX_RESULTS));
+        setHighlightedIndex(-1);
+        setLoading(false);
+      } catch {
+        if (controller.signal.aborted) return;
+        setError(true);
+        setLoading(false);
+        setOptions([]);
+      }
+    },
+    [lookup],
+  );
+
+  const debouncedSearch = React.useCallback(
+    (search: string) => {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => doSearch(search), DEBOUNCE_MS);
+    },
+    [doSearch],
+  );
+
+  // Cleanup on unmount
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(debounceRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  // --- Selection ---
+  const selectOption = React.useCallback(
+    (opt: TypeaheadOption) => {
+      setInputValue(opt.value);
+      onChange(opt.value);
+      setOpen(false);
+      setOptions([]);
+    },
+    [onChange],
+  );
+
+  const createValue = React.useCallback(
+    (val: string) => {
+      const trimmed = val.trim();
+      if (!trimmed) return;
+      setInputValue(trimmed);
+      onChange(trimmed);
+      setOpen(false);
+      setOptions([]);
+    },
+    [onChange],
+  );
+
+  // --- Show "create" option? ---
+  const trimmedInput = inputValue.trim();
+  const exactMatch = options.some((o) => o.value.toLowerCase() === trimmedInput.toLowerCase());
+  const showCreate = allowCreate && trimmedInput.length > 0 && !exactMatch;
+  const totalItems = options.length + (showCreate ? 1 : 0);
+
+  // --- Input handlers ---
+  const handleInputChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value;
+      setInputValue(val);
+      setOpen(true);
+      debouncedSearch(val);
+    },
+    [debouncedSearch],
+  );
+
+  const handleFocus = React.useCallback(() => {
+    setOpen(true);
+    doSearch(inputValue);
+  }, [doSearch, inputValue]);
+
+  // Close on outside click
+  React.useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        // Revert to last confirmed value if input changed
+        if (inputValue.trim() !== value) {
+          setInputValue(value);
+        }
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open, inputValue, value]);
+
+  // --- Keyboard ---
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open) {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          setOpen(true);
+          doSearch(inputValue);
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev + 1) % totalItems);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev - 1 + totalItems) % totalItems);
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
+            selectOption(options[highlightedIndex] as TypeaheadOption);
+          } else if (showCreate && highlightedIndex === options.length) {
+            createValue(trimmedInput);
+          } else if (showCreate) {
+            createValue(trimmedInput);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setOpen(false);
+          setInputValue(value);
+          break;
+        case 'Tab':
+          // Accept current selection or typed value on Tab
+          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
+            selectOption(options[highlightedIndex] as TypeaheadOption);
+          } else if (trimmedInput && allowCreate) {
+            createValue(trimmedInput);
+          }
+          setOpen(false);
+          break;
+      }
+    },
+    [
+      open,
+      totalItems,
+      highlightedIndex,
+      options,
+      showCreate,
+      trimmedInput,
+      selectOption,
+      createValue,
+      value,
+      doSearch,
+      inputValue,
+      allowCreate,
+    ],
+  );
+
+  // Scroll highlighted item into view
+  React.useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const showDropdown = open && (loading || error || options.length > 0 || showCreate);
+
+  return (
+    <div ref={wrapperRef} className={cn('relative', className)} data-slot="typeahead-input">
+      <Input
+        ref={inputRef}
+        value={inputValue}
+        onChange={handleInputChange}
+        onFocus={handleFocus}
+        onKeyDownCapture={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        role="combobox"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        aria-activedescendant={
+          highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
+        }
+        autoComplete="off"
+      />
+
+      {showDropdown && (
+        <div
+          ref={listRef}
+          role="listbox"
+          className="absolute z-50 top-full left-0 right-0 mt-1 max-h-52 overflow-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md"
+        >
+          {/* Loading */}
+          {loading && (
+            <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Searching\u2026
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <button
+              type="button"
+              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
+              onClick={() => doSearch(inputValue)}
+            >
+              <AlertCircle className="w-4 h-4" />
+              Failed to load. Click to retry.
+            </button>
+          )}
+
+          {/* Options */}
+          {!loading &&
+            !error &&
+            options.map((opt, i) => (
+              <div
+                key={opt.value}
+                id={`typeahead-opt-${i}`}
+                role="option"
+                aria-selected={i === highlightedIndex}
+                className={cn(
+                  'px-3 py-2 text-sm cursor-pointer',
+                  i === highlightedIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent/50',
+                )}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  selectOption(opt);
+                }}
+                onMouseEnter={() => setHighlightedIndex(i)}
+              >
+                {opt.label}
+              </div>
+            ))}
+
+          {/* Create new */}
+          {!loading && !error && showCreate && (
+            <div
+              id={`typeahead-opt-${options.length}`}
+              role="option"
+              aria-selected={highlightedIndex === options.length}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2 text-sm cursor-pointer',
+                highlightedIndex === options.length
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent/50',
+              )}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                createValue(trimmedInput);
+              }}
+              onMouseEnter={() => setHighlightedIndex(options.length)}
+            >
+              <Plus className="w-4 h-4" />
+              New: {trimmedInput}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!loading && !error && options.length === 0 && !showCreate && (
+            <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ItemCardEditor, EMPTY_ITEM_CARD_FIELDS, type ItemCardFields } from './item-card-editor';
 import { ITEM_IMAGE_CONFIG, MOCK_ITEM_IMAGE } from '@/components/canary/__mocks__/image-story-data';
+import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
 
 // ---------------------------------------------------------------------------
 // Wrapper for controlled state
@@ -16,7 +18,12 @@ function ItemCardEditorDemo({ initialFields }: { initialFields?: Partial<ItemCar
 
   return (
     <div className="flex items-center justify-center p-4 sm:p-8 bg-muted/30 min-h-[600px]">
-      <ItemCardEditor imageConfig={ITEM_IMAGE_CONFIG} fields={fields} onChange={setFields} />
+      <ItemCardEditor
+        imageConfig={ITEM_IMAGE_CONFIG}
+        unitLookup={lookupUnits}
+        fields={fields}
+        onChange={setFields}
+      />
     </div>
   );
 }
@@ -27,7 +34,10 @@ function ItemCardEditorDemo({ initialFields }: { initialFields?: Partial<ItemCar
 
 const meta: Meta = {
   title: 'Components/Canary/Organisms/ItemCardEditor',
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: [unitLookupHandler] },
+  },
 };
 
 export default meta;

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -88,6 +88,8 @@ export function ItemCardEditor({
   );
 
   // New images go straight onto the card — no dialog.
+  // For URLs (e.g. dragged from Google Images), fetch as blob first to avoid
+  // referrer-restricted or short-lived URLs breaking the <img> tag.
   const handleDropZoneInput = React.useCallback(
     (input: ImageInput) => {
       if (input.type === 'error') return;
@@ -104,8 +106,27 @@ export function ItemCardEditor({
         onChange({ ...fields, imageUrl: url });
         onImageConfirmed?.(url);
       } else if (input.type === 'url') {
-        onChange({ ...fields, imageUrl: input.url });
-        onImageConfirmed?.(input.url);
+        // Fetch the image as a blob so it works even if the source URL
+        // is referrer-restricted (Google Images, CDNs with hotlink protection).
+        fetch(input.url, { mode: 'cors' })
+          .then((res) => {
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const ct = res.headers.get('content-type') ?? '';
+            if (!ct.startsWith('image/')) throw new Error(`Not an image: ${ct}`);
+            return res.blob();
+          })
+          .then((blob) => {
+            const url = URL.createObjectURL(blob);
+            objectUrlRef.current = url;
+            onChange({ ...fields, imageUrl: url });
+            onImageConfirmed?.(url);
+          })
+          .catch(() => {
+            // If fetch fails (CORS, not an image), fall back to using the URL directly.
+            // It may still work if the server allows <img> loading but blocks fetch.
+            onChange({ ...fields, imageUrl: input.url });
+            onImageConfirmed?.(input.url);
+          });
       }
     },
     [fields, onChange, onImageConfirmed],

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -10,6 +10,10 @@ import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-up
 import { ArdaConfirmDialog } from '@/components/canary/atoms/confirm-dialog/confirm-dialog';
 import { Button } from '@/components/canary/primitives/button';
 import { Input } from '@/components/canary/primitives/input';
+import {
+  TypeaheadInput,
+  type TypeaheadOption,
+} from '@/components/canary/molecules/typeahead-input/typeahead-input';
 import type {
   ImageFieldConfig,
   ImageInput,
@@ -33,6 +37,8 @@ export interface ItemCardFields {
 export interface ItemCardEditorInitProps {
   /** Image field configuration (accepted formats, aspect ratio, etc.). */
   imageConfig: ImageFieldConfig;
+  /** Async lookup for unit typeahead fields. */
+  unitLookup: (search: string) => Promise<TypeaheadOption[]>;
 }
 
 /** Runtime props for ItemCardEditor. */
@@ -58,6 +64,7 @@ export type ItemCardEditorProps = ItemCardEditorInitProps & ItemCardEditorRuntim
  */
 export function ItemCardEditor({
   imageConfig,
+  unitLookup,
   fields,
   onChange,
   onImageConfirmed,
@@ -189,13 +196,15 @@ export function ItemCardEditor({
                   placeholder={section.qtyPlaceholder}
                   value={fields[section.qtyKey]}
                   onChange={(e) => updateField(section.qtyKey, e.target.value)}
-                  className="text-sm h-9 rounded-lg"
+                  className="text-sm h-9 rounded-lg w-[86px] flex-shrink-0"
                 />
-                <Input
-                  placeholder={section.unitPlaceholder}
+                <TypeaheadInput
                   value={fields[section.unitKey]}
-                  onChange={(e) => updateField(section.unitKey, e.target.value)}
-                  className="text-sm h-9 rounded-lg"
+                  onChange={(val) => updateField(section.unitKey, val)}
+                  lookup={unitLookup}
+                  allowCreate
+                  placeholder={section.unitPlaceholder}
+                  className="flex-1 min-w-0"
                 />
               </div>
             </div>

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -200,7 +200,7 @@ export function ItemCardEditor({
                 />
                 <TypeaheadInput
                   value={fields[section.unitKey]}
-                  onChange={(val) => updateField(section.unitKey, val)}
+                  onValueChange={(val) => updateField(section.unitKey, val)}
                   lookup={unitLookup}
                   allowCreate
                   placeholder={section.unitPlaceholder}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,6 +9,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@utility focus-ring {
+  outline: none;
+  &:focus-visible,
+  &:focus-within {
+    border-color: var(--ring);
+    box-shadow: 0 0 0 3px oklch(from var(--ring) l c h / 0.5);
+  }
+}
+
 @layer base, theme-override;
 
 :root {

--- a/src/use-cases/reference/items/create-item/0010-set-image/during-creation-inline.stories.tsx
+++ b/src/use-cases/reference/items/create-item/0010-set-image/during-creation-inline.stories.tsx
@@ -17,6 +17,8 @@ import {
   type ItemCardFields,
 } from '@/components/canary/organisms/item-card-editor/item-card-editor';
 import { ITEM_IMAGE_CONFIG } from '@/components/canary/__mocks__/image-story-data';
+import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
 
 // ---------------------------------------------------------------------------
 // Live page wrapper
@@ -35,7 +37,12 @@ function InlineCardCreationPage() {
           Fill in the card fields directly. Drop or select an image in the card&rsquo;s image area.
         </p>
       </div>
-      <ItemCardEditor imageConfig={ITEM_IMAGE_CONFIG} fields={fields} onChange={setFields} />
+      <ItemCardEditor
+        imageConfig={ITEM_IMAGE_CONFIG}
+        unitLookup={lookupUnits}
+        fields={fields}
+        onChange={setFields}
+      />
     </div>
   );
 }
@@ -162,6 +169,7 @@ const meta: Meta = {
     'Use Cases/Reference/Items/ITM-0003 Create Item/0010 Set Image/During Creation \u2013 Inline on Card',
   parameters: {
     layout: 'fullscreen',
+    msw: { handlers: [unitLookupHandler] },
   },
 };
 


### PR DESCRIPTION
## Summary
- Fix drag-and-drop from Google Images — extracts base64 image data from the `text/html` the browser provides, and falls back to the `imgurl` param from Google's search URL
- Defer file rejection errors to allow URL/data URI fallback before showing errors
- Add `focus-ring` Tailwind utility to `globals.css` for consistent focus styling
- Add clickable focus state on dropzone to signal paste readiness (Ctrl+V)
- Add PR workflow rule to `CLAUDE.md`: always ask about changelog before PRs

## Test plan
- [ ] Drag an image from Google Images search results → image appears on card
- [ ] Drag a local file → still works as before
- [ ] Click the dropzone → focus ring appears, Ctrl+V paste works
- [ ] `npx tsc --noEmit` — zero errors
- [ ] `npx vitest run src/components/canary/molecules/image-drop-zone` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)