### PR TITLE
Add standalone ColorPicker atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.7.3] - 2026-04-08
+
+### Added
+
+- `ColorPicker` atom: standalone swatch button with popover palette, arrow-key
+  navigation, 44px touch targets, responsive wrapping for mobile.
+
+### Deprecated
+
+- `ColorSwatchPicker` — use `ColorPicker` instead. The old component coupled
+  the swatch button with a color bar.
+
 ## [4.7.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [4.7.3] - 2026-04-08
+## [4.8.0] - 2026-04-08
 
 ### Added
 

--- a/src/components/canary/atoms/color-picker/color-picker.stories.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.stories.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ColorPicker } from './color-picker';
+
+function ColorPickerDemo({ initialValue = 'GRAY' }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <div className="p-8 flex flex-col gap-4">
+      <ColorPicker value={value} onValueChange={setValue} />
+      <p className="text-xs text-muted-foreground">
+        Selected: <code>{value}</code>
+      </p>
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: 'Components/Canary/Atoms/ColorPicker',
+};
+
+export default meta;
+
+export const Default: StoryObj = {
+  render: () => <ColorPickerDemo />,
+};
+
+export const PreSelected: StoryObj = {
+  render: () => <ColorPickerDemo initialValue="BLUE" />,
+};
+
+export const Disabled: StoryObj = {
+  render: () => (
+    <div className="p-8">
+      <ColorPicker value="RED" onValueChange={() => {}} disabled />
+    </div>
+  ),
+};

--- a/src/components/canary/atoms/color-picker/color-picker.test.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+import { ColorPicker, getColorHex } from './color-picker';
+
+const SMALL_MAP = {
+  RED: { hex: '#EF4444', name: 'Red' },
+  GREEN: { hex: '#22C55E', name: 'Green' },
+  BLUE: { hex: '#3B82F6', name: 'Blue' },
+};
+
+function renderPicker(
+  overrides: Partial<{
+    value: string;
+    onValueChange: ReturnType<typeof vi.fn>;
+    disabled: boolean;
+    colors: Record<string, { hex: string; name: string }>;
+  }> = {},
+) {
+  const onValueChange = overrides.onValueChange ?? vi.fn();
+  const result = render(
+    <ColorPicker
+      value={overrides.value ?? 'RED'}
+      onValueChange={onValueChange}
+      disabled={overrides.disabled ?? false}
+      colors={overrides.colors ?? SMALL_MAP}
+    />,
+  );
+  return { ...result, onValueChange };
+}
+
+describe('ColorPicker', () => {
+  it('renders trigger button with correct aria-label', () => {
+    renderPicker({ value: 'RED' });
+    expect(screen.getByRole('button', { name: /Color: Red/i })).toBeInTheDocument();
+  });
+
+  it('renders data-slot attribute', () => {
+    renderPicker();
+    expect(document.querySelector('[data-slot="color-picker"]')).toBeInTheDocument();
+  });
+
+  it('starts closed', () => {
+    renderPicker();
+    expect(document.querySelector('[data-slot="color-picker"]')).toHaveAttribute(
+      'data-state',
+      'closed',
+    );
+  });
+
+  it('opens palette on trigger click', async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(screen.getByRole('button', { name: /Color: Red/i }));
+    expect(screen.getByRole('radiogroup', { name: /Color palette/i })).toBeInTheDocument();
+  });
+
+  it('renders all color options in palette', async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(screen.getByRole('button', { name: /Color: Red/i }));
+    expect(screen.getByRole('radio', { name: 'Red' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Green' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Blue' })).toBeInTheDocument();
+  });
+
+  it('marks selected color with aria-checked', async () => {
+    const user = userEvent.setup();
+    renderPicker({ value: 'GREEN' });
+    await user.click(screen.getByRole('button', { name: /Color: Green/i }));
+    expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls onValueChange when a color is selected', async () => {
+    const user = userEvent.setup();
+    const { onValueChange } = renderPicker({ value: 'RED' });
+    await user.click(screen.getByRole('button', { name: /Color: Red/i }));
+    await user.click(screen.getByRole('radio', { name: 'Blue' }));
+    expect(onValueChange).toHaveBeenCalledWith('BLUE');
+  });
+
+  it('does not open when disabled', async () => {
+    const user = userEvent.setup();
+    renderPicker({ disabled: true });
+    await user.click(screen.getByRole('button', { name: /Color: Red/i }));
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+  });
+
+  it('sets data-disabled when disabled', () => {
+    renderPicker({ disabled: true });
+    expect(document.querySelector('[data-slot="color-picker"]')).toHaveAttribute('data-disabled');
+  });
+
+  it('navigates with arrow keys', async () => {
+    const user = userEvent.setup();
+    const { onValueChange } = renderPicker({ value: 'RED' });
+
+    // Open palette
+    await user.click(screen.getByRole('button', { name: /Color: Red/i }));
+
+    // Wait for focus to settle
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    // ArrowRight moves to next color
+    await user.keyboard('{ArrowRight}');
+    // Enter selects it
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith('GREEN');
+  });
+
+  it('wraps around with arrow keys', async () => {
+    const user = userEvent.setup();
+    const { onValueChange } = renderPicker({ value: 'BLUE' });
+
+    await user.click(screen.getByRole('button', { name: /Color: Blue/i }));
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    // ArrowRight from last item wraps to first
+    await user.keyboard('{ArrowRight}');
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith('RED');
+  });
+
+  it('selects with Space key', async () => {
+    const user = userEvent.setup();
+    const { onValueChange } = renderPicker({ value: 'RED' });
+
+    await user.click(screen.getByRole('button', { name: /Color: Red/i }));
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    await user.keyboard('{ }');
+    expect(onValueChange).toHaveBeenCalledWith('RED');
+  });
+});
+
+describe('getColorHex', () => {
+  it('returns hex for known color', () => {
+    expect(getColorHex('RED', SMALL_MAP)).toBe('#EF4444');
+  });
+
+  it('returns fallback for unknown color', () => {
+    expect(getColorHex('UNKNOWN', SMALL_MAP)).toBe('#6B7280');
+  });
+});

--- a/src/components/canary/atoms/color-picker/color-picker.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import { cn } from '@/types/canary/utilities/utils';
+import { DEFAULT_COLOR_MAP } from '@/components/canary/atoms/grid/color/color-cell-display';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/canary/primitives/popover';
+
+// --- Types ---
+
+export interface ColorPickerProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
+  /** Selected color key (e.g. "GRAY"). */
+  value: string;
+  /** Called when a color is selected. */
+  onValueChange: (color: string) => void;
+  /** Custom color map. Defaults to the standard 10-color palette. */
+  colors?: Record<string, { hex: string; name: string }>;
+  /** Disable the picker. */
+  disabled?: boolean;
+}
+
+// --- Component ---
+
+/**
+ * ColorPicker — compact color selector with a popover palette.
+ *
+ * Shows a small swatch button. Clicking opens a popover with the full palette.
+ */
+export function ColorPicker({
+  value,
+  onValueChange,
+  colors = DEFAULT_COLOR_MAP,
+  disabled = false,
+  className,
+  ...rest
+}: ColorPickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const selectedHex = colors[value]?.hex ?? colors.GRAY?.hex ?? '#6B7280';
+  const colorEntries = Object.entries(colors);
+
+  const handleSelect = (key: string) => {
+    onValueChange(key);
+    setOpen(false);
+  };
+
+  return (
+    <div
+      data-slot="color-picker"
+      data-state={open ? 'open' : 'closed'}
+      data-disabled={disabled || undefined}
+      className={cn(className)}
+      {...rest}
+    >
+      <Popover open={open} onOpenChange={disabled ? () => {} : setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={disabled}
+            className="flex-shrink-0 cursor-pointer rounded-lg border border-input bg-background p-[7px] shadow-xs focus-ring disabled:opacity-50 disabled:pointer-events-none"
+            aria-label={`Color: ${colors[value]?.name ?? value}. Click to change.`}
+          >
+            <div
+              className="size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)]"
+              style={{ backgroundColor: selectedHex }}
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="flex gap-1.5 items-center w-auto p-[7px] rounded-lg"
+        >
+          {colorEntries.map(([key, { hex, name }]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => handleSelect(key)}
+              className={cn(
+                'size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] cursor-pointer',
+                key === value && 'ring-2 ring-ring ring-offset-1',
+              )}
+              style={{ backgroundColor: hex }}
+              aria-label={name}
+              aria-pressed={key === value}
+            />
+          ))}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+/** Lookup a color hex by key. */
+export function getColorHex(key: string, colors = DEFAULT_COLOR_MAP): string {
+  return colors[key]?.hex ?? '#6B7280';
+}

--- a/src/components/canary/atoms/color-picker/color-picker.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.tsx
@@ -56,7 +56,7 @@ export function ColorPicker({
       const target = buttons?.[selectedIdx >= 0 ? selectedIdx : 0];
       target?.focus();
     });
-  }, [open, colorEntries, value]);
+  }, [open]);
 
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
@@ -127,14 +127,14 @@ export function ColorPicker({
         <PopoverContent
           align="start"
           sideOffset={-44}
-          className="w-auto max-w-[calc(100vw-2rem)] p-3 rounded-lg"
+          className="w-auto max-w-[calc(100vw-2rem)] p-0 rounded-lg"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div
             ref={paletteRef}
             role="radiogroup"
             aria-label="Color palette"
-            className="flex flex-wrap gap-0 items-center justify-center"
+            className="flex flex-wrap items-center"
             onKeyDown={handleKeyDown}
           >
             {colorEntries.map(([key, { hex, name }], i) => (
@@ -146,14 +146,14 @@ export function ColorPicker({
                 aria-label={name}
                 tabIndex={i === focusedIndex ? 0 : -1}
                 onClick={() => handleSelect(key)}
+                onKeyDown={handleKeyDown}
                 className={cn(
-                  'min-h-11 min-w-11 flex items-center justify-center rounded-md cursor-pointer',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-                  key === value && 'ring-2 ring-ring ring-offset-1',
+                  'min-h-11 min-w-11 flex items-center justify-center rounded-md cursor-pointer outline-none',
+                  i === focusedIndex && 'ring-2 ring-ring ring-offset-1',
                 )}
               >
                 <span
-                  className="size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)]"
+                  className="size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] pointer-events-none"
                   style={{ backgroundColor: hex }}
                 />
               </button>

--- a/src/components/canary/atoms/color-picker/color-picker.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.tsx
@@ -23,6 +23,7 @@ export interface ColorPickerProps extends Omit<React.ComponentProps<'div'>, 'onC
  * ColorPicker — compact color selector with a popover palette.
  *
  * Shows a small swatch button. Clicking opens a popover with the full palette.
+ * Palette supports arrow-key navigation between swatches.
  */
 export function ColorPicker({
   value,
@@ -33,6 +34,8 @@ export function ColorPicker({
   ...rest
 }: ColorPickerProps) {
   const [open, setOpen] = React.useState(false);
+  const [focusedIndex, setFocusedIndex] = React.useState(-1);
+  const paletteRef = React.useRef<HTMLDivElement>(null);
 
   const selectedHex = colors[value]?.hex ?? colors.GRAY?.hex ?? '#6B7280';
   const colorEntries = Object.entries(colors);
@@ -41,6 +44,63 @@ export function ColorPicker({
     onValueChange(key);
     setOpen(false);
   };
+
+  // Focus the selected swatch when palette opens
+  React.useEffect(() => {
+    if (!open) return;
+    const selectedIdx = colorEntries.findIndex(([key]) => key === value);
+    setFocusedIndex(selectedIdx >= 0 ? selectedIdx : 0);
+    // Focus after popover renders
+    requestAnimationFrame(() => {
+      const buttons = paletteRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+      const target = buttons?.[selectedIdx >= 0 ? selectedIdx : 0];
+      target?.focus();
+    });
+  }, [open]);
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      const len = colorEntries.length;
+      let next = focusedIndex;
+
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          e.preventDefault();
+          next = (focusedIndex + 1) % len;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          e.preventDefault();
+          next = (focusedIndex - 1 + len) % len;
+          break;
+        case 'Home':
+          e.preventDefault();
+          next = 0;
+          break;
+        case 'End':
+          e.preventDefault();
+          next = len - 1;
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          if (focusedIndex >= 0 && focusedIndex < len) {
+            handleSelect(
+              (colorEntries[focusedIndex] as [string, { hex: string; name: string }])[0],
+            );
+          }
+          return;
+        default:
+          return;
+      }
+
+      setFocusedIndex(next);
+      const buttons = paletteRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+      buttons?.[next]?.focus();
+    },
+    [focusedIndex, colorEntries, handleSelect],
+  );
 
   return (
     <div
@@ -55,7 +115,7 @@ export function ColorPicker({
           <button
             type="button"
             disabled={disabled}
-            className="flex-shrink-0 cursor-pointer rounded-lg border border-input bg-background p-[7px] shadow-xs focus-ring disabled:opacity-50 disabled:pointer-events-none"
+            className="relative flex-shrink-0 cursor-pointer rounded-lg border border-input bg-background p-[7px] shadow-xs focus-ring disabled:opacity-50 disabled:pointer-events-none min-h-11 min-w-11 flex items-center justify-center"
             aria-label={`Color: ${colors[value]?.name ?? value}. Click to change.`}
           >
             <div
@@ -66,23 +126,36 @@ export function ColorPicker({
         </PopoverTrigger>
         <PopoverContent
           align="start"
-          sideOffset={4}
+          sideOffset={-44}
           className="flex gap-1.5 items-center w-auto p-[7px] rounded-lg"
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
-          {colorEntries.map(([key, { hex, name }]) => (
-            <button
-              key={key}
-              type="button"
-              onClick={() => handleSelect(key)}
-              className={cn(
-                'size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] cursor-pointer',
-                key === value && 'ring-2 ring-ring ring-offset-1',
-              )}
-              style={{ backgroundColor: hex }}
-              aria-label={name}
-              aria-pressed={key === value}
-            />
-          ))}
+          <div
+            ref={paletteRef}
+            role="radiogroup"
+            aria-label="Color palette"
+            className="flex gap-1.5 items-center"
+            onKeyDown={handleKeyDown}
+          >
+            {colorEntries.map(([key, { hex, name }], i) => (
+              <button
+                key={key}
+                type="button"
+                role="radio"
+                aria-checked={key === value}
+                aria-label={name}
+                tabIndex={i === focusedIndex ? 0 : -1}
+                onClick={() => handleSelect(key)}
+                className={cn(
+                  'relative size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] cursor-pointer',
+                  'before:absolute before:inset-[-4px] before:rounded-md',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                  key === value && 'ring-2 ring-ring ring-offset-1',
+                )}
+                style={{ backgroundColor: hex }}
+              />
+            ))}
+          </div>
         </PopoverContent>
       </Popover>
     </div>

--- a/src/components/canary/atoms/color-picker/color-picker.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.tsx
@@ -127,7 +127,7 @@ export function ColorPicker({
         <PopoverContent
           align="start"
           sideOffset={-44}
-          className="flex gap-1.5 items-center w-auto p-[7px] rounded-lg"
+          className="flex gap-1.5 items-center w-auto p-3 rounded-lg"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div
@@ -148,7 +148,7 @@ export function ColorPicker({
                 onClick={() => handleSelect(key)}
                 className={cn(
                   'relative size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] cursor-pointer',
-                  'before:absolute before:inset-[-4px] before:rounded-md',
+                  'before:absolute before:inset-[-11px] before:rounded-md',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
                   key === value && 'ring-2 ring-ring ring-offset-1',
                 )}

--- a/src/components/canary/atoms/color-picker/color-picker.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.tsx
@@ -56,7 +56,7 @@ export function ColorPicker({
       const target = buttons?.[selectedIdx >= 0 ? selectedIdx : 0];
       target?.focus();
     });
-  }, [open]);
+  }, [open, colorEntries, value]);
 
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
@@ -134,7 +134,7 @@ export function ColorPicker({
             ref={paletteRef}
             role="radiogroup"
             aria-label="Color palette"
-            className="flex flex-wrap gap-3 items-center justify-center"
+            className="flex flex-wrap gap-0 items-center justify-center"
             onKeyDown={handleKeyDown}
           >
             {colorEntries.map(([key, { hex, name }], i) => (
@@ -147,13 +147,16 @@ export function ColorPicker({
                 tabIndex={i === focusedIndex ? 0 : -1}
                 onClick={() => handleSelect(key)}
                 className={cn(
-                  'relative size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)] cursor-pointer',
-                  'before:absolute before:inset-[-11px] before:rounded-md',
+                  'min-h-11 min-w-11 flex items-center justify-center rounded-md cursor-pointer',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
                   key === value && 'ring-2 ring-ring ring-offset-1',
                 )}
-                style={{ backgroundColor: hex }}
-              />
+              >
+                <span
+                  className="size-[22px] rounded-sm shadow-[0.5px_0.5px_1.5px_0.5px_rgba(0,0,0,0.12)]"
+                  style={{ backgroundColor: hex }}
+                />
+              </button>
             ))}
           </div>
         </PopoverContent>

--- a/src/components/canary/atoms/color-picker/color-picker.tsx
+++ b/src/components/canary/atoms/color-picker/color-picker.tsx
@@ -127,14 +127,14 @@ export function ColorPicker({
         <PopoverContent
           align="start"
           sideOffset={-44}
-          className="flex gap-1.5 items-center w-auto p-3 rounded-lg"
+          className="w-auto max-w-[calc(100vw-2rem)] p-3 rounded-lg"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div
             ref={paletteRef}
             role="radiogroup"
             aria-label="Color palette"
-            className="flex gap-1.5 items-center"
+            className="flex flex-wrap gap-3 items-center justify-center"
             onKeyDown={handleKeyDown}
           >
             {colorEntries.map(([key, { hex, name }], i) => (

--- a/src/components/canary/atoms/color-swatch-picker/color-swatch-picker.tsx
+++ b/src/components/canary/atoms/color-swatch-picker/color-swatch-picker.tsx
@@ -17,6 +17,10 @@ export interface ColorSwatchPickerProps {
 // --- Component ---
 
 /**
+ * @deprecated Use `ColorPicker` from `canary/atoms/color-picker` instead.
+ * This component couples the swatch button with a color bar. The new
+ * `ColorPicker` is just the swatch button — compose the bar separately.
+ *
  * ColorSwatchPicker — compact color selector with a popover palette.
  *
  * Default state shows a small swatch + accent bar. Clicking opens a popover

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { PackageMinus, Package, Crop, Trash2 } from 'lucide-react';
 
-import {
-  ColorSwatchPicker,
-  getSwatchHex,
-} from '@/components/canary/atoms/color-swatch-picker/color-swatch-picker';
+import { ColorPicker, getColorHex } from '@/components/canary/atoms/color-picker/color-picker';
 import { ImageDropZone } from '@/components/canary/molecules/image-drop-zone/image-drop-zone';
 import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog';
 import { ArdaConfirmDialog } from '@/components/canary/atoms/confirm-dialog/confirm-dialog';
@@ -171,7 +168,7 @@ export function ItemCardEditor({
         {/* Accent Divider */}
         <div
           className="w-full h-1 transition-colors"
-          style={{ backgroundColor: getSwatchHex(fields.accentColor) }}
+          style={{ backgroundColor: getColorHex(fields.accentColor) }}
         />
 
         {/* Attribute Blocks — editable inputs */}
@@ -246,10 +243,16 @@ export function ItemCardEditor({
         </div>
 
         {/* Color Swatch Picker + accent bar */}
-        <ColorSwatchPicker
-          value={fields.accentColor}
-          onChange={(color) => updateField('accentColor', color)}
-        />
+        <div className="flex items-center gap-2 w-full">
+          <ColorPicker
+            value={fields.accentColor}
+            onValueChange={(color) => updateField('accentColor', color)}
+          />
+          <div
+            className="flex-1 h-[10px] transition-colors"
+            style={{ backgroundColor: getColorHex(fields.accentColor) }}
+          />
+        </div>
 
         {/* Footer Branding */}
         <div className="text-center pb-1">

--- a/src/components/extras/atoms/form/date-time/date-time.test.tsx
+++ b/src/components/extras/atoms/form/date-time/date-time.test.tsx
@@ -19,7 +19,7 @@ describe('ArdaDateTimeFieldDisplay', () => {
   });
 
   it('formats ISO datetime', () => {
-    render(<ArdaDateTimeFieldDisplay value="2024-12-31T23:59" />);
+    render(<ArdaDateTimeFieldDisplay value="2024-12-31T12:00" timezone="Etc/UTC" />);
     expect(screen.getByText(/12\/31\/2024/)).toBeInTheDocument();
   });
 

--- a/src/components/extras/atoms/grid/date-time/date-time.test.tsx
+++ b/src/components/extras/atoms/grid/date-time/date-time.test.tsx
@@ -25,7 +25,7 @@ describe('ArdaDateTimeCellDisplay', () => {
   });
 
   it('formats ISO datetime', () => {
-    render(<ArdaDateTimeCellDisplay value="2024-12-31T23:59" />);
+    render(<ArdaDateTimeCellDisplay value="2024-12-31T12:00" timezone="Etc/UTC" />);
     expect(screen.getByText(/12\/31\/2024/)).toBeInTheDocument();
   });
 

--- a/src/docs/workflows/using-the-design-system.mdx
+++ b/src/docs/workflows/using-the-design-system.mdx
@@ -466,7 +466,7 @@ The design system enforces a **display-only cursor policy** via a global CSS rul
 
 {/* AUTO-GENERATED:START — do not edit manually. Run: node tools/update-package-contents.js */}
 
-## Current Content as of 2026-03-25
+## Current Content as of 2026-04-08
 
 ### Components (JS/TS)
 
@@ -507,7 +507,7 @@ Each entry point ships as ESM (`.js`), CJS (`.cjs`), and TypeScript declarations
     </tr>
     <tr>
       <td>Atoms</td>
-      <td><code>Badge</code>, <code>ArdaBadge</code>, <code>Button</code>, <code>ArdaButton</code>, <code>buttonVariants</code>, <code>Drawer</code>, <code>DrawerHeader</code>, <code>DrawerTitle</code>, <code>DrawerDescription</code>, <code>DrawerBody</code>, <code>DrawerFooter</code>, <code>ArdaDrawer</code>, <code>ArdaDrawerHeader</code>, <code>ArdaDrawerTitle</code>, <code>ArdaDrawerDescription</code>, <code>ArdaDrawerBody</code>, <code>ArdaDrawerFooter</code>, <code>IconButton</code>, <code>ArdaIconButton</code>, <code>BrandLogo</code>, <code>BrandIcon</code>, <code>IconLabel</code>, <code>ReadOnlyField</code>, <code>readOnlyFieldVariants</code>, <code>TextCellDisplay</code>, <code>TextCellEditor</code>, <code>createTextCellEditor</code>, <code>NumberCellDisplay</code>, <code>NumberCellEditor</code>, <code>createNumberCellEditor</code>, <code>BooleanCellDisplay</code>, <code>BooleanCellEditor</code>, <code>createBooleanCellEditor</code>, <code>DateCellDisplay</code>, <code>DateCellEditor</code>, <code>createDateCellEditor</code>, <code>SelectCellDisplay</code>, <code>SelectCellEditor</code>, <code>createSelectCellEditor</code>, <code>MemoCellDisplay</code>, <code>MemoCellEditor</code>, <code>createMemoCellEditor</code>, <code>MemoButtonCell</code>, <code>createMemoButtonCellEditor</code>, <code>ColorCellDisplay</code>, <code>ColorCellEditor</code>, <code>createColorCellEditor</code>, <code>DEFAULT_COLOR_MAP</code>, <code>ImageCellDisplay</code>, <code>ImageCellEditor</code>, <code>createImageCellEditor</code>, <code>CopyrightAcknowledgment</code>, <code>ActionCellRenderer</code></td>
+      <td><code>Badge</code>, <code>ArdaBadge</code>, <code>Button</code>, <code>ArdaButton</code>, <code>buttonVariants</code>, <code>Drawer</code>, <code>DrawerHeader</code>, <code>DrawerTitle</code>, <code>DrawerDescription</code>, <code>DrawerBody</code>, <code>DrawerFooter</code>, <code>ArdaDrawer</code>, <code>ArdaDrawerHeader</code>, <code>ArdaDrawerTitle</code>, <code>ArdaDrawerDescription</code>, <code>ArdaDrawerBody</code>, <code>ArdaDrawerFooter</code>, <code>IconButton</code>, <code>ArdaIconButton</code>, <code>BrandLogo</code>, <code>BrandIcon</code>, <code>IconLabel</code>, <code>ReadOnlyField</code>, <code>readOnlyFieldVariants</code>, <code>TextCellDisplay</code>, <code>TextCellEditor</code>, <code>createTextCellEditor</code>, <code>NumberCellDisplay</code>, <code>NumberCellEditor</code>, <code>createNumberCellEditor</code>, <code>BooleanCellDisplay</code>, <code>BooleanCellEditor</code>, <code>createBooleanCellEditor</code>, <code>DateCellDisplay</code>, <code>DateCellEditor</code>, <code>createDateCellEditor</code>, <code>SelectCellDisplay</code>, <code>SelectCellEditor</code>, <code>createSelectCellEditor</code>, <code>MemoCellDisplay</code>, <code>MemoCellEditor</code>, <code>createMemoCellEditor</code>, <code>MemoButtonCell</code>, <code>createMemoButtonCellEditor</code>, <code>ColorCellDisplay</code>, <code>ColorCellEditor</code>, <code>createColorCellEditor</code>, <code>DEFAULT_COLOR_MAP</code>, <code>ImageCellDisplay</code>, <code>ImageCellEditor</code>, <code>createImageCellEditor</code>, <code>CopyrightAcknowledgment</code>, <code>ColorPicker</code>, <code>getColorHex</code>, <code>ActionCellRenderer</code></td>
     </tr>
     <tr>
       <td>Molecules</td>
@@ -557,7 +557,7 @@ Each entry point ships as ESM (`.js`), CJS (`.cjs`), and TypeScript declarations
     </tr>
     <tr>
       <td>Atoms</td>
-      <td><code>ArdaBadge</code>, <code>ArdaButton</code>, <code>ConfirmDialog</code>, <code>ArdaTypeahead</code></td>
+      <td><code>ArdaBadge</code>, <code>ArdaButton</code>, <code>ConfirmDialog</code>, <code>ArdaConfirmDialog</code>, <code>ArdaTypeahead</code></td>
     </tr>
     <tr>
       <td>Molecules</td>
@@ -689,7 +689,7 @@ Each entry point ships as ESM (`.js`), CJS (`.cjs`), and TypeScript declarations
   <tbody>
     <tr>
       <td><code>./assets/images/*</code></td>
-      <td>25 files &#8212; brand logos, decorative elements, theme icons</td>
+      <td>26 files &#8212; brand logos, decorative elements, theme icons</td>
     </tr>
     <tr>
       <td><code>./assets/canary/images/*</code></td>


### PR DESCRIPTION
## Summary
- New `ColorPicker` atom — swatch button with popover palette, decoupled from color bar
- Arrow-key navigation (roving tabIndex radiogroup pattern), Home/End support
- 44px touch targets on both trigger and palette swatches
- Responsive palette wrapping for small screens
- Migrated `ItemCardEditor` to use `ColorPicker` instead of `ColorSwatchPicker`
- Deprecated `ColorSwatchPicker`

## Test plan
- [ ] ColorPicker stories: select colors, keyboard nav, disabled state
- [ ] ItemCardEditor stories: color picker + bar still work
- [ ] Mobile: palette wraps instead of overflowing
- [ ] `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)