### PR TITLE
fix: pin TypeScript to ~5.9.3 — TS 6.0 breaks type exports (4.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.11.2] - 2026-04-10
+
+### Fixed
+
+- Pin TypeScript to ~5.9.3 — TypeScript 6.0 causes `vite-plugin-dts` to
+  produce empty `.d.ts` files due to TS2882 errors on CSS side-effect
+  imports, breaking all type exports from the published package.
+
 ## [4.11.1] - 2026-04-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "storybook": "^10.3.1",
         "tailwindcss": "^4.1.7",
         "tw-animate-css": "^1.4.0",
-        "typescript": "6.0.2",
+        "typescript": "~5.9.3",
         "vite": "^6.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.2",
@@ -2527,20 +2527,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
@@ -15761,9 +15747,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "storybook": "^10.3.1",
     "tailwindcss": "^4.1.7",
     "tw-animate-css": "^1.4.0",
-    "typescript": "6.0.2",
+    "typescript": "~5.9.3",
     "vite": "^6.0.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.2",


### PR DESCRIPTION
## Summary

- Pin TypeScript from `6.0.2` back to `~5.9.3` to fix empty `.d.ts` files in the published package.

### Root Cause

TypeScript 6.0 introduced TS2882 as an error for CSS side-effect imports (`import './button.css'`) that lack type declarations. With `vite-plugin-dts` configured with `rollupTypes: true`, these errors cause the declaration rollup to fail silently, producing empty `.d.ts` files (`export { }`). This broke all type exports from `@arda-cards/design-system` starting with 4.11.1.

### Impact

- `@arda-cards/design-system@4.11.1` shipped with empty `canary.d.ts` — consumers importing any canary component (e.g., `ReadOnlyField`, `ItemCardEditor`) get TypeScript errors
- Blocks `arda-frontend-app` PR #742 (build fails on `ReadOnlyField` import)

### Verification

After this fix, `make build-lib` produces `canary.d.ts` with 2605 lines (vs 1 line with TS 6.0), including all expected exports.

## Test plan

- [x] `make check` (lint + typecheck) passes
- [x] `make test` — 1285 tests pass
- [x] `make build-lib` — `canary.d.ts` contains `ReadOnlyField` and all other type exports
- [x] CHANGELOG validated (clq)
- [ ] CI pipeline passes
- [ ] Package publishes as 4.11.2 after merge

> [!note]
> Authored by Claude Code for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)"