### PR TITLE
feat: Edit Lifecycle framework, image component updates, and 4.8.0 release

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code Trigger
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,36 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.8.0] - 2026-04-08
+
+### Added
+
+- Edit Lifecycle framework types: `FieldError`, `ValidationResult`, `Validator<T>`,
+  `EditPhase`, `EditLifecycleCallbacks<T>`, `EditableComponentProps<T>`
+- `useDraft<T>` hook for managing edit draft state, validation, and lifecycle phases
+- `setNestedField` utility for immutable dot-path field updates
+- `UploadError` phase in `ImageUploadDialog` with retry and discard actions
+- `contextErrors` prop on `ImageFormField` for parent-injected validation errors
+- `initialValue` prop on `ImageFormField` as canonical data source
+  (`imageUrl` deprecated)
+- `ImageCellEditorConfig` interface with required typed provider hooks
+  (`useImageUpload`, `useCheckReachability`) for FD-01/FD-15 compliance
+- `ItemGridEditorHooks` interface with required typed provider hooks
+- `ItemGridLookups` expanded to 9 lookup fields (was 2)
+- `crossOrigin="use-credentials"` on `ImagePreviewEditor` crop canvas for
+  CDN-hosted images (FD-17, requires infrastructure#439)
+
+### Fixed
+
+- `ImageUploadDialog` now shows an indeterminate spinner instead of a
+  simulated progress percentage during upload (FD-04)
+- `ImageUploadDialog` triggers upload directly on confirm instead of
+  after a simulated delay
+
+### Deprecated
+
+- `ImageFormField.imageUrl` prop — use `initialValue` instead
+
 ## [4.7.0] - 2026-04-06
 
 ### Added

--- a/src/canary.ts
+++ b/src/canary.ts
@@ -5,6 +5,17 @@
 
 export { getInitials } from './types/canary/utilities/get-initials';
 export { getCroppedImage } from './types/canary/utilities/get-cropped-image';
+export { setNestedField } from './types/canary/utilities/set-nested-field';
+export { useDraft } from './types/canary/utilities/use-draft';
+export type { UseDraftOptions, DraftState } from './types/canary/utilities/use-draft';
+export type {
+  FieldError,
+  ValidationResult,
+  Validator,
+  EditPhase,
+  EditLifecycleCallbacks,
+  EditableComponentProps,
+} from './types/canary/utilities/edit-lifecycle';
 export type {
   ImageMimeType,
   ImageFieldStaticConfig,

--- a/src/canary.ts
+++ b/src/canary.ts
@@ -216,6 +216,7 @@ export {
 export type {
   ImageCellDisplayProps,
   ImageCellEditorProps,
+  ImageCellEditorConfig,
   ImageCellEditorHandle,
 } from './components/canary/atoms/grid/image';
 
@@ -306,7 +307,10 @@ export {
   itemGridDefaultColDef,
   createItemGridColumnDefs,
 } from './components/canary/molecules/item-grid/item-grid-columns';
-export type { ItemGridLookups } from './components/canary/molecules/item-grid/item-grid-columns';
+export type {
+  ItemGridLookups,
+  ItemGridEditorHooks,
+} from './components/canary/molecules/item-grid/item-grid-columns';
 
 export { itemGridFixtures } from './components/canary/molecules/item-grid/item-grid-fixtures';
 

--- a/src/components/canary/atoms/grid/image/image-cell-editor.tsx
+++ b/src/components/canary/atoms/grid/image/image-cell-editor.tsx
@@ -6,6 +6,15 @@ import type {
 } from '@/types/canary/utilities/image-field-config';
 import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog';
 
+/** Configuration for the image cell editor factory (FD-01 / FD-15). */
+export interface ImageCellEditorConfig {
+  config: ImageFieldConfig;
+  /** Hook returning the upload mutation — required (FD-15). */
+  useImageUpload: () => { mutateAsync: (file: Blob) => Promise<string>; isPending: boolean };
+  /** Hook returning the reachability check — required (FD-15). */
+  useCheckReachability: () => { mutateAsync: (url: string) => Promise<boolean> };
+}
+
 // --- Interfaces ---
 
 /** Design-time configuration for ImageCellEditor (no static props). */
@@ -30,6 +39,10 @@ export type ImageCellEditorProps = ImageCellEditorStaticProps &
   ImageCellEditorRuntimeProps & {
     /** Curried by createImageCellEditor — not passed by AG Grid directly. */
     config: ImageFieldConfig;
+    /** Upload hook — returns mutateAsync for the upload flow. */
+    useImageUpload?: () => { mutateAsync: (file: Blob) => Promise<string>; isPending: boolean };
+    /** Reachability hook — returns mutateAsync for URL checking. */
+    useCheckReachability?: () => { mutateAsync: (url: string) => Promise<boolean> };
   };
 
 /** Ref handle exposing getValue and isPopup for AG Grid. */
@@ -61,9 +74,13 @@ export interface ImageCellEditorHandle {
  * ```
  */
 export const ImageCellEditor = forwardRef<ImageCellEditorHandle, ImageCellEditorProps>(
-  ({ value: initialValue, stopEditing, config }, ref) => {
+  ({ value: initialValue, stopEditing, config, useImageUpload, useCheckReachability }, ref) => {
     const [currentValue, setCurrentValue] = useState<string | null>(initialValue);
     const [dialogOpen, setDialogOpen] = useState(true);
+
+    // Invoke hooks at the top level (Rules of Hooks) — only when provided
+    const uploadHook = useImageUpload?.();
+    const reachabilityHook = useCheckReachability?.();
 
     useImperativeHandle(ref, () => ({
       getValue: () => currentValue,
@@ -96,6 +113,10 @@ export const ImageCellEditor = forwardRef<ImageCellEditorHandle, ImageCellEditor
           open={dialogOpen}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
+          {...(uploadHook ? { onUpload: (file: Blob) => uploadHook.mutateAsync(file) } : {})}
+          {...(reachabilityHook
+            ? { onCheckReachability: (url: string) => reachabilityHook.mutateAsync(url) }
+            : {})}
         />
       </>
     );
@@ -105,11 +126,27 @@ export const ImageCellEditor = forwardRef<ImageCellEditorHandle, ImageCellEditor
 ImageCellEditor.displayName = 'ImageCellEditor';
 
 /**
- * Factory helper for creating an image cell editor with a curried config.
+ * Factory helper for creating an image cell editor with curried config and hooks.
+ *
+ * Accepts either the legacy `ImageFieldConfig` (Storybook/default handlers) or
+ * the full `ImageCellEditorConfig` with required typed provider hooks (FD-15).
  */
-export function createImageCellEditor(config: ImageFieldConfig) {
+export function createImageCellEditor(configOrFull: ImageFieldConfig | ImageCellEditorConfig) {
+  const isFullConfig = 'useImageUpload' in configOrFull;
+  const config = isFullConfig ? configOrFull.config : configOrFull;
+  const useImageUpload = isFullConfig ? configOrFull.useImageUpload : undefined;
+  const useCheckReachability = isFullConfig ? configOrFull.useCheckReachability : undefined;
+
   const WrappedEditor = forwardRef<ImageCellEditorHandle, ImageCellEditorRuntimeProps>(
-    (props, editorRef) => <ImageCellEditor {...props} config={config} ref={editorRef} />,
+    (props, editorRef) => (
+      <ImageCellEditor
+        {...props}
+        config={config}
+        {...(useImageUpload ? { useImageUpload } : {})}
+        {...(useCheckReachability ? { useCheckReachability } : {})}
+        ref={editorRef}
+      />
+    ),
   );
   WrappedEditor.displayName = `ImageCellEditor(${config.entityTypeDisplayName})`;
   return WrappedEditor;

--- a/src/components/canary/atoms/grid/image/index.ts
+++ b/src/components/canary/atoms/grid/image/index.ts
@@ -9,6 +9,7 @@ export type {
 export { ImageCellEditor, createImageCellEditor } from './image-cell-editor';
 export type {
   ImageCellEditorProps,
+  ImageCellEditorConfig,
   ImageCellEditorStaticProps,
   ImageCellEditorInitProps,
   ImageCellEditorRuntimeProps,

--- a/src/components/canary/molecules/form/image/image-form-field.tsx
+++ b/src/components/canary/molecules/form/image/image-form-field.tsx
@@ -18,6 +18,7 @@ import type {
   ImageFieldConfig,
   ImageUploadResult,
 } from '@/types/canary/utilities/image-field-config';
+import type { FieldError } from '@/types/canary/utilities/edit-lifecycle';
 
 // --- Interfaces ---
 
@@ -32,10 +33,20 @@ export interface ImageFormFieldInitProps {
 
 /** Runtime configuration for ImageFormField (live data and callbacks). */
 export interface ImageFormFieldRuntimeProps {
-  /** Current image URL. Null means no image is set. */
-  imageUrl: string | null;
+  /**
+   * Initial value — canonical prop per EditableComponentProps<string | null>.
+   * Takes precedence over `imageUrl` when both are provided.
+   */
+  initialValue?: string | null;
+  /**
+   * Current image URL. Null means no image is set.
+   * @deprecated Use `initialValue` instead.
+   */
+  imageUrl?: string | null;
   /** Called when the image is changed. Pass `null` to remove the image. */
   onChange: (imageUrl: string | null) => void;
+  /** Contextual errors injected by the parent after its own validation. */
+  contextErrors?: FieldError[];
   /** When true the field is read-only and no actions are available. */
   disabled?: boolean;
 }
@@ -67,10 +78,13 @@ export type ImageFormFieldProps = ImageFormFieldStaticProps &
  */
 export function ImageFormField({
   config,
+  initialValue,
   imageUrl,
   onChange,
+  contextErrors,
   disabled = false,
 }: ImageFormFieldProps) {
+  const resolvedImageUrl = initialValue ?? imageUrl ?? null;
   const { entityTypeDisplayName, propertyDisplayName } = config;
 
   const [inspectorOpen, setInspectorOpen] = React.useState(false);
@@ -101,7 +115,7 @@ export function ImageFormField({
         {/* Interactive ImageDisplay — double-click/Enter opens upload dialog */}
         <div className="w-full h-full rounded-lg">
           <ImageDisplay
-            imageUrl={imageUrl}
+            imageUrl={resolvedImageUrl}
             entityTypeDisplayName={entityTypeDisplayName}
             propertyDisplayName={propertyDisplayName}
             config={config}
@@ -119,7 +133,7 @@ export function ImageFormField({
           )}
         >
           {/* Eye icon — opens inspector (suppressed when no image) */}
-          {imageUrl !== null && (
+          {resolvedImageUrl !== null && (
             <button
               type="button"
               aria-label="Inspect image"
@@ -135,7 +149,7 @@ export function ImageFormField({
           )}
 
           {/* Trash icon — opens remove confirmation (hidden when no image) */}
-          {imageUrl !== null && (
+          {resolvedImageUrl !== null && (
             <button
               type="button"
               aria-label="Remove image"
@@ -155,10 +169,21 @@ export function ImageFormField({
       {/* Label */}
       <span className="text-sm text-muted-foreground">{propertyDisplayName}</span>
 
+      {/* Contextual errors */}
+      {contextErrors && contextErrors.length > 0 && (
+        <div className="flex flex-col gap-0.5" role="alert">
+          {contextErrors.map((err) => (
+            <span key={`${err.field}:${err.message}`} className="text-xs text-destructive">
+              {err.message}
+            </span>
+          ))}
+        </div>
+      )}
+
       {/* ImageInspectorOverlay — controlled by eye icon button */}
-      {imageUrl !== null && (
+      {resolvedImageUrl !== null && (
         <ImageInspectorOverlay
-          imageUrl={imageUrl}
+          imageUrl={resolvedImageUrl}
           open={inspectorOpen}
           onClose={() => setInspectorOpen(false)}
           onEdit={() => {

--- a/src/components/canary/molecules/image-preview-editor/image-preview-editor.test.tsx
+++ b/src/components/canary/molecules/image-preview-editor/image-preview-editor.test.tsx
@@ -8,13 +8,16 @@ vi.mock('react-easy-crop', () => ({
   default: ({
     onCropComplete,
     image,
+    mediaProps,
   }: {
     onCropComplete?: (croppedArea: unknown, croppedAreaPixels: unknown) => void;
     image?: string;
+    mediaProps?: Record<string, string>;
   }) => (
     <div
       data-testid="mock-cropper"
       data-image={image}
+      data-cross-origin={mediaProps?.crossOrigin ?? ''}
       onClick={() =>
         onCropComplete?.(
           { x: 0, y: 0, width: 100, height: 100 },
@@ -108,6 +111,26 @@ describe('ImagePreviewEditor', () => {
 
     await user.click(screen.getByRole('button', { name: /reset/i }));
     expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  describe('crossOrigin for CDN URLs (FD-17)', () => {
+    it('sets crossOrigin="use-credentials" for CDN URLs', () => {
+      renderEditor({ imageData: 'https://dev.alpha002.assets.arda.cards/images/item/123.jpg' });
+      const cropper = screen.getByTestId('mock-cropper');
+      expect(cropper).toHaveAttribute('data-cross-origin', 'use-credentials');
+    });
+
+    it('does not set crossOrigin for non-CDN URLs', () => {
+      renderEditor({ imageData: 'https://picsum.photos/seed/test/400/400' });
+      const cropper = screen.getByTestId('mock-cropper');
+      expect(cropper).toHaveAttribute('data-cross-origin', '');
+    });
+
+    it('does not set crossOrigin for blob URLs', () => {
+      renderEditor({ imageData: 'blob:http://localhost/fake-uuid' });
+      const cropper = screen.getByTestId('mock-cropper');
+      expect(cropper).toHaveAttribute('data-cross-origin', '');
+    });
   });
 
   describe('File to object URL conversion', () => {

--- a/src/components/canary/molecules/image-preview-editor/image-preview-editor.tsx
+++ b/src/components/canary/molecules/image-preview-editor/image-preview-editor.tsx
@@ -34,6 +34,11 @@ export type ImagePreviewEditorProps = ImagePreviewEditorStaticProps &
 
 // --- Helpers ---
 
+/** CDN URL pattern — matches `*.assets.arda.cards` domains (FD-17). */
+function isCdnUrl(src: string): boolean {
+  return src.includes('.assets.arda.cards');
+}
+
 const TOOLBAR_BUTTON_CLASS = cn(
   'inline-flex items-center justify-center rounded-md p-2',
   'text-muted-foreground hover:text-foreground bg-transparent hover:bg-accent',
@@ -136,6 +141,7 @@ export function ImagePreviewEditor({
             onZoomChange={setZoom}
             onRotationChange={setRotation}
             onCropComplete={handleCropComplete}
+            {...(isCdnUrl(imageSrc) ? { mediaProps: { crossOrigin: 'use-credentials' } } : {})}
           />
         )}
       </div>

--- a/src/components/canary/molecules/item-grid/item-grid-columns.tsx
+++ b/src/components/canary/molecules/item-grid/item-grid-columns.tsx
@@ -5,7 +5,7 @@ import type { Item } from '@/types/extras';
 import { TypeaheadCellEditor, type TypeaheadOption } from './typeahead-cell-editor';
 import { SelectCellEditor } from '../../atoms/grid/select/select-cell-editor';
 import { DragHeader } from './drag-header';
-import { ImageCellDisplay } from '../../atoms/grid/image';
+import { ImageCellDisplay, createImageCellEditor } from '../../atoms/grid/image';
 import type { ImageFieldConfig } from '@/types/canary/utilities/image-field-config';
 
 // --- Local image config (no mock dependency) ---
@@ -231,6 +231,21 @@ const tabularNumsStyle = { fontVariantNumeric: 'tabular-nums' };
 export interface ItemGridLookups {
   supplier?: (search: string) => Promise<TypeaheadOption[]>;
   classificationType?: (search: string) => Promise<TypeaheadOption[]>;
+  classificationSubType?: (search: string) => Promise<TypeaheadOption[]>;
+  useCase?: (search: string) => Promise<TypeaheadOption[]>;
+  facility?: (search: string) => Promise<TypeaheadOption[]>;
+  department?: (search: string) => Promise<TypeaheadOption[]>;
+  location?: (search: string) => Promise<TypeaheadOption[]>;
+  sublocation?: (search: string) => Promise<TypeaheadOption[]>;
+  unit?: (search: string) => Promise<TypeaheadOption[]>;
+}
+
+/** Typed provider hooks for grid cell editors (FD-01 / FD-15). */
+export interface ItemGridEditorHooks {
+  /** Hook returning the upload mutation — required (FD-15). */
+  useImageUpload: () => { mutateAsync: (file: Blob) => Promise<string>; isPending: boolean };
+  /** Hook returning the reachability check — required (FD-15). */
+  useCheckReachability: () => { mutateAsync: (url: string) => Promise<boolean> };
 }
 
 // --- Defaults ---
@@ -248,11 +263,13 @@ export const itemGridDefaultColDef: ColDef<Item> = {
 /** Static columns (no lookups needed). Used as default. */
 export const itemGridColumnDefs: ColDef<Item>[] = createItemGridColumnDefs();
 
-/** Factory — pass lookups and callbacks to get fully-configured columns. */
+/** Factory — pass lookups, editor hooks, and callbacks to get fully-configured columns. */
 export function createItemGridColumnDefs(
   lookups?: ItemGridLookups,
-  options?: { onNotesClick?: (item: Item) => void },
+  options?: { onNotesClick?: (item: Item) => void; editorHooks?: ItemGridEditorHooks },
 ): ColDef<Item>[] {
+  const editorHooks = options?.editorHooks;
+
   return [
     {
       headerName: 'Image',
@@ -261,9 +278,19 @@ export function createItemGridColumnDefs(
       width: 60,
       sortable: false,
       resizable: false,
-      editable: false,
+      editable: !!editorHooks,
       cellRenderer: ImageCellDisplay,
       cellRendererParams: { config: ITEM_IMAGE_CONFIG },
+      ...(editorHooks
+        ? {
+            cellEditor: createImageCellEditor({
+              config: ITEM_IMAGE_CONFIG,
+              useImageUpload: editorHooks.useImageUpload,
+              useCheckReachability: editorHooks.useCheckReachability,
+            }),
+            cellEditorPopup: true,
+          }
+        : {}),
     },
     {
       headerName: 'Name',

--- a/src/components/canary/molecules/item-grid/typeahead-cell-editor.tsx
+++ b/src/components/canary/molecules/item-grid/typeahead-cell-editor.tsx
@@ -11,6 +11,17 @@ export interface TypeaheadOption {
   value: string;
 }
 
+/**
+ * Props for TypeaheadCellEditor.
+ *
+ * The `lookup` callback is a typed data provider (FD-01 compliant) — the
+ * component is agnostic to the data source (TanStack Query, REST, static
+ * list). The promise-based interface was evaluated for hook conversion
+ * (Phase 3.3, decision #2) and retained because:
+ * - Already FD-01 compliant as a typed, TanStack-agnostic callback
+ * - Component correctly manages loading/error state from the promise
+ * - Debounce is a UI concern handled internally by the component
+ */
 export interface TypeaheadCellEditorProps {
   value: string | null;
   onValueChange: (value: string | null) => void;

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.test.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.test.tsx
@@ -212,12 +212,84 @@ describe('ImageUploadDialog', () => {
   });
 
   it('calls onConfirm with result on confirm (mock the upload)', async () => {
-    vi.useFakeTimers();
-    try {
+    const { defaultUploadHandler } = await import('@/types/canary/utilities/image-upload-handlers');
+    (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValue(
+      'https://cdn.example.com/images/mock-uploaded.jpg',
+    );
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm });
+
+    fireEvent.click(screen.getByText('drop file'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ imageUrl: 'https://cdn.example.com/images/mock-uploaded.jpg' }),
+      );
+    });
+  });
+
+  it('shows indeterminate indicator during upload (no progress percentage)', async () => {
+    // Make onUpload hang so we can inspect the Uploading state
+    const { defaultUploadHandler } = await import('@/types/canary/utilities/image-upload-handlers');
+    (defaultUploadHandler as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    renderDialog();
+
+    fireEvent.click(screen.getByText('drop file'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByText('Uploading image\u2026')).toBeInTheDocument();
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+  });
+
+  // --- UploadError state tests ---
+
+  describe('UploadError state', () => {
+    async function enterUploadError() {
       const { defaultUploadHandler } =
         await import('@/types/canary/utilities/image-upload-handlers');
-      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValue(
-        'https://cdn.example.com/images/mock-uploaded.jpg',
+      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Network failure'),
+      );
+      renderDialog();
+
+      fireEvent.click(screen.getByText('drop file'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+    }
+
+    it('renders error message on upload failure', async () => {
+      await enterUploadError();
+      expect(screen.getByRole('alert')).toHaveTextContent('Network failure');
+    });
+
+    it('retry transitions back to Uploading', async () => {
+      const { defaultUploadHandler } =
+        await import('@/types/canary/utilities/image-upload-handlers');
+      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Network failure'),
+      );
+      // On retry, succeed
+      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        'https://cdn.example.com/retried.jpg',
       );
       const onConfirm = vi.fn();
       renderDialog({ onConfirm });
@@ -226,47 +298,30 @@ describe('ImageUploadDialog', () => {
       await act(async () => {
         await Promise.resolve();
       });
-
       fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
-      // Advance timers to complete the progress simulation
-      await act(async () => {
-        vi.advanceTimersByTime(2000);
-        await Promise.resolve();
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Network failure');
       });
 
-      await act(async () => {
-        await Promise.resolve();
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+      await waitFor(() => {
+        expect(onConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: 'https://cdn.example.com/retried.jpg' }),
+        );
       });
+    });
 
-      expect(onConfirm).toHaveBeenCalledWith(
-        expect.objectContaining({ imageUrl: 'https://cdn.example.com/images/mock-uploaded.jpg' }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    it('discard transitions to EmptyImage', async () => {
+      await enterUploadError();
 
-  it('shows progress bar during upload', async () => {
-    vi.useFakeTimers();
-    try {
-      renderDialog();
-      fireEvent.click(screen.getByText('drop file'));
-      await act(async () => {
-        await Promise.resolve();
+      fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
       });
-
-      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-      await act(async () => {
-        vi.advanceTimersByTime(100);
-        await Promise.resolve();
-      });
-
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
-    } finally {
-      vi.useRealTimers();
-    }
+    });
   });
 
   it('comparison layout shown when existingImageUrl set and new image provided', async () => {
@@ -342,57 +397,40 @@ describe('ImageUploadDialog', () => {
     });
 
     it('"Confirm" in EditExisting triggers upload (enters Uploading state)', async () => {
-      vi.useFakeTimers();
-      try {
-        renderDialog({ existingImageUrl: EXISTING_URL });
+      const { defaultUploadHandler } =
+        await import('@/types/canary/utilities/image-upload-handlers');
+      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+      renderDialog({ existingImageUrl: EXISTING_URL });
 
-        await act(async () => {
-          fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-          await Promise.resolve();
-        });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+        await Promise.resolve();
+      });
 
-        await act(async () => {
-          vi.advanceTimersByTime(100);
-          await Promise.resolve();
-        });
-
-        expect(screen.getByRole('progressbar')).toBeInTheDocument();
-      } finally {
-        vi.useRealTimers();
-      }
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toBeInTheDocument();
+      });
     });
 
     it('"Confirm" in EditExisting calls onConfirm after upload completes', async () => {
-      vi.useFakeTimers();
-      try {
-        const { defaultUploadHandler } =
-          await import('@/types/canary/utilities/image-upload-handlers');
-        (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValue(
-          'https://cdn.example.com/images/mock-uploaded.jpg',
-        );
-        const onConfirm = vi.fn();
-        renderDialog({ existingImageUrl: EXISTING_URL, onConfirm });
+      const { defaultUploadHandler } =
+        await import('@/types/canary/utilities/image-upload-handlers');
+      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValue(
+        'https://cdn.example.com/images/mock-uploaded.jpg',
+      );
+      const onConfirm = vi.fn();
+      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm });
 
-        await act(async () => {
-          fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-          await Promise.resolve();
-        });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+        await Promise.resolve();
+      });
 
-        await act(async () => {
-          vi.advanceTimersByTime(2000);
-          await Promise.resolve();
-        });
-
-        await act(async () => {
-          await Promise.resolve();
-        });
-
+      await waitFor(() => {
         expect(onConfirm).toHaveBeenCalledWith(
           expect.objectContaining({ imageUrl: 'https://cdn.example.com/images/mock-uploaded.jpg' }),
         );
-      } finally {
-        vi.useRealTimers();
-      }
+      });
     });
 
     it('opens in EmptyImage state when existingImageUrl is null', () => {

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
@@ -18,7 +18,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '@/components/canary/primitives/alert-dialog';
-import { Progress } from '@/components/canary/primitives/progress';
+import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/canary/primitives/button';
 import { ImageDropZone } from '@/components/canary/molecules/image-drop-zone/image-drop-zone';
 import { ImagePreviewEditor } from '@/components/canary/molecules/image-preview-editor/image-preview-editor';
@@ -44,7 +44,10 @@ export interface ImageUploadDialogInitProps {
   config: ImageFieldConfig;
 }
 
-/** Runtime props for ImageUploadDialog. */
+/**
+ * Runtime props for ImageUploadDialog.
+ * Confirm/cancel callbacks follow `EditLifecycleCallbacks<ImageUploadResult>`.
+ */
 export interface ImageUploadDialogRuntimeProps {
   existingImageUrl: string | null;
   onConfirm: (result: ImageUploadResult) => void;
@@ -74,7 +77,8 @@ type DialogPhase =
   | { name: 'EmptyImage' }
   | { name: 'ProvidedImage'; imageData: File | Blob | string }
   | { name: 'FailedValidation'; errorMessage: string }
-  | { name: 'Uploading'; imageData: File | Blob | string; progress: number }
+  | { name: 'Uploading'; imageData: File | Blob | string }
+  | { name: 'UploadError'; error: string; imageData: File | Blob | string }
   | { name: 'Warn'; imageData: File | Blob | string };
 
 type DialogAction =
@@ -83,7 +87,9 @@ type DialogAction =
   | { type: 'INPUT_ERROR'; message: string }
   | { type: 'CANCEL_CLICK' }
   | { type: 'CONFIRM_CLICK' }
-  | { type: 'UPLOAD_PROGRESS'; progress: number }
+  | { type: 'UPLOAD_ERROR'; error: string }
+  | { type: 'UPLOAD_RETRY' }
+  | { type: 'UPLOAD_DISCARD' }
   | { type: 'WARN_DISCARD' }
   | { type: 'WARN_GO_BACK' }
   | { type: 'EDIT_CONFIRM' }
@@ -106,13 +112,25 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
     }
     case 'CONFIRM_CLICK': {
       if (state.name === 'ProvidedImage') {
-        return { name: 'Uploading', imageData: state.imageData, progress: 0 };
+        return { name: 'Uploading', imageData: state.imageData };
       }
       return state;
     }
-    case 'UPLOAD_PROGRESS': {
+    case 'UPLOAD_ERROR': {
       if (state.name === 'Uploading') {
-        return { ...state, progress: action.progress };
+        return { name: 'UploadError', error: action.error, imageData: state.imageData };
+      }
+      return state;
+    }
+    case 'UPLOAD_RETRY': {
+      if (state.name === 'UploadError') {
+        return { name: 'Uploading', imageData: state.imageData };
+      }
+      return state;
+    }
+    case 'UPLOAD_DISCARD': {
+      if (state.name === 'UploadError') {
+        return { name: 'EmptyImage' };
       }
       return state;
     }
@@ -126,7 +144,7 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
     }
     case 'EDIT_CONFIRM': {
       if (state.name === 'EditExisting') {
-        return { name: 'Uploading', imageData: state.imageUrl, progress: 0 };
+        return { name: 'Uploading', imageData: state.imageUrl };
       }
       return state;
     }
@@ -178,34 +196,33 @@ export function ImageUploadDialog({
     }
   }, [open]); // Intentionally deps on open only — existingImageUrl is captured at open time
 
-  // Handle upload progress simulation
+  // Trigger upload when entering the Uploading phase
   React.useEffect(() => {
     if (phase.name !== 'Uploading') return;
 
+    let cancelled = false;
     const imageData = phase.imageData;
-    const startTime = Date.now();
-    const duration = 1500;
+    const blob = typeof imageData === 'string' ? new Blob([]) : imageData;
 
-    const intervalId = setInterval(() => {
-      const elapsed = Date.now() - startTime;
-      const progress = Math.min(100, Math.round((elapsed / duration) * 100));
-      dispatch({ type: 'UPLOAD_PROGRESS', progress });
-
-      if (progress >= 100) {
-        clearInterval(intervalId);
-        const blob = typeof imageData === 'string' ? new Blob([]) : imageData;
-        onUpload(blob).then((imageUrl) => {
-          onConfirm({
-            imageUrl,
-            wasCompressed: false,
-            originalSizeBytes: blob.size,
-            finalSizeBytes: blob.size,
-          });
+    onUpload(blob)
+      .then((imageUrl) => {
+        if (cancelled) return;
+        onConfirm({
+          imageUrl,
+          wasCompressed: false,
+          originalSizeBytes: blob.size,
+          finalSizeBytes: blob.size,
         });
-      }
-    }, 50);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Upload failed';
+        dispatch({ type: 'UPLOAD_ERROR', error: message });
+      });
 
-    return () => clearInterval(intervalId);
+    return () => {
+      cancelled = true;
+    };
   }, [phase.name]); // Intentionally deps on phase.name only — fires once on entering Uploading
 
   const handleInput = React.useCallback(
@@ -283,6 +300,7 @@ export function ImageUploadDialog({
   );
 
   const isUploading = phase.name === 'Uploading';
+  const isUploadError = phase.name === 'UploadError';
   const isProvidedOrUploading =
     phase.name === 'ProvidedImage' || phase.name === 'Uploading' || phase.name === 'Warn';
 
@@ -379,17 +397,39 @@ export function ImageUploadDialog({
             </div>
           )}
 
-          {/* Uploading state */}
+          {/* Uploading state — indeterminate spinner (FD-04) */}
           {phase.name === 'Uploading' && (
+            <div className="flex flex-col items-center gap-4 py-8" role="status">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
+              <p className="text-sm text-muted-foreground">Uploading image&#8230;</p>
+            </div>
+          )}
+
+          {/* UploadError state — error message with retry/discard */}
+          {phase.name === 'UploadError' && (
             <div className="flex flex-col gap-4">
-              <p className="text-sm text-muted-foreground text-center">Uploading image&#8230;</p>
-              <Progress value={phase.progress} className="bg-muted" />
+              <p className={cn('text-sm text-destructive')} role="alert">
+                {phase.error}
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => dispatch({ type: 'UPLOAD_DISCARD' })}
+                >
+                  Discard
+                </Button>
+                <Button type="button" onClick={() => dispatch({ type: 'UPLOAD_RETRY' })}>
+                  Retry
+                </Button>
+              </div>
             </div>
           )}
 
           {/* Footer — shown only for ProvidedImage */}
           {/* EditExisting footer is baked into ImageComparisonLayout above */}
           {!isUploading &&
+            !isUploadError &&
             phase.name !== 'EmptyImage' &&
             phase.name !== 'FailedValidation' &&
             phase.name !== 'EditExisting' &&

--- a/src/types/canary.ts
+++ b/src/types/canary.ts
@@ -3,3 +3,12 @@
 
 export { cn } from './canary/utilities/utils';
 export type { PaginationData } from './canary/utilities/pagination';
+export type {
+  FieldError,
+  ValidationResult,
+  Validator,
+  EditPhase,
+  EditLifecycleCallbacks,
+  EditableComponentProps,
+} from './canary/utilities/edit-lifecycle';
+export { setNestedField } from './canary/utilities/set-nested-field';

--- a/src/types/canary/utilities/edit-lifecycle.test.ts
+++ b/src/types/canary/utilities/edit-lifecycle.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type {
+  FieldError,
+  ValidationResult,
+  Validator,
+  EditPhase,
+  EditLifecycleCallbacks,
+  EditableComponentProps,
+} from './edit-lifecycle';
+
+describe('edit-lifecycle types', () => {
+  it('FieldError has required field and message string fields', () => {
+    expectTypeOf<FieldError['field']>().toEqualTypeOf<string>();
+    expectTypeOf<FieldError['message']>().toEqualTypeOf<string>();
+  });
+
+  it('FieldError.severity accepts only error and warning', () => {
+    expectTypeOf<FieldError['severity']>().toEqualTypeOf<'error' | 'warning' | undefined>();
+  });
+
+  it('FieldError.code is optional string', () => {
+    expectTypeOf<FieldError['code']>().toEqualTypeOf<string | undefined>();
+  });
+
+  it('ValidationResult has boolean valid and FieldError[] errors', () => {
+    expectTypeOf<ValidationResult['valid']>().toEqualTypeOf<boolean>();
+    expectTypeOf<ValidationResult['errors']>().toEqualTypeOf<FieldError[]>();
+  });
+
+  it('Validator<T> is callable with T and returns ValidationResult', () => {
+    expectTypeOf<Validator<string>>().toEqualTypeOf<(value: string) => ValidationResult>();
+  });
+
+  it('EditPhase is a union of exactly 4 string literals', () => {
+    expectTypeOf<EditPhase>().toEqualTypeOf<'idle' | 'editing' | 'confirming' | 'error'>();
+  });
+
+  it('EditLifecycleCallbacks<T> has optional onChange, onConfirm, onCancel', () => {
+    type Cbs = EditLifecycleCallbacks<number>;
+    expectTypeOf<Cbs['onChange']>().toEqualTypeOf<
+      ((value: number, validation: ValidationResult) => void) | undefined
+    >();
+    expectTypeOf<Cbs['onConfirm']>().toEqualTypeOf<((value: number) => void) | undefined>();
+    expectTypeOf<Cbs['onCancel']>().toEqualTypeOf<(() => void) | undefined>();
+  });
+
+  it('EditableComponentProps<T> extends EditLifecycleCallbacks<T>', () => {
+    expectTypeOf<EditableComponentProps<string>>().toMatchTypeOf<EditLifecycleCallbacks<string>>();
+  });
+
+  it('EditableComponentProps<T>.contextErrors accepts FieldError[]', () => {
+    expectTypeOf<EditableComponentProps<string>['contextErrors']>().toEqualTypeOf<
+      FieldError[] | undefined
+    >();
+  });
+});

--- a/src/types/canary/utilities/edit-lifecycle.ts
+++ b/src/types/canary/utilities/edit-lifecycle.ts
@@ -1,0 +1,45 @@
+/** A single validation error on a specific field. */
+export interface FieldError {
+  /** Dot-path to the field (e.g., "street1", "supplier.address.postalCode"). */
+  field: string;
+  /** Human-readable error message. */
+  message: string;
+  /** Machine-readable code for testing and i18n. */
+  code?: string;
+  /** Severity — 'error' blocks confirm; 'warning' allows but shows message. */
+  severity?: 'error' | 'warning';
+}
+
+/** Result of validating a value. */
+export interface ValidationResult {
+  /** True if no errors (warnings are allowed). */
+  valid: boolean;
+  /** List of field-level errors and warnings. */
+  errors: FieldError[];
+}
+
+/** A function that validates a value and returns a result. */
+export type Validator<T> = (value: T) => ValidationResult;
+
+/** The phase of an edit session. */
+export type EditPhase = 'idle' | 'editing' | 'confirming' | 'error';
+
+/** Callbacks for the edit lifecycle. */
+export interface EditLifecycleCallbacks<T> {
+  /** Called on every draft change with current validation result. */
+  onChange?: (value: T, validation: ValidationResult) => void;
+  /** Called when the user confirms and intrinsic validation passes. */
+  onConfirm?: (value: T) => void;
+  /** Called when the user cancels the edit. */
+  onCancel?: () => void;
+}
+
+/** Standard props for any editable component. */
+export interface EditableComponentProps<T> extends EditLifecycleCallbacks<T> {
+  /** Initial value — from parent's draft or from a data provider. */
+  initialValue: T;
+  /** Contextual errors injected by the parent after its own validation. */
+  contextErrors?: FieldError[];
+  /** Component is disabled (parent is saving, or a sibling edit is active). */
+  disabled?: boolean;
+}

--- a/src/types/canary/utilities/index.ts
+++ b/src/types/canary/utilities/index.ts
@@ -5,3 +5,5 @@ export * from './image-field-config';
 export * from './get-initials';
 export * from './get-cropped-image';
 export * from './maybe-convert-heic';
+export * from './edit-lifecycle';
+export * from './set-nested-field';

--- a/src/types/canary/utilities/set-nested-field.test.ts
+++ b/src/types/canary/utilities/set-nested-field.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { setNestedField } from './set-nested-field';
+
+describe('setNestedField', () => {
+  it('sets a shallow path', () => {
+    expect(setNestedField({ name: 'a' }, 'name', 'b')).toEqual({ name: 'b' });
+  });
+
+  it('sets a nested path', () => {
+    expect(setNestedField({ address: { city: 'a' } }, 'address.city', 'b')).toEqual({
+      address: { city: 'b' },
+    });
+  });
+
+  it('sets a deep path', () => {
+    expect(setNestedField({ a: { b: { c: 1 } } }, 'a.b.c', 2)).toEqual({
+      a: { b: { c: 2 } },
+    });
+  });
+
+  it('creates intermediate objects when they do not exist', () => {
+    expect(setNestedField({}, 'a.b.c', 1)).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  it('does not mutate the original object', () => {
+    const original = { name: 'a' };
+    const result = setNestedField(original, 'name', 'b');
+    expect(Object.is(original, result)).toBe(false);
+    expect(original.name).toBe('a');
+  });
+
+  it('does not mutate intermediate objects', () => {
+    const inner = { city: 'a' };
+    const original = { address: inner };
+    setNestedField(original, 'address.city', 'b');
+    expect(inner.city).toBe('a');
+  });
+
+  it('handles a single-segment path', () => {
+    expect(setNestedField({ x: 1 }, 'x', 2)).toEqual({ x: 2 });
+  });
+
+  it('preserves sibling fields', () => {
+    expect(setNestedField({ a: 1, b: 2 }, 'a', 3)).toEqual({ a: 3, b: 2 });
+  });
+});

--- a/src/types/canary/utilities/set-nested-field.ts
+++ b/src/types/canary/utilities/set-nested-field.ts
@@ -1,0 +1,22 @@
+/**
+ * Set a value at a dot-separated path in an object, creating intermediate
+ * objects as needed. Returns a new object — does not mutate the input.
+ *
+ * Each level on the changed path is shallow-copied; sibling subtrees retain
+ * referential identity (important for React.memo and dependency arrays).
+ */
+export function setNestedField<T>(obj: T, path: string, value: unknown): T {
+  const segments = path.split('.');
+  const head = segments[0] as string;
+
+  if (segments.length === 1) {
+    return { ...obj, [head]: value };
+  }
+
+  const rest = segments.slice(1);
+  const child = (obj as Record<string, unknown>)[head] ?? {};
+  return {
+    ...obj,
+    [head]: setNestedField(child, rest.join('.'), value),
+  } as T;
+}

--- a/src/types/canary/utilities/use-draft.test.ts
+++ b/src/types/canary/utilities/use-draft.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDraft } from './use-draft';
+import type { FieldError, Validator } from './edit-lifecycle';
+
+// ── Test fixtures ───────────────────────────────────────────────────────────
+
+interface TestAddress {
+  street: string;
+  city: string;
+  postalCode: string;
+}
+
+const VALID_ADDRESS: TestAddress = { street: '123 Main', city: 'Springfield', postalCode: '62701' };
+const EMPTY_ADDRESS: TestAddress = { street: '', city: '', postalCode: '' };
+
+const validateAddress: Validator<TestAddress> = (addr) => {
+  const errors: FieldError[] = [];
+  if (!addr.street) errors.push({ field: 'street', message: 'Required' });
+  if (!addr.city) errors.push({ field: 'city', message: 'Required' });
+  if (addr.postalCode && !/^\d{5}$/.test(addr.postalCode))
+    errors.push({ field: 'postalCode', message: 'Invalid format' });
+  return { valid: errors.length === 0, errors };
+};
+
+const alwaysValid: Validator<TestAddress> = () => ({ valid: true, errors: [] });
+
+function renderDraft(overrides: Partial<Parameters<typeof useDraft<TestAddress>>[0]> = {}) {
+  return renderHook(
+    (props) =>
+      useDraft<TestAddress>({
+        initialValue: VALID_ADDRESS,
+        validate: validateAddress,
+        ...props,
+      }),
+    { initialProps: overrides },
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useDraft', () => {
+  describe('initial state', () => {
+    it('value matches initialValue', () => {
+      const { result } = renderDraft();
+      expect(result.current.value).toBe(VALID_ADDRESS);
+    });
+
+    it('phase is idle', () => {
+      const { result } = renderDraft();
+      expect(result.current.phase).toBe('idle');
+    });
+
+    it('dirty is false', () => {
+      const { result } = renderDraft();
+      expect(result.current.dirty).toBe(false);
+    });
+
+    it('intrinsicValidation reflects validation of initial value', () => {
+      const { result } = renderDraft();
+      expect(result.current.intrinsicValidation.valid).toBe(true);
+      expect(result.current.intrinsicValidation.errors).toEqual([]);
+    });
+
+    it('isValid reflects validation of initial value', () => {
+      const { result } = renderDraft();
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it('allErrors matches intrinsic errors when no contextErrors', () => {
+      const { result } = renderDraft({ initialValue: EMPTY_ADDRESS });
+      expect(result.current.allErrors).toEqual(result.current.intrinsicValidation.errors);
+    });
+  });
+
+  describe('update()', () => {
+    it('updates value and sets phase to editing', () => {
+      const { result } = renderDraft();
+      const newValue = { ...VALID_ADDRESS, city: 'Shelbyville' };
+      act(() => result.current.update(newValue));
+      expect(result.current.value).toEqual(newValue);
+      expect(result.current.phase).toBe('editing');
+      expect(result.current.dirty).toBe(true);
+    });
+
+    it('runs validation: invalid value produces errors', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      expect(result.current.intrinsicValidation.valid).toBe(false);
+      expect(result.current.intrinsicValidation.errors.length).toBeGreaterThan(0);
+    });
+
+    it('calls onChange with new value and validation result', () => {
+      const onChange = vi.fn();
+      const { result } = renderDraft({ onChange });
+      const newValue = { ...VALID_ADDRESS, city: 'Shelbyville' };
+      act(() => result.current.update(newValue));
+      expect(onChange).toHaveBeenCalledWith(newValue, expect.objectContaining({ valid: true }));
+    });
+  });
+
+  describe('update() with function updater', () => {
+    it('applies the updater function to previous value', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update((prev) => ({ ...prev, city: 'New York' })));
+      expect(result.current.value.city).toBe('New York');
+      expect(result.current.value.street).toBe(VALID_ADDRESS.street);
+    });
+  });
+
+  describe('updateField()', () => {
+    it('updates a single field by dot-path', () => {
+      const { result } = renderDraft();
+      act(() => result.current.updateField('city', 'Springfield'));
+      expect(result.current.value.city).toBe('Springfield');
+    });
+
+    it('runs validation after field update', () => {
+      const { result } = renderDraft();
+      act(() => result.current.updateField('street', ''));
+      expect(result.current.intrinsicValidation.valid).toBe(false);
+    });
+
+    it('preserves sibling fields', () => {
+      const { result } = renderDraft();
+      act(() => result.current.updateField('city', 'Shelbyville'));
+      expect(result.current.value.street).toBe(VALID_ADDRESS.street);
+      expect(result.current.value.postalCode).toBe(VALID_ADDRESS.postalCode);
+    });
+  });
+
+  describe('confirm() — valid', () => {
+    it('calls onConfirm with current value when valid', () => {
+      const onConfirm = vi.fn();
+      const { result } = renderDraft({ onConfirm });
+      act(() => result.current.update({ ...VALID_ADDRESS, city: 'Shelbyville' }));
+      act(() => result.current.confirm());
+      expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ city: 'Shelbyville' }));
+    });
+
+    it('sets phase to confirming', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update({ ...VALID_ADDRESS, city: 'Shelbyville' }));
+      act(() => result.current.confirm());
+      expect(result.current.phase).toBe('confirming');
+    });
+  });
+
+  describe('confirm() — invalid', () => {
+    it('does not call onConfirm when draft is invalid', () => {
+      const onConfirm = vi.fn();
+      const { result } = renderDraft({ onConfirm });
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.confirm());
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('sets phase to error', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.confirm());
+      expect(result.current.phase).toBe('error');
+    });
+  });
+
+  describe('cancel()', () => {
+    it('resets value to initialValue', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.cancel());
+      expect(result.current.value).toBe(VALID_ADDRESS);
+    });
+
+    it('sets phase to idle and dirty to false', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.cancel());
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.dirty).toBe(false);
+    });
+
+    it('calls onCancel callback', () => {
+      const onCancel = vi.fn();
+      const { result } = renderDraft({ onCancel });
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.cancel());
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('reset()', () => {
+    it('resets value to initialValue', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.reset());
+      expect(result.current.value).toBe(VALID_ADDRESS);
+    });
+
+    it('sets phase to idle', () => {
+      const { result } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.reset());
+      expect(result.current.phase).toBe('idle');
+    });
+
+    it('does NOT call onCancel', () => {
+      const onCancel = vi.fn();
+      const { result } = renderDraft({ onCancel });
+      act(() => result.current.update(EMPTY_ADDRESS));
+      act(() => result.current.reset());
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initialValue change', () => {
+    it('resets draft when initialValue reference changes', () => {
+      const { result, rerender } = renderDraft();
+      act(() => result.current.update(EMPTY_ADDRESS));
+      expect(result.current.phase).toBe('editing');
+
+      const newInitial = { ...VALID_ADDRESS, city: 'Capital City' };
+      rerender({ initialValue: newInitial, validate: validateAddress });
+
+      expect(result.current.value).toEqual(newInitial);
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.dirty).toBe(false);
+    });
+  });
+
+  describe('isEqual option', () => {
+    it('prevents reset when structurally equal value has new reference', () => {
+      const isEqual = (a: TestAddress, b: TestAddress) =>
+        a.street === b.street && a.city === b.city && a.postalCode === b.postalCode;
+
+      const { result, rerender } = renderDraft({ isEqual });
+      act(() => result.current.update({ ...VALID_ADDRESS, city: 'Shelbyville' }));
+      expect(result.current.phase).toBe('editing');
+
+      // Re-render with structurally identical but new reference
+      const newRef = { ...VALID_ADDRESS };
+      rerender({ initialValue: newRef, validate: validateAddress, isEqual });
+
+      // Draft should NOT reset — isEqual returns true
+      expect(result.current.value.city).toBe('Shelbyville');
+      expect(result.current.phase).toBe('editing');
+    });
+
+    it('without isEqual, new reference triggers reset even if structurally equal', () => {
+      const { result, rerender } = renderDraft();
+      act(() => result.current.update({ ...VALID_ADDRESS, city: 'Shelbyville' }));
+
+      // New reference, identical content — but no isEqual provided
+      const newRef = { ...VALID_ADDRESS };
+      rerender({ initialValue: newRef, validate: validateAddress });
+
+      // Draft resets because Object.is(original, newRef) is false
+      expect(result.current.value).toEqual(VALID_ADDRESS);
+      expect(result.current.phase).toBe('idle');
+    });
+  });
+
+  describe('contextErrors merge', () => {
+    const parentError: FieldError = { field: 'city', message: 'Duplicate city' };
+
+    it('adds contextErrors to allErrors', () => {
+      const { result } = renderDraft({ contextErrors: [parentError] });
+      expect(result.current.allErrors).toContainEqual(parentError);
+    });
+
+    it('isValid is false when contextErrors contain error-severity errors', () => {
+      const { result } = renderDraft({
+        validate: alwaysValid,
+        contextErrors: [{ field: 'city', message: 'Bad', severity: 'error' }],
+      });
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it('isValid is true when contextErrors contain only warnings', () => {
+      const { result } = renderDraft({
+        validate: alwaysValid,
+        contextErrors: [{ field: 'city', message: 'Consider changing', severity: 'warning' }],
+      });
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe('errorsFor() filtering', () => {
+    const errors: FieldError[] = [
+      { field: 'address', message: 'Address incomplete' },
+      { field: 'address.city', message: 'City required' },
+      { field: 'address.postalCode', message: 'Invalid zip' },
+      { field: 'addressLine2', message: 'Too long' },
+    ];
+
+    it('matches exact field and dot-path children', () => {
+      const { result } = renderDraft({
+        validate: () => ({ valid: false, errors }),
+      });
+      const addressErrors = result.current.errorsFor('address');
+      expect(addressErrors).toHaveLength(3);
+      expect(addressErrors.map((e) => e.field)).toEqual([
+        'address',
+        'address.city',
+        'address.postalCode',
+      ]);
+    });
+
+    it('does not match similar-prefix fields', () => {
+      const { result } = renderDraft({
+        validate: () => ({ valid: false, errors }),
+      });
+      const addressErrors = result.current.errorsFor('address');
+      expect(addressErrors.map((e) => e.field)).not.toContain('addressLine2');
+    });
+
+    it('returns empty array when no errors match', () => {
+      const { result } = renderDraft();
+      expect(result.current.errorsFor('nonexistent')).toEqual([]);
+    });
+  });
+
+  describe('warning severity', () => {
+    const warningValidator: Validator<TestAddress> = () => ({
+      valid: true,
+      errors: [{ field: 'postalCode', message: 'Unusual format', severity: 'warning' }],
+    });
+
+    it('warning appears in allErrors', () => {
+      const { result } = renderDraft({ validate: warningValidator });
+      expect(result.current.allErrors).toHaveLength(1);
+      expect(result.current.allErrors[0]?.severity).toBe('warning');
+    });
+
+    it('warning does not block confirm (isValid remains true)', () => {
+      const onConfirm = vi.fn();
+      const { result } = renderDraft({ validate: warningValidator, onConfirm });
+      act(() => result.current.update({ ...VALID_ADDRESS, city: 'New' }));
+      act(() => result.current.confirm());
+      expect(result.current.isValid).toBe(true);
+      expect(onConfirm).toHaveBeenCalled();
+      expect(result.current.phase).toBe('confirming');
+    });
+
+    it('error severity (default) blocks confirm', () => {
+      const onConfirm = vi.fn();
+      const { result } = renderDraft({ onConfirm, initialValue: EMPTY_ADDRESS });
+      act(() => result.current.confirm());
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe('error');
+    });
+  });
+});

--- a/src/types/canary/utilities/use-draft.ts
+++ b/src/types/canary/utilities/use-draft.ts
@@ -1,0 +1,165 @@
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import type { FieldError, ValidationResult, Validator, EditPhase } from './edit-lifecycle';
+import { setNestedField } from './set-nested-field';
+
+export interface UseDraftOptions<T> {
+  /** Initial value — resets the draft when this value changes. */
+  initialValue: T;
+  /** Intrinsic validator — called on every draft change. */
+  validate: Validator<T>;
+  /** Contextual errors from parent — merged into the validation display. */
+  contextErrors?: FieldError[];
+  /** Lifecycle callbacks — forwarded from EditableComponentProps. */
+  onChange?: (value: T, validation: ValidationResult) => void;
+  onConfirm?: (value: T) => void;
+  onCancel?: () => void;
+  /**
+   * Custom equality check for initialValue. When provided, draft resets
+   * only when isEqual returns false. When omitted, uses reference equality
+   * (Object.is) — callers must memoize initialValue to prevent unwanted resets.
+   */
+  isEqual?: (a: T, b: T) => boolean;
+}
+
+export interface DraftState<T> {
+  /** Current draft value. */
+  value: T;
+  /** Intrinsic validation result of the current draft. */
+  intrinsicValidation: ValidationResult;
+  /** All errors: intrinsic + contextual, for display. */
+  allErrors: FieldError[];
+  /** Whether the draft differs from initialValue. */
+  dirty: boolean;
+  /** Whether the draft is valid (intrinsic + no contextual error-severity errors). */
+  isValid: boolean;
+  /** Current lifecycle phase. */
+  phase: EditPhase;
+
+  /** Update the draft. Runs validation and notifies parent via onChange. */
+  update: (updater: T | ((prev: T) => T)) => void;
+  /** Update a single field by dot-path. */
+  updateField: (path: string, value: unknown) => void;
+  /** Confirm the draft. Calls onConfirm if valid. */
+  confirm: () => void;
+  /** Cancel the edit. Resets draft to initialValue and calls onCancel. */
+  cancel: () => void;
+  /** Reset draft to initialValue without calling onCancel. */
+  reset: () => void;
+  /** Get errors for a specific field (for rendering inline errors). */
+  errorsFor: (field: string) => FieldError[];
+}
+
+function hasBlockingErrors(errors: FieldError[]): boolean {
+  return errors.some((e) => e.severity !== 'warning');
+}
+
+/**
+ * Manages draft state, validation, and lifecycle for an editable component.
+ *
+ * Key behaviors:
+ * - Resets draft when `initialValue` changes (uses `isEqual` or `Object.is`)
+ * - Runs `validate()` on every `update()`/`updateField()` call
+ * - Merges `contextErrors` into `allErrors`
+ * - `confirm()` only succeeds if `isValid` is true
+ * - `errorsFor(field)` filters by exact match or dot-path prefix
+ */
+export function useDraft<T>(options: UseDraftOptions<T>): DraftState<T> {
+  const { initialValue, validate, contextErrors, onChange, onConfirm, onCancel, isEqual } = options;
+
+  const [value, setValue] = useState<T>(initialValue);
+  const [phase, setPhase] = useState<EditPhase>('idle');
+
+  // Track initial value for reset detection
+  const prevInitialRef = useRef(initialValue);
+
+  // Reset when initialValue changes
+  useEffect(() => {
+    const prev = prevInitialRef.current;
+    const equal = isEqual ? isEqual(prev, initialValue) : Object.is(prev, initialValue);
+    if (!equal) {
+      prevInitialRef.current = initialValue;
+      setValue(initialValue);
+      setPhase('idle');
+    }
+  }, [initialValue, isEqual]);
+
+  const intrinsicValidation = useMemo(() => validate(value), [validate, value]);
+
+  const contextErrorsList = contextErrors ?? [];
+
+  const allErrors = useMemo(
+    () => [...intrinsicValidation.errors, ...contextErrorsList],
+    [intrinsicValidation.errors, contextErrorsList],
+  );
+
+  const isValid = intrinsicValidation.valid && !hasBlockingErrors(contextErrorsList);
+
+  const dirty = !Object.is(value, initialValue);
+
+  const update = useCallback(
+    (updater: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const next = typeof updater === 'function' ? (updater as (prev: T) => T)(prev) : updater;
+        const validation = validate(next);
+        onChange?.(next, validation);
+        return next;
+      });
+      setPhase('editing');
+    },
+    [validate, onChange],
+  );
+
+  const updateField = useCallback(
+    (path: string, fieldValue: unknown) => {
+      setValue((prev) => {
+        const next = setNestedField(prev, path, fieldValue);
+        const validation = validate(next);
+        onChange?.(next, validation);
+        return next;
+      });
+      setPhase('editing');
+    },
+    [validate, onChange],
+  );
+
+  const confirm = useCallback(() => {
+    if (isValid) {
+      onConfirm?.(value);
+      setPhase('confirming');
+    } else {
+      setPhase('error');
+    }
+  }, [isValid, value, onConfirm]);
+
+  const cancel = useCallback(() => {
+    setValue(initialValue);
+    setPhase('idle');
+    onCancel?.();
+  }, [initialValue, onCancel]);
+
+  const reset = useCallback(() => {
+    setValue(initialValue);
+    setPhase('idle');
+  }, [initialValue]);
+
+  const errorsFor = useCallback(
+    (field: string): FieldError[] =>
+      allErrors.filter((e) => e.field === field || e.field.startsWith(field + '.')),
+    [allErrors],
+  );
+
+  return {
+    value,
+    intrinsicValidation,
+    allErrors,
+    dirty,
+    isValid,
+    phase,
+    update,
+    updateField,
+    confirm,
+    cancel,
+    reset,
+    errorsFor,
+  };
+}


### PR DESCRIPTION
## Summary

- **Edit Lifecycle framework** — `FieldError`, `ValidationResult`, `Validator<T>`, `EditPhase`, `EditLifecycleCallbacks<T>`, `EditableComponentProps<T>` types; `useDraft<T>` hook with 4-phase state machine; `setNestedField` immutable utility. 52 new tests.
- **Image component updates** — `ImageUploadDialog` indeterminate progress (FD-04) + `UploadError` phase with retry/discard; `ImageCellEditor` factory with required typed hooks (FD-15); `ImageFormField` contextErrors + initialValue; `ItemGridLookups` expanded to 9 fields; `ItemGridEditorHooks` interface.
- **CORS canvas support** — `crossOrigin="use-credentials"` on `ImagePreviewEditor` for CDN images (FD-17, requires infrastructure#439).
- **CHANGELOG 4.8.0** — Added, Changed, Deprecated entries.

## Test plan

- [ ] 1271 unit tests pass (`make test`)
- [ ] Lint + typecheck clean (`make check`)
- [ ] Storybook build succeeds (`make build`)
- [ ] Library build succeeds (`make build-lib`)
- [ ] No `@tanstack` imports in `src/` (FD-01 compliance)
- [ ] Verify `canary.d.ts` and `types-canary.d.ts` include lifecycle exports after publish

> [!note]
> Authored by Claude Code for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)