### PR TITLE
Add cell editor mode to TypeaheadInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.7.0] - 2026-04-06
+
+### Added
+
+- `TypeaheadInput` molecule: standalone async typeahead with debounced search,
+  keyboard navigation, allow-create, and MSW-backed unit lookup matching the
+  production API. Wired into `ItemCardEditor` units fields.
+
 ## [4.6.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.7.2] - 2026-04-08
+
+### Fixed
+
+- `TypeaheadInput`: added `cellEditorMode` prop for inline AG Grid editing
+  (borderless input, blur-accepts-value, Popover dropdown for both modes).
+- `TypeaheadInput`: unique IDs per instance via `useId()` — fixes broken ARIA
+  when multiple typeaheads render on the same page.
+- `TypeaheadInput`: debounce aligned to 250ms matching the frontend app.
+- `TypeaheadCellEditor` factory: `createTypeaheadCellEditor({ lookup, ... })`
+  for AG Grid column definitions.
+- Date-time tests: timezone-independent by using midday UTC timestamps.
+
 ## [4.7.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   (borderless input, blur-accepts-value, Popover dropdown for both modes).
 - `TypeaheadInput`: unique IDs per instance via `useId()` — fixes broken ARIA
   when multiple typeaheads render on the same page.
-- `TypeaheadInput`: debounce aligned to 250ms matching the frontend app.
-- `TypeaheadCellEditor` factory: `createTypeaheadCellEditor({ lookup, ... })`
-  for AG Grid column definitions.
-- Date-time tests: timezone-independent by using midday UTC timestamps.
 
 ## [4.7.0] - 2026-04-06
 

--- a/docs/plan-typeahead-input.md
+++ b/docs/plan-typeahead-input.md
@@ -1,0 +1,91 @@
+# Plan: Add TypeaheadInput molecule and wire into ItemCardEditor units fields
+
+## Context
+The `ItemCardEditor` currently uses plain `<Input>` for the units fields (minUnit, orderUnit). In the production frontend app, these are `UnitTypeahead` components — async typeaheads that search an API, show filtered results, and allow creating new units. We need a canary molecule that replicates this behavior standalone (no AG Grid dependency), then swap the units inputs in `ItemCardEditor`.
+
+## Reference implementations
+- **Vendored**: `vendored/arda-frontend/components/items/UnitTypeahead.tsx` — production implementation, tightly coupled to Arda API
+- **Callil's branch**: `canary/molecules/item-grid/typeahead-cell-editor.tsx` — clean implementation but coupled to AG Grid's `useGridCellEditor` hook
+
+## Approach: Build a standalone `TypeaheadInput` molecule
+
+Take the UI/behavior from Callil's `TypeaheadCellEditor` (debounced async search, keyboard nav, create option, loading/error states) but remove the AG Grid dependency so it works as a regular form input.
+
+### Phase 1: Create `TypeaheadInput` molecule
+**New file:** `src/components/canary/molecules/typeahead-input/typeahead-input.tsx`
+
+**Props interface:**
+```typescript
+interface TypeaheadOption {
+  label: string;
+  value: string;
+}
+
+interface TypeaheadInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  allowCreate?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+```
+
+**Behavior (matching vendored UnitTypeahead):**
+- Debounced search (150ms) on input change
+- Dropdown shows up to 8 results
+- "New: {typed value}" option when `allowCreate=true` and no exact match
+- Arrow Up/Down to navigate, Enter to select, Escape to close dropdown
+- AbortController for request cancellation
+- Loading spinner during fetch, error state with retry
+- Uses Arda design tokens (`bg-popover`, `border-input`, `text-muted-foreground`, etc.)
+- Renders as a Popover-style dropdown below the input (no AG Grid popup)
+
+**Reuse from existing codebase:**
+- `Input` primitive from `@/components/canary/primitives/input`
+- `Loader2`, `Plus`, `AlertCircle` icons from `lucide-react`
+- `cn()` utility for class merging
+
+### Phase 2: Create stories
+**New file:** `src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx`
+
+Stories:
+- **Default** — mock async lookup with unit options (each, case, box, pallet, pair, kg, lb, oz)
+- **AllowCreate** — same but with `allowCreate={true}`
+- **Loading** — slow lookup to show spinner
+- **PrePopulated** — starts with a value
+
+### Phase 3: Wire into ItemCardEditor
+**File:** `src/components/canary/organisms/item-card-editor/item-card-editor.tsx`
+
+- Add `unitLookup` prop to `ItemCardEditorInitProps` — the async lookup function
+- Replace the units `<Input>` fields (lines ~185-190) with `<TypeaheadInput>`
+- Pass `allowCreate={true}` so users can add custom units
+
+**Updated props:**
+```typescript
+interface ItemCardEditorInitProps {
+  imageConfig: ImageFieldConfig;
+  unitLookup: (search: string) => Promise<TypeaheadOption[]>;
+}
+```
+
+### Phase 4: Update stories with mock lookup
+**File:** `src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx`
+
+- Create a `mockUnitLookup` function that filters a static list (matching vendored mock data)
+- Pass it to `ItemCardEditor` in both stories
+
+## Files to create/modify
+1. **Create** `src/components/canary/molecules/typeahead-input/typeahead-input.tsx`
+2. **Create** `src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx`
+3. **Modify** `src/components/canary/organisms/item-card-editor/item-card-editor.tsx` — add `unitLookup` prop, swap Input → TypeaheadInput for unit fields
+4. **Modify** `src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx` — add mock lookup
+5. **Modify** `src/use-cases/reference/items/create-item/0010-set-image/during-creation-inline.stories.tsx` — add mock lookup
+
+## Verification
+1. Storybook: TypeaheadInput stories — type to search, select, create new, keyboard nav
+2. Storybook: ItemCardEditor stories — units fields show typeahead dropdown
+3. Type check: `npx tsc --noEmit`
+4. Tests: `npx vitest run src/components/canary/`

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.14'
+const PACKAGE_VERSION = '2.13.1'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/components/canary/__mocks__/handlers/unit-lookup.ts
+++ b/src/components/canary/__mocks__/handlers/unit-lookup.ts
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from 'msw';
+
+export const MOCK_UNITS = [
+  { eId: 'unit-001', name: 'each' },
+  { eId: 'unit-002', name: 'case' },
+  { eId: 'unit-003', name: 'box' },
+  { eId: 'unit-004', name: 'pallet' },
+  { eId: 'unit-005', name: 'pair' },
+  { eId: 'unit-006', name: 'kg' },
+  { eId: 'unit-007', name: 'lb' },
+  { eId: 'unit-008', name: 'oz' },
+  { eId: 'unit-009', name: 'liter' },
+  { eId: 'unit-010', name: 'gallon' },
+];
+
+export const unitLookupHandler = http.get('/api/arda/items/lookup-units', ({ request }) => {
+  const url = new URL(request.url);
+  const name = url.searchParams.get('name') || '';
+
+  const filtered = name
+    ? MOCK_UNITS.filter((u) => u.name.toLowerCase().includes(name.toLowerCase()))
+    : MOCK_UNITS;
+
+  return HttpResponse.json({ ok: true, status: 200, data: filtered });
+});

--- a/src/components/canary/__mocks__/unit-lookup.ts
+++ b/src/components/canary/__mocks__/unit-lookup.ts
@@ -1,0 +1,13 @@
+import type { TypeaheadOption } from '@/components/canary/molecules/typeahead-input/typeahead-input';
+
+/**
+ * Lookup function that calls the MSW-mocked unit endpoint.
+ * Matches the vendored `ardaClient.lookupUnits()` API shape.
+ */
+export async function lookupUnits(search: string): Promise<TypeaheadOption[]> {
+  const params = new URLSearchParams({ name: search });
+  const res = await fetch(`/api/arda/items/lookup-units?${params}`);
+  const json = await res.json();
+  const data: { eId: string; name: string }[] = json.data ?? [];
+  return data.map((d) => ({ label: d.name, value: d.name }));
+}

--- a/src/components/canary/molecules/typeahead-input/typeahead-cell-editor.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-cell-editor.tsx
@@ -1,0 +1,78 @@
+import { useState, useRef, useCallback } from 'react';
+import { useGridCellEditor } from 'ag-grid-react';
+
+import { TypeaheadInput, type TypeaheadOption } from './typeahead-input';
+
+// --- Types ---
+
+export interface TypeaheadCellEditorConfig {
+  /** Async lookup function for options. */
+  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  /** Allow creating new values not in the lookup results. */
+  allowCreate?: boolean;
+  /** Input placeholder text. */
+  placeholder?: string;
+}
+
+export interface TypeaheadCellEditorProps {
+  value: string | null;
+  onValueChange: (value: string | null) => void;
+  stopEditing: (cancel?: boolean) => void;
+}
+
+// --- Component ---
+
+function TypeaheadCellEditorInner({
+  value,
+  onValueChange,
+  config,
+}: Omit<TypeaheadCellEditorProps, 'stopEditing'> & { config: TypeaheadCellEditorConfig }) {
+  const [currentValue, setCurrentValue] = useState(value ?? '');
+  const wasCancelledRef = useRef(false);
+
+  useGridCellEditor({
+    isCancelAfterEnd: () => wasCancelledRef.current,
+  });
+
+  const handleValueChange = useCallback(
+    (val: string) => {
+      setCurrentValue(val);
+      onValueChange(val || null);
+    },
+    [onValueChange],
+  );
+
+  return (
+    <TypeaheadInput
+      value={currentValue}
+      onValueChange={handleValueChange}
+      lookup={config.lookup}
+      allowCreate={config.allowCreate ?? false}
+      placeholder={config.placeholder ?? 'Search\u2026'}
+      cellEditorMode
+      className="w-full"
+    />
+  );
+}
+
+// --- Factory ---
+
+/**
+ * Creates a TypeaheadCellEditor component configured for a specific entity.
+ *
+ * Usage:
+ * ```tsx
+ * const UnitCellEditor = createTypeaheadCellEditor({
+ *   lookup: lookupUnits,
+ *   allowCreate: true,
+ *   placeholder: 'Search units...',
+ * });
+ * ```
+ */
+export function createTypeaheadCellEditor(config: TypeaheadCellEditorConfig) {
+  function CellEditor(props: TypeaheadCellEditorProps) {
+    return <TypeaheadCellEditorInner {...props} config={config} />;
+  }
+  CellEditor.displayName = `TypeaheadCellEditor(${config.placeholder ?? 'Search'})`;
+  return CellEditor;
+}

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -1,7 +1,12 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AgGridReact } from 'ag-grid-react';
+import { ModuleRegistry, AllCommunityModule, type ColDef } from 'ag-grid-community';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
 
 import { TypeaheadInput } from './typeahead-input';
+import { createTypeaheadCellEditor } from './typeahead-cell-editor';
 import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
 import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
 
@@ -64,4 +69,70 @@ export const Disabled: StoryObj = {
   render: () => (
     <TypeaheadDemo lookup={lookupUnits} initialValue="kg" disabled placeholder="Select unit..." />
   ),
+};
+
+/** Cell editor mode — blur accepts typed value, dropdown portaled via Popover. */
+export const CellEditorMode: StoryObj = {
+  render: () => (
+    <div className="p-8">
+      <p className="text-sm text-muted-foreground mb-4">
+        Cell editor mode: blur accepts typed value instead of reverting. Dropdown is portaled.
+      </p>
+      <div className="w-64 overflow-hidden border border-border rounded-md p-2">
+        <TypeaheadDemo
+          lookup={lookupUnits}
+          allowCreate
+          cellEditorMode
+          placeholder="Search units (cell editor)..."
+        />
+      </div>
+    </div>
+  ),
+};
+
+/** Cell editor in an AG Grid — double-click the Unit column to edit. */
+export const InGrid: StoryObj = {
+  render: () => {
+    const UnitCellEditor = useMemo(
+      () =>
+        createTypeaheadCellEditor({
+          lookup: lookupUnits,
+          allowCreate: true,
+          placeholder: 'Search units...',
+        }),
+      [],
+    );
+
+    const [rowData] = useState([
+      { item: 'Hex Bolt M10x30', qty: 100, unit: 'each' },
+      { item: 'Flat Washer 3/8"', qty: 500, unit: 'box' },
+      { item: 'Spring Pin 4x20', qty: 50, unit: '' },
+    ]);
+
+    const columnDefs = useMemo<ColDef[]>(
+      () => [
+        { field: 'item', headerName: 'Item', flex: 2 },
+        { field: 'qty', headerName: 'Qty', width: 80 },
+        {
+          field: 'unit',
+          headerName: 'Unit',
+          flex: 1,
+          editable: true,
+          cellEditor: UnitCellEditor,
+        },
+      ],
+      [UnitCellEditor],
+    );
+
+    return (
+      <div className="p-8">
+        <p className="text-sm text-muted-foreground mb-4">
+          Double-click the <strong>Unit</strong> column to open the typeahead cell editor.
+        </p>
+        <div className="ag-theme-quartz w-[500px] h-[200px]">
+          <AgGridReact rowData={rowData} columnDefs={columnDefs} />
+        </div>
+      </div>
+    );
+  },
 };

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TypeaheadInput } from './typeahead-input';
+import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function TypeaheadDemo({
+  initialValue = '',
+  ...props
+}: Omit<React.ComponentProps<typeof TypeaheadInput>, 'value' | 'onChange'> & {
+  initialValue?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <div className="w-64 p-8">
+      <TypeaheadInput value={value} onChange={setValue} {...props} />
+      <p className="mt-2 text-xs text-muted-foreground">
+        Value: <code>{value || '(empty)'}</code>
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta = {
+  title: 'Components/Canary/Molecules/TypeaheadInput',
+  parameters: {
+    msw: { handlers: [unitLookupHandler] },
+  },
+};
+
+export default meta;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+export const Default: StoryObj = {
+  render: () => <TypeaheadDemo lookup={lookupUnits} placeholder="Select unit..." />,
+};
+
+export const AllowCreate: StoryObj = {
+  render: () => (
+    <TypeaheadDemo lookup={lookupUnits} allowCreate placeholder="Type or create unit..." />
+  ),
+};
+
+export const PrePopulated: StoryObj = {
+  render: () => (
+    <TypeaheadDemo lookup={lookupUnits} initialValue="each" placeholder="Select unit..." />
+  ),
+};
+
+export const Disabled: StoryObj = {
+  render: () => (
+    <TypeaheadDemo lookup={lookupUnits} initialValue="kg" disabled placeholder="Select unit..." />
+  ),
+};

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -12,14 +12,14 @@ import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-l
 function TypeaheadDemo({
   initialValue = '',
   ...props
-}: Omit<React.ComponentProps<typeof TypeaheadInput>, 'value' | 'onChange'> & {
+}: Omit<React.ComponentProps<typeof TypeaheadInput>, 'value' | 'onValueChange'> & {
   initialValue?: string;
 }) {
   const [value, setValue] = useState(initialValue);
 
   return (
     <div className="w-64 p-8">
-      <TypeaheadInput value={value} onChange={setValue} {...props} />
+      <TypeaheadInput value={value} onValueChange={setValue} {...props} />
       <p className="mt-2 text-xs text-muted-foreground">
         Value: <code>{value || '(empty)'}</code>
       </p>

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -3,6 +3,7 @@ import { Plus, Loader2, AlertCircle } from 'lucide-react';
 
 import { cn } from '@/types/canary/utilities/utils';
 import { Input } from '@/components/canary/primitives/input';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/canary/primitives/popover';
 
 // --- Types ---
 
@@ -26,10 +27,16 @@ export interface TypeaheadInputProps extends Omit<React.ComponentProps<'div'>, '
   'aria-label'?: string;
   /** Disable the input. */
   disabled?: boolean;
+  /**
+   * Cell editor mode — for use inside AG Grid or similar overflow-clipped containers.
+   * When true: blur accepts typed value (instead of reverting) and the dropdown
+   * is portaled via Radix Popover to escape overflow clipping.
+   */
+  cellEditorMode?: boolean;
 }
 
 const MAX_RESULTS = 8;
-const DEBOUNCE_MS = 150;
+const DEBOUNCE_MS = 250;
 const LISTBOX_ID = 'typeahead-listbox';
 
 // Hoisted static JSX — avoids recreation on every render
@@ -58,6 +65,7 @@ export function TypeaheadInput({
   placeholder = 'Search\u2026',
   'aria-label': ariaLabel,
   disabled = false,
+  cellEditorMode = false,
   className,
   ...rest
 }: TypeaheadInputProps) {
@@ -175,20 +183,29 @@ export function TypeaheadInput({
     doSearch(inputValueRef.current);
   }, [doSearch]);
 
-  // Close on outside click — deps narrowed to [open] via refs
+  // Close on outside click — deps narrowed to [open, cellEditorMode] via refs
   React.useEffect(() => {
     if (!open) return;
     const handleClickOutside = (e: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
         setOpen(false);
-        if (inputValueRef.current.trim() !== valueRef.current) {
-          setInputValue(valueRef.current);
+        if (cellEditorMode) {
+          // Cell editor: accept typed value on blur
+          const trimmed = inputValueRef.current.trim();
+          if (trimmed && trimmed !== valueRef.current) {
+            onValueChange(trimmed);
+          }
+        } else {
+          // Form mode: revert to confirmed value
+          if (inputValueRef.current.trim() !== valueRef.current) {
+            setInputValue(valueRef.current);
+          }
         }
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
+  }, [open, cellEditorMode, onValueChange]);
 
   // --- Keyboard — uses refs for stable callback ---
   const handleKeyDown = React.useCallback(
@@ -241,12 +258,14 @@ export function TypeaheadInput({
             selectOption(opts[hi] as TypeaheadOption);
           } else if (inputValueRef.current.trim() && allowCreate) {
             createValue(inputValueRef.current.trim());
+          } else if (cellEditorMode && inputValueRef.current.trim()) {
+            onValueChange(inputValueRef.current.trim());
           }
           setOpen(false);
           break;
       }
     },
-    [open, allowCreate, doSearch, selectOption, createValue],
+    [open, allowCreate, cellEditorMode, doSearch, selectOption, createValue, onValueChange],
   );
 
   // Scroll highlighted item into view
@@ -269,6 +288,95 @@ export function TypeaheadInput({
           ? 'No results'
           : '';
 
+  // --- Dropdown list content (shared between inline and portaled) ---
+  const dropdownList = (
+    <div ref={listRef} id={LISTBOX_ID} role="listbox">
+      {loading && loadingIndicator}
+
+      {error && (
+        <button
+          type="button"
+          className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
+          onClick={() => doSearch(inputValue)}
+        >
+          <AlertCircle className="w-4 h-4" aria-hidden="true" />
+          Failed to load. Click to retry.
+        </button>
+      )}
+
+      {!loading &&
+        !error &&
+        options.map((opt, i) => (
+          <div
+            key={opt.value}
+            id={`typeahead-opt-${i}`}
+            role="option"
+            aria-selected={i === highlightedIndex}
+            className={cn(
+              'px-3 py-2 text-sm cursor-pointer',
+              i === highlightedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',
+            )}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              selectOption(opt);
+            }}
+            onMouseEnter={() => setHighlightedIndex(i)}
+          >
+            {opt.label}
+          </div>
+        ))}
+
+      {!loading && !error && showCreate && (
+        <div
+          id={`typeahead-opt-${options.length}`}
+          role="option"
+          aria-selected={highlightedIndex === options.length}
+          className={cn(
+            'flex items-center gap-2 px-3 py-2 text-sm cursor-pointer text-primary',
+            highlightedIndex === options.length ? 'bg-accent text-primary' : 'hover:bg-accent/50',
+          )}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            createValue(trimmedInput);
+          }}
+          onMouseEnter={() => setHighlightedIndex(options.length)}
+        >
+          <Plus className="w-4 h-4" aria-hidden="true" />
+          {trimmedInput}
+        </div>
+      )}
+
+      {!loading && !error && options.length === 0 && !showCreate && noResults}
+    </div>
+  );
+
+  // --- Input element (shared) ---
+  const inputElement = (
+    <Input
+      ref={inputRef}
+      value={inputValue}
+      onChange={handleInputChange}
+      onFocus={handleFocus}
+      onKeyDownCapture={handleKeyDown}
+      placeholder={placeholder}
+      disabled={disabled}
+      role="combobox"
+      aria-expanded={showDropdown}
+      aria-haspopup="listbox"
+      aria-controls={showDropdown ? LISTBOX_ID : undefined}
+      aria-activedescendant={
+        highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
+      }
+      aria-label={ariaLabel ?? placeholder}
+      autoComplete="off"
+      className={
+        cellEditorMode
+          ? 'border-0 shadow-none bg-transparent focus-visible:ring-0 focus-visible:border-transparent h-full'
+          : undefined
+      }
+    />
+  );
+
   return (
     <div
       ref={wrapperRef}
@@ -277,6 +385,7 @@ export function TypeaheadInput({
       data-state={open ? 'open' : 'closed'}
       data-loading={loading || undefined}
       data-disabled={disabled || undefined}
+      data-cell-editor={cellEditorMode || undefined}
       {...rest}
     >
       {/* Live region for screen readers */}
@@ -284,99 +393,18 @@ export function TypeaheadInput({
         {statusMessage}
       </div>
 
-      <Input
-        ref={inputRef}
-        value={inputValue}
-        onChange={handleInputChange}
-        onFocus={handleFocus}
-        onKeyDownCapture={handleKeyDown}
-        placeholder={placeholder}
-        disabled={disabled}
-        role="combobox"
-        aria-expanded={showDropdown}
-        aria-haspopup="listbox"
-        aria-controls={showDropdown ? LISTBOX_ID : undefined}
-        aria-activedescendant={
-          highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
-        }
-        aria-label={ariaLabel ?? placeholder}
-        autoComplete="off"
-      />
-
-      {showDropdown && (
-        <div
-          ref={listRef}
-          id={LISTBOX_ID}
-          role="listbox"
-          className="absolute z-50 top-full left-0 right-0 mt-1 max-h-52 overflow-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md"
+      <Popover open={showDropdown}>
+        <PopoverAnchor asChild>{inputElement}</PopoverAnchor>
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="w-(--radix-popover-trigger-width) p-0 max-h-52 overflow-auto"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
         >
-          {/* Loading */}
-          {loading && loadingIndicator}
-
-          {/* Error */}
-          {error && (
-            <button
-              type="button"
-              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
-              onClick={() => doSearch(inputValue)}
-            >
-              <AlertCircle className="w-4 h-4" aria-hidden="true" />
-              Failed to load. Click to retry.
-            </button>
-          )}
-
-          {/* Options */}
-          {!loading &&
-            !error &&
-            options.map((opt, i) => (
-              <div
-                key={opt.value}
-                id={`typeahead-opt-${i}`}
-                role="option"
-                aria-selected={i === highlightedIndex}
-                className={cn(
-                  'px-3 py-2 text-sm cursor-pointer',
-                  i === highlightedIndex
-                    ? 'bg-accent text-accent-foreground'
-                    : 'hover:bg-accent/50',
-                )}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  selectOption(opt);
-                }}
-                onMouseEnter={() => setHighlightedIndex(i)}
-              >
-                {opt.label}
-              </div>
-            ))}
-
-          {/* Create new */}
-          {!loading && !error && showCreate && (
-            <div
-              id={`typeahead-opt-${options.length}`}
-              role="option"
-              aria-selected={highlightedIndex === options.length}
-              className={cn(
-                'flex items-center gap-2 px-3 py-2 text-sm cursor-pointer',
-                highlightedIndex === options.length
-                  ? 'bg-accent text-accent-foreground'
-                  : 'hover:bg-accent/50',
-              )}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                createValue(trimmedInput);
-              }}
-              onMouseEnter={() => setHighlightedIndex(options.length)}
-            >
-              <Plus className="w-4 h-4" aria-hidden="true" />
-              New: {trimmedInput}
-            </div>
-          )}
-
-          {/* Empty state */}
-          {!loading && !error && options.length === 0 && !showCreate && noResults}
-        </div>
-      )}
+          {dropdownList}
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -11,25 +11,36 @@ export interface TypeaheadOption {
   value: string;
 }
 
-export interface TypeaheadInputProps {
+export interface TypeaheadInputProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
   /** Current value. */
   value: string;
   /** Called when the user selects or creates a value. */
-  onChange: (value: string) => void;
+  onValueChange: (value: string) => void;
   /** Async lookup function — receives search text, returns matching options. */
   lookup: (search: string) => Promise<TypeaheadOption[]>;
   /** Allow creating new values not in the lookup results. */
   allowCreate?: boolean;
   /** Input placeholder text. */
   placeholder?: string;
+  /** Accessible label for the input. */
+  'aria-label'?: string;
   /** Disable the input. */
   disabled?: boolean;
-  /** Additional class names for the wrapper. */
-  className?: string;
 }
 
 const MAX_RESULTS = 8;
 const DEBOUNCE_MS = 150;
+const LISTBOX_ID = 'typeahead-listbox';
+
+// Hoisted static JSX — avoids recreation on every render
+const loadingIndicator = (
+  <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+    <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+    Searching&hellip;
+  </div>
+);
+
+const noResults = <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>;
 
 // --- Component ---
 
@@ -41,12 +52,14 @@ const DEBOUNCE_MS = 150;
  */
 export function TypeaheadInput({
   value,
-  onChange,
+  onValueChange,
   lookup,
   allowCreate = false,
   placeholder = 'Search\u2026',
+  'aria-label': ariaLabel,
   disabled = false,
   className,
+  ...rest
 }: TypeaheadInputProps) {
   const [inputValue, setInputValue] = React.useState(value);
   const [options, setOptions] = React.useState<TypeaheadOption[]>([]);
@@ -60,6 +73,16 @@ export function TypeaheadInput({
   const debounceRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const abortRef = React.useRef<AbortController>(undefined);
   const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  // Refs for values used in stable callbacks
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const inputValueRef = React.useRef(inputValue);
+  inputValueRef.current = inputValue;
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+  const highlightedRef = React.useRef(highlightedIndex);
+  highlightedRef.current = highlightedIndex;
 
   // Sync external value changes
   React.useEffect(() => {
@@ -112,11 +135,11 @@ export function TypeaheadInput({
   const selectOption = React.useCallback(
     (opt: TypeaheadOption) => {
       setInputValue(opt.value);
-      onChange(opt.value);
+      onValueChange(opt.value);
       setOpen(false);
       setOptions([]);
     },
-    [onChange],
+    [onValueChange],
   );
 
   const createValue = React.useCallback(
@@ -124,18 +147,17 @@ export function TypeaheadInput({
       const trimmed = val.trim();
       if (!trimmed) return;
       setInputValue(trimmed);
-      onChange(trimmed);
+      onValueChange(trimmed);
       setOpen(false);
       setOptions([]);
     },
-    [onChange],
+    [onValueChange],
   );
 
-  // --- Show "create" option? ---
+  // --- Derived state ---
   const trimmedInput = inputValue.trim();
   const exactMatch = options.some((o) => o.value.toLowerCase() === trimmedInput.toLowerCase());
   const showCreate = allowCreate && trimmedInput.length > 0 && !exactMatch;
-  const totalItems = options.length + (showCreate ? 1 : 0);
 
   // --- Input handlers ---
   const handleInputChange = React.useCallback(
@@ -150,86 +172,81 @@ export function TypeaheadInput({
 
   const handleFocus = React.useCallback(() => {
     setOpen(true);
-    doSearch(inputValue);
-  }, [doSearch, inputValue]);
+    doSearch(inputValueRef.current);
+  }, [doSearch]);
 
-  // Close on outside click
+  // Close on outside click — deps narrowed to [open] via refs
   React.useEffect(() => {
     if (!open) return;
     const handleClickOutside = (e: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
         setOpen(false);
-        // Revert to last confirmed value if input changed
-        if (inputValue.trim() !== value) {
-          setInputValue(value);
+        if (inputValueRef.current.trim() !== valueRef.current) {
+          setInputValue(valueRef.current);
         }
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open, inputValue, value]);
+  }, [open]);
 
-  // --- Keyboard ---
+  // --- Keyboard — uses refs for stable callback ---
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
       if (!open) {
         if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
           e.preventDefault();
           setOpen(true);
-          doSearch(inputValue);
+          doSearch(inputValueRef.current);
         }
         return;
       }
 
+      const opts = optionsRef.current;
+      const hi = highlightedRef.current;
+      const total =
+        opts.length +
+        (allowCreate &&
+        inputValueRef.current.trim().length > 0 &&
+        !opts.some((o) => o.value.toLowerCase() === inputValueRef.current.trim().toLowerCase())
+          ? 1
+          : 0);
+
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
-          setHighlightedIndex((prev) => (prev + 1) % totalItems);
+          setHighlightedIndex((prev) => (prev + 1) % total);
           break;
         case 'ArrowUp':
           e.preventDefault();
-          setHighlightedIndex((prev) => (prev - 1 + totalItems) % totalItems);
+          setHighlightedIndex((prev) => (prev - 1 + total) % total);
           break;
         case 'Enter':
           e.preventDefault();
-          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
-            selectOption(options[highlightedIndex] as TypeaheadOption);
-          } else if (showCreate && highlightedIndex === options.length) {
-            createValue(trimmedInput);
-          } else if (showCreate) {
-            createValue(trimmedInput);
+          if (hi >= 0 && hi < opts.length) {
+            selectOption(opts[hi] as TypeaheadOption);
+          } else if (hi === opts.length && total > opts.length) {
+            createValue(inputValueRef.current.trim());
+          } else if (total > opts.length) {
+            createValue(inputValueRef.current.trim());
           }
           break;
         case 'Escape':
           e.preventDefault();
           setOpen(false);
-          setInputValue(value);
+          setInputValue(valueRef.current);
           break;
         case 'Tab':
-          // Accept current selection or typed value on Tab
-          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
-            selectOption(options[highlightedIndex] as TypeaheadOption);
-          } else if (trimmedInput && allowCreate) {
-            createValue(trimmedInput);
+          if (hi >= 0 && hi < opts.length) {
+            selectOption(opts[hi] as TypeaheadOption);
+          } else if (inputValueRef.current.trim() && allowCreate) {
+            createValue(inputValueRef.current.trim());
           }
           setOpen(false);
           break;
       }
     },
-    [
-      open,
-      totalItems,
-      highlightedIndex,
-      options,
-      showCreate,
-      trimmedInput,
-      selectOption,
-      createValue,
-      value,
-      doSearch,
-      inputValue,
-      allowCreate,
-    ],
+    [open, allowCreate, doSearch, selectOption, createValue],
   );
 
   // Scroll highlighted item into view
@@ -241,8 +258,32 @@ export function TypeaheadInput({
 
   const showDropdown = open && (loading || error || options.length > 0 || showCreate);
 
+  // Live region announcement
+  const statusMessage = loading
+    ? 'Searching'
+    : error
+      ? 'Failed to load results'
+      : options.length > 0
+        ? `${options.length} result${options.length === 1 ? '' : 's'} available`
+        : open && trimmedInput
+          ? 'No results'
+          : '';
+
   return (
-    <div ref={wrapperRef} className={cn('relative', className)} data-slot="typeahead-input">
+    <div
+      ref={wrapperRef}
+      className={cn('relative', className)}
+      data-slot="typeahead-input"
+      data-state={open ? 'open' : 'closed'}
+      data-loading={loading || undefined}
+      data-disabled={disabled || undefined}
+      {...rest}
+    >
+      {/* Live region for screen readers */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {statusMessage}
+      </div>
+
       <Input
         ref={inputRef}
         value={inputValue}
@@ -254,25 +295,23 @@ export function TypeaheadInput({
         role="combobox"
         aria-expanded={showDropdown}
         aria-haspopup="listbox"
+        aria-controls={showDropdown ? LISTBOX_ID : undefined}
         aria-activedescendant={
           highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
         }
+        aria-label={ariaLabel ?? placeholder}
         autoComplete="off"
       />
 
       {showDropdown && (
         <div
           ref={listRef}
+          id={LISTBOX_ID}
           role="listbox"
           className="absolute z-50 top-full left-0 right-0 mt-1 max-h-52 overflow-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md"
         >
           {/* Loading */}
-          {loading && (
-            <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              Searching\u2026
-            </div>
-          )}
+          {loading && loadingIndicator}
 
           {/* Error */}
           {error && (
@@ -281,7 +320,7 @@ export function TypeaheadInput({
               className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
               onClick={() => doSearch(inputValue)}
             >
-              <AlertCircle className="w-4 h-4" />
+              <AlertCircle className="w-4 h-4" aria-hidden="true" />
               Failed to load. Click to retry.
             </button>
           )}
@@ -329,15 +368,13 @@ export function TypeaheadInput({
               }}
               onMouseEnter={() => setHighlightedIndex(options.length)}
             >
-              <Plus className="w-4 h-4" />
+              <Plus className="w-4 h-4" aria-hidden="true" />
               New: {trimmedInput}
             </div>
           )}
 
           {/* Empty state */}
-          {!loading && !error && options.length === 0 && !showCreate && (
-            <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>
-          )}
+          {!loading && !error && options.length === 0 && !showCreate && noResults}
         </div>
       )}
     </div>

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -1,0 +1,345 @@
+import * as React from 'react';
+import { Plus, Loader2, AlertCircle } from 'lucide-react';
+
+import { cn } from '@/types/canary/utilities/utils';
+import { Input } from '@/components/canary/primitives/input';
+
+// --- Types ---
+
+export interface TypeaheadOption {
+  label: string;
+  value: string;
+}
+
+export interface TypeaheadInputProps {
+  /** Current value. */
+  value: string;
+  /** Called when the user selects or creates a value. */
+  onChange: (value: string) => void;
+  /** Async lookup function — receives search text, returns matching options. */
+  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  /** Allow creating new values not in the lookup results. */
+  allowCreate?: boolean;
+  /** Input placeholder text. */
+  placeholder?: string;
+  /** Disable the input. */
+  disabled?: boolean;
+  /** Additional class names for the wrapper. */
+  className?: string;
+}
+
+const MAX_RESULTS = 8;
+const DEBOUNCE_MS = 150;
+
+// --- Component ---
+
+/**
+ * TypeaheadInput — async search input with filtered dropdown.
+ *
+ * Debounces search, shows up to 8 results, supports keyboard navigation
+ * and optional creation of new values. Standalone — no AG Grid dependency.
+ */
+export function TypeaheadInput({
+  value,
+  onChange,
+  lookup,
+  allowCreate = false,
+  placeholder = 'Search\u2026',
+  disabled = false,
+  className,
+}: TypeaheadInputProps) {
+  const [inputValue, setInputValue] = React.useState(value);
+  const [options, setOptions] = React.useState<TypeaheadOption[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortRef = React.useRef<AbortController>(undefined);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  // Sync external value changes
+  React.useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  // --- Search ---
+  const doSearch = React.useCallback(
+    async (search: string) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      setError(false);
+
+      try {
+        const results = await lookup(search);
+        if (controller.signal.aborted) return;
+        setOptions(results.slice(0, MAX_RESULTS));
+        setHighlightedIndex(-1);
+        setLoading(false);
+      } catch {
+        if (controller.signal.aborted) return;
+        setError(true);
+        setLoading(false);
+        setOptions([]);
+      }
+    },
+    [lookup],
+  );
+
+  const debouncedSearch = React.useCallback(
+    (search: string) => {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => doSearch(search), DEBOUNCE_MS);
+    },
+    [doSearch],
+  );
+
+  // Cleanup on unmount
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(debounceRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  // --- Selection ---
+  const selectOption = React.useCallback(
+    (opt: TypeaheadOption) => {
+      setInputValue(opt.value);
+      onChange(opt.value);
+      setOpen(false);
+      setOptions([]);
+    },
+    [onChange],
+  );
+
+  const createValue = React.useCallback(
+    (val: string) => {
+      const trimmed = val.trim();
+      if (!trimmed) return;
+      setInputValue(trimmed);
+      onChange(trimmed);
+      setOpen(false);
+      setOptions([]);
+    },
+    [onChange],
+  );
+
+  // --- Show "create" option? ---
+  const trimmedInput = inputValue.trim();
+  const exactMatch = options.some((o) => o.value.toLowerCase() === trimmedInput.toLowerCase());
+  const showCreate = allowCreate && trimmedInput.length > 0 && !exactMatch;
+  const totalItems = options.length + (showCreate ? 1 : 0);
+
+  // --- Input handlers ---
+  const handleInputChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value;
+      setInputValue(val);
+      setOpen(true);
+      debouncedSearch(val);
+    },
+    [debouncedSearch],
+  );
+
+  const handleFocus = React.useCallback(() => {
+    setOpen(true);
+    doSearch(inputValue);
+  }, [doSearch, inputValue]);
+
+  // Close on outside click
+  React.useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        // Revert to last confirmed value if input changed
+        if (inputValue.trim() !== value) {
+          setInputValue(value);
+        }
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open, inputValue, value]);
+
+  // --- Keyboard ---
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open) {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          setOpen(true);
+          doSearch(inputValue);
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev + 1) % totalItems);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev - 1 + totalItems) % totalItems);
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
+            selectOption(options[highlightedIndex] as TypeaheadOption);
+          } else if (showCreate && highlightedIndex === options.length) {
+            createValue(trimmedInput);
+          } else if (showCreate) {
+            createValue(trimmedInput);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setOpen(false);
+          setInputValue(value);
+          break;
+        case 'Tab':
+          // Accept current selection or typed value on Tab
+          if (highlightedIndex >= 0 && highlightedIndex < options.length) {
+            selectOption(options[highlightedIndex] as TypeaheadOption);
+          } else if (trimmedInput && allowCreate) {
+            createValue(trimmedInput);
+          }
+          setOpen(false);
+          break;
+      }
+    },
+    [
+      open,
+      totalItems,
+      highlightedIndex,
+      options,
+      showCreate,
+      trimmedInput,
+      selectOption,
+      createValue,
+      value,
+      doSearch,
+      inputValue,
+      allowCreate,
+    ],
+  );
+
+  // Scroll highlighted item into view
+  React.useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const showDropdown = open && (loading || error || options.length > 0 || showCreate);
+
+  return (
+    <div ref={wrapperRef} className={cn('relative', className)} data-slot="typeahead-input">
+      <Input
+        ref={inputRef}
+        value={inputValue}
+        onChange={handleInputChange}
+        onFocus={handleFocus}
+        onKeyDownCapture={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        role="combobox"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        aria-activedescendant={
+          highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
+        }
+        autoComplete="off"
+      />
+
+      {showDropdown && (
+        <div
+          ref={listRef}
+          role="listbox"
+          className="absolute z-50 top-full left-0 right-0 mt-1 max-h-52 overflow-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md"
+        >
+          {/* Loading */}
+          {loading && (
+            <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Searching\u2026
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <button
+              type="button"
+              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
+              onClick={() => doSearch(inputValue)}
+            >
+              <AlertCircle className="w-4 h-4" />
+              Failed to load. Click to retry.
+            </button>
+          )}
+
+          {/* Options */}
+          {!loading &&
+            !error &&
+            options.map((opt, i) => (
+              <div
+                key={opt.value}
+                id={`typeahead-opt-${i}`}
+                role="option"
+                aria-selected={i === highlightedIndex}
+                className={cn(
+                  'px-3 py-2 text-sm cursor-pointer',
+                  i === highlightedIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent/50',
+                )}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  selectOption(opt);
+                }}
+                onMouseEnter={() => setHighlightedIndex(i)}
+              >
+                {opt.label}
+              </div>
+            ))}
+
+          {/* Create new */}
+          {!loading && !error && showCreate && (
+            <div
+              id={`typeahead-opt-${options.length}`}
+              role="option"
+              aria-selected={highlightedIndex === options.length}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2 text-sm cursor-pointer',
+                highlightedIndex === options.length
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent/50',
+              )}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                createValue(trimmedInput);
+              }}
+              onMouseEnter={() => setHighlightedIndex(options.length)}
+            >
+              <Plus className="w-4 h-4" />
+              New: {trimmedInput}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!loading && !error && options.length === 0 && !showCreate && (
+            <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -37,7 +37,7 @@ export interface TypeaheadInputProps extends Omit<React.ComponentProps<'div'>, '
 
 const MAX_RESULTS = 8;
 const DEBOUNCE_MS = 250;
-const LISTBOX_ID = 'typeahead-listbox';
+// LISTBOX_ID generated per instance via useId() — see component body
 
 // Hoisted static JSX — avoids recreation on every render
 const loadingIndicator = (
@@ -75,6 +75,9 @@ export function TypeaheadInput({
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
   const [open, setOpen] = React.useState(false);
+  const instanceId = React.useId();
+  const listboxId = `typeahead-listbox-${instanceId}`;
+  const optionId = (index: number) => `typeahead-opt-${instanceId}-${index}`;
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
@@ -290,7 +293,7 @@ export function TypeaheadInput({
 
   // --- Dropdown list content (shared between inline and portaled) ---
   const dropdownList = (
-    <div ref={listRef} id={LISTBOX_ID} role="listbox">
+    <div ref={listRef} id={listboxId} role="listbox">
       {loading && loadingIndicator}
 
       {error && (
@@ -309,7 +312,7 @@ export function TypeaheadInput({
         options.map((opt, i) => (
           <div
             key={opt.value}
-            id={`typeahead-opt-${i}`}
+            id={optionId(i)}
             role="option"
             aria-selected={i === highlightedIndex}
             className={cn(
@@ -328,7 +331,7 @@ export function TypeaheadInput({
 
       {!loading && !error && showCreate && (
         <div
-          id={`typeahead-opt-${options.length}`}
+          id={optionId(options.length)}
           role="option"
           aria-selected={highlightedIndex === options.length}
           className={cn(
@@ -363,10 +366,8 @@ export function TypeaheadInput({
       role="combobox"
       aria-expanded={showDropdown}
       aria-haspopup="listbox"
-      aria-controls={showDropdown ? LISTBOX_ID : undefined}
-      aria-activedescendant={
-        highlightedIndex >= 0 ? `typeahead-opt-${highlightedIndex}` : undefined
-      }
+      aria-controls={showDropdown ? listboxId : undefined}
+      aria-activedescendant={highlightedIndex >= 0 ? optionId(highlightedIndex) : undefined}
       aria-label={ariaLabel ?? placeholder}
       autoComplete="off"
       className={

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ItemCardEditor, EMPTY_ITEM_CARD_FIELDS, type ItemCardFields } from './item-card-editor';
 import { ITEM_IMAGE_CONFIG, MOCK_ITEM_IMAGE } from '@/components/canary/__mocks__/image-story-data';
+import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
 
 // ---------------------------------------------------------------------------
 // Wrapper for controlled state
@@ -16,7 +18,12 @@ function ItemCardEditorDemo({ initialFields }: { initialFields?: Partial<ItemCar
 
   return (
     <div className="flex items-center justify-center p-4 sm:p-8 bg-muted/30 min-h-[600px]">
-      <ItemCardEditor imageConfig={ITEM_IMAGE_CONFIG} fields={fields} onChange={setFields} />
+      <ItemCardEditor
+        imageConfig={ITEM_IMAGE_CONFIG}
+        unitLookup={lookupUnits}
+        fields={fields}
+        onChange={setFields}
+      />
     </div>
   );
 }
@@ -27,7 +34,10 @@ function ItemCardEditorDemo({ initialFields }: { initialFields?: Partial<ItemCar
 
 const meta: Meta = {
   title: 'Components/Canary/Organisms/ItemCardEditor',
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: [unitLookupHandler] },
+  },
 };
 
 export default meta;

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -10,6 +10,10 @@ import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-up
 import { ArdaConfirmDialog } from '@/components/canary/atoms/confirm-dialog/confirm-dialog';
 import { Button } from '@/components/canary/primitives/button';
 import { Input } from '@/components/canary/primitives/input';
+import {
+  TypeaheadInput,
+  type TypeaheadOption,
+} from '@/components/canary/molecules/typeahead-input/typeahead-input';
 import type {
   ImageFieldConfig,
   ImageInput,
@@ -33,6 +37,8 @@ export interface ItemCardFields {
 export interface ItemCardEditorInitProps {
   /** Image field configuration (accepted formats, aspect ratio, etc.). */
   imageConfig: ImageFieldConfig;
+  /** Async lookup for unit typeahead fields. */
+  unitLookup: (search: string) => Promise<TypeaheadOption[]>;
 }
 
 /** Runtime props for ItemCardEditor. */
@@ -58,6 +64,7 @@ export type ItemCardEditorProps = ItemCardEditorInitProps & ItemCardEditorRuntim
  */
 export function ItemCardEditor({
   imageConfig,
+  unitLookup,
   fields,
   onChange,
   onImageConfirmed,
@@ -189,13 +196,15 @@ export function ItemCardEditor({
                   placeholder={section.qtyPlaceholder}
                   value={fields[section.qtyKey]}
                   onChange={(e) => updateField(section.qtyKey, e.target.value)}
-                  className="text-sm h-9 rounded-lg"
+                  className="text-sm h-9 rounded-lg w-[86px] flex-shrink-0"
                 />
-                <Input
-                  placeholder={section.unitPlaceholder}
+                <TypeaheadInput
                   value={fields[section.unitKey]}
-                  onChange={(e) => updateField(section.unitKey, e.target.value)}
-                  className="text-sm h-9 rounded-lg"
+                  onChange={(val) => updateField(section.unitKey, val)}
+                  lookup={unitLookup}
+                  allowCreate
+                  placeholder={section.unitPlaceholder}
+                  className="flex-1 min-w-0"
                 />
               </div>
             </div>

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -200,7 +200,7 @@ export function ItemCardEditor({
                 />
                 <TypeaheadInput
                   value={fields[section.unitKey]}
-                  onChange={(val) => updateField(section.unitKey, val)}
+                  onValueChange={(val) => updateField(section.unitKey, val)}
                   lookup={unitLookup}
                   allowCreate
                   placeholder={section.unitPlaceholder}

--- a/src/components/extras/atoms/form/date-time/date-time.test.tsx
+++ b/src/components/extras/atoms/form/date-time/date-time.test.tsx
@@ -19,7 +19,7 @@ describe('ArdaDateTimeFieldDisplay', () => {
   });
 
   it('formats ISO datetime', () => {
-    render(<ArdaDateTimeFieldDisplay value="2024-12-31T23:59" />);
+    render(<ArdaDateTimeFieldDisplay value="2024-12-31T12:00" timezone="Etc/UTC" />);
     expect(screen.getByText(/12\/31\/2024/)).toBeInTheDocument();
   });
 

--- a/src/components/extras/atoms/grid/date-time/date-time.test.tsx
+++ b/src/components/extras/atoms/grid/date-time/date-time.test.tsx
@@ -25,7 +25,7 @@ describe('ArdaDateTimeCellDisplay', () => {
   });
 
   it('formats ISO datetime', () => {
-    render(<ArdaDateTimeCellDisplay value="2024-12-31T23:59" />);
+    render(<ArdaDateTimeCellDisplay value="2024-12-31T12:00" timezone="Etc/UTC" />);
     expect(screen.getByText(/12\/31\/2024/)).toBeInTheDocument();
   });
 

--- a/src/use-cases/reference/items/create-item/0010-set-image/during-creation-inline.stories.tsx
+++ b/src/use-cases/reference/items/create-item/0010-set-image/during-creation-inline.stories.tsx
@@ -17,6 +17,8 @@ import {
   type ItemCardFields,
 } from '@/components/canary/organisms/item-card-editor/item-card-editor';
 import { ITEM_IMAGE_CONFIG } from '@/components/canary/__mocks__/image-story-data';
+import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
 
 // ---------------------------------------------------------------------------
 // Live page wrapper
@@ -35,7 +37,12 @@ function InlineCardCreationPage() {
           Fill in the card fields directly. Drop or select an image in the card&rsquo;s image area.
         </p>
       </div>
-      <ItemCardEditor imageConfig={ITEM_IMAGE_CONFIG} fields={fields} onChange={setFields} />
+      <ItemCardEditor
+        imageConfig={ITEM_IMAGE_CONFIG}
+        unitLookup={lookupUnits}
+        fields={fields}
+        onChange={setFields}
+      />
     </div>
   );
 }
@@ -162,6 +169,7 @@ const meta: Meta = {
     'Use Cases/Reference/Items/ITM-0003 Create Item/0010 Set Image/During Creation \u2013 Inline on Card',
   parameters: {
     layout: 'fullscreen',
+    msw: { handlers: [unitLookupHandler] },
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `cellEditorMode` prop to `TypeaheadInput` — borderless inline input for AG Grid, blur accepts typed value
- Popover dropdown for both modes (portaled via Radix, escapes overflow clipping)
- `createTypeaheadCellEditor` factory for AG Grid column definitions
- Unique IDs per instance via `useId()` — fixes ARIA when multiple typeaheads on same page
- Debounce aligned to 250ms matching the frontend app
- Orange plus icon for create-new option
- Fix timezone-dependent date-time tests (pre-existing)

## Test plan
- [ ] TypeaheadInput stories: form mode unchanged, cell editor mode blur-accepts
- [ ] In Grid story: double-click Unit column, typeahead works inline
- [ ] ItemCardEditor: both unit fields work side by side (unique IDs)
- [ ] `make ci` — all 1212 tests pass
- [ ] `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)