### PR TITLE
fix: republish 4.9.1 with ColorPicker export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.9.1] - 2026-04-09
+
+### Fixed
+
+- Republish: `ColorPicker` export was missing from 4.9.0 due to publish race
+  condition (package was published before the export PR merged).
+
 ## [4.9.0] - 2026-04-08
 ### Added
 

--- a/src/canary.ts
+++ b/src/canary.ts
@@ -224,6 +224,10 @@ export type {
 export { CopyrightAcknowledgment } from './components/canary/atoms/copyright-acknowledgment';
 export type { CopyrightAcknowledgmentProps } from './components/canary/atoms/copyright-acknowledgment';
 
+// Atoms: ColorPicker
+export { ColorPicker, getColorHex } from './components/canary/atoms/color-picker/color-picker';
+export type { ColorPickerProps } from './components/canary/atoms/color-picker/color-picker';
+
 // Cell atoms: action
 export { ActionCellRenderer } from './components/canary/atoms/grid/action';
 export type {

--- a/src/docs/workflows/using-the-design-system.mdx
+++ b/src/docs/workflows/using-the-design-system.mdx
@@ -503,7 +503,7 @@ Each entry point ships as ESM (`.js`), CJS (`.cjs`), and TypeScript declarations
   <tbody>
     <tr>
       <td>Utilities and Types</td>
-      <td><code>getInitials</code>, <code>getCroppedImage</code></td>
+      <td><code>getInitials</code>, <code>getCroppedImage</code>, <code>setNestedField</code>, <code>useDraft</code></td>
     </tr>
     <tr>
       <td>Atoms</td>
@@ -589,7 +589,7 @@ Each entry point ships as ESM (`.js`), CJS (`.cjs`), and TypeScript declarations
   <tbody>
     <tr>
       <td>Components</td>
-      <td><code>cn</code></td>
+      <td><code>cn</code>, <code>setNestedField</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- Bump version to 4.9.1 to trigger a republish
- 4.9.0 was published before the ColorPicker export PR (#85) merged, so the published package was missing the `ColorPicker` and `getColorHex` exports

## Test plan
- [ ] Verify 4.9.1 publishes successfully
- [ ] Verify `ColorPicker` is in the canary exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)