### PR TITLE
Add Pull Request Upkeep workflow

### DIFF
--- a/.github/workflows/pull_request_upkeep.yml
+++ b/.github/workflows/pull_request_upkeep.yml
@@ -1,0 +1,18 @@
+name: Pull Request Upkeep
+
+on:
+  pull_request:
+    types: [ opened ]
+
+permissions: { }
+
+jobs:
+  upkeep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Arda-cards/pull-request-setup-action@v1
+        with:
+          iteration_field_name: "Iteration"
+          project_title: "${{ vars.ARDA_CLOUD_PROJECT_NAME }}"
+          pull_request_number: "${{ github.event.pull_request.number }}"
+          token: "${{ secrets.ARDA_GH_ACTION_PROJECT_WRITER }}"

--- a/.github/workflows/pull_request_upkeep.yml
+++ b/.github/workflows/pull_request_upkeep.yml
@@ -2,9 +2,9 @@ name: Pull Request Upkeep
 
 on:
   pull_request:
-    types: [ opened ]
+    types: [opened]
 
-permissions: { }
+permissions: {}
 
 jobs:
   upkeep:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.10.0] - 2026-04-08
+
+### Added
+
+- Pull Request Upkeep workflow to auto-assign new PRs to the GitHub Project
+  board with the current iteration, matching arda-frontend-app and
+  accounts-component conventions
+
 ## [4.9.0] - 2026-04-08
 ### Added
 


### PR DESCRIPTION
## Summary

- Adds `pull_request_upkeep.yml` workflow that auto-assigns new PRs to the GitHub Project board with the current iteration
- Brings ux-prototype in line with arda-frontend-app and accounts-component conventions

## Prerequisites

The repo needs `ARDA_CLOUD_PROJECT_NAME` variable and `ARDA_GH_ACTION_PROJECT_WRITER` secret configured (likely already available at org level).

## Test plan

- [ ] Verify `ARDA_CLOUD_PROJECT_NAME` var and `ARDA_GH_ACTION_PROJECT_WRITER` secret are available to this repo
- [ ] Confirm this PR itself triggers the upkeep workflow on open
- [ ] Check that future PRs are auto-assigned to the project board

> [!note]
> Authored by Claude Code for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)