### PR TITLE
fix(canary/dialog): wire edit-existing crop/rotate into upload path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.11.4] - 2026-04-14
+
+### Fixed
+
+- Wire `getCroppedImage` result into the upload path in `ImageUploadDialog`
+  edit-existing flow. Previously the cropped blob was discarded and the
+  original URL was confirmed unchanged (`skipUpload: true`). Now: if
+  crop/rotate produced a blob, it is uploaded as a new image; the new CDN
+  URL is returned via `onConfirm`. Falls back to original URL only if
+  canvas crop fails (e.g. CORS taint on non-production origins).
+
 ## [4.11.3] - 2026-04-14
 
 ### Fixed

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.test.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.test.tsx
@@ -35,6 +35,20 @@ vi.mock('@/components/canary/molecules/image-preview-editor/image-preview-editor
       >
         crop
       </button>
+      <button
+        onClick={() =>
+          onCropChange({ pixelCrop: { x: 0, y: 0, width: 0, height: 0 }, zoom: 1, rotation: 90 })
+        }
+      >
+        rotate
+      </button>
+      <button
+        onClick={() =>
+          onCropChange({ pixelCrop: { x: 0, y: 0, width: 0, height: 0 }, zoom: 2, rotation: 0 })
+        }
+      >
+        zoom
+      </button>
       <button onClick={onReset}>reset</button>
     </div>
   ),
@@ -412,17 +426,106 @@ describe('ImageUploadDialog', () => {
       });
     });
 
-    it('"Confirm" in EditExisting calls onConfirm with existing URL (no upload)', async () => {
+    it('"Accept" without edits confirms with existing URL (skipUpload)', async () => {
       const onConfirm = vi.fn();
       renderDialog({ existingImageUrl: EXISTING_URL, onConfirm });
 
+      // Don't crop/rotate — just accept immediately
       await act(async () => {
         fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
         await Promise.resolve();
       });
 
       await waitFor(() => {
-        // String imageData bypasses upload — confirms directly with the URL
+        expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ imageUrl: EXISTING_URL }));
+      });
+    });
+
+    it('"Accept" after crop uploads cropped blob and returns new URL', async () => {
+      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/cropped-new.jpg');
+      const onConfirm = vi.fn();
+      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm, onUpload });
+
+      // Simulate crop edit (non-zero pixelCrop)
+      fireEvent.click(screen.getByText('crop'));
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(onUpload).toHaveBeenCalledWith(expect.any(Blob));
+        expect(onConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: 'https://cdn.example.com/cropped-new.jpg' }),
+        );
+      });
+    });
+
+    it('"Accept" after rotate-only uploads rotated blob (not skipUpload)', async () => {
+      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/rotated-new.jpg');
+      const onConfirm = vi.fn();
+      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm, onUpload });
+
+      // Simulate rotation-only edit (zero pixelCrop, rotation=90)
+      fireEvent.click(screen.getByText('rotate'));
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(onUpload).toHaveBeenCalledWith(expect.any(Blob));
+        expect(onConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: 'https://cdn.example.com/rotated-new.jpg' }),
+        );
+      });
+    });
+
+    it('"Accept" after zoom-only uploads zoomed blob (not skipUpload)', async () => {
+      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/zoomed-new.jpg');
+      const onConfirm = vi.fn();
+      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm, onUpload });
+
+      // Simulate zoom-only edit (zero pixelCrop, zoom=2)
+      fireEvent.click(screen.getByText('zoom'));
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(onUpload).toHaveBeenCalledWith(expect.any(Blob));
+        expect(onConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: 'https://cdn.example.com/zoomed-new.jpg' }),
+        );
+      });
+    });
+
+    it('"Accept" falls back to original URL when getCroppedImage fails', async () => {
+      const { getCroppedImage } = await import('@/types/canary/utilities/get-cropped-image');
+      (getCroppedImage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('CORS taint'));
+      const onConfirm = vi.fn();
+      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm });
+
+      // Simulate crop edit
+      fireEvent.click(screen.getByText('crop'));
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        // Falls back to original URL (skipUpload path)
         expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ imageUrl: EXISTING_URL }));
       });
     });

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
@@ -92,7 +92,7 @@ type DialogAction =
   | { type: 'UPLOAD_DISCARD' }
   | { type: 'WARN_DISCARD' }
   | { type: 'WARN_GO_BACK' }
-  | { type: 'EDIT_CONFIRM' }
+  | { type: 'EDIT_CONFIRM'; croppedBlob?: Blob }
   | { type: 'UPLOAD_NEW' }
   | { type: 'RESET'; existingImageUrl: string | null };
 
@@ -144,6 +144,11 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
     }
     case 'EDIT_CONFIRM': {
       if (state.name === 'EditExisting') {
+        // If the action carries a cropped blob, upload it as a new image.
+        // If no blob (crop failed or no edits), confirm with the original URL.
+        if (action.croppedBlob) {
+          return { name: 'Uploading', imageData: action.croppedBlob };
+        }
         return { name: 'Uploading', imageData: state.imageUrl, skipUpload: true };
       }
       return state;
@@ -285,17 +290,39 @@ export function ImageUploadDialog({
     if (phase.name !== 'EditExisting') return;
     const cropData = cropDataRef.current as {
       pixelCrop: { x: number; y: number; width: number; height: number };
+      zoom?: number;
       rotation?: number;
     } | null;
-    if (cropData !== null && cropData.pixelCrop.width > 0 && cropData.pixelCrop.height > 0) {
+
+    // Determine if the user made any edits (crop, rotate, or zoom).
+    // Rotate/zoom handlers in ImagePreviewEditor fire onCropChange with a
+    // zero-sized pixelCrop, so we can't rely on pixelCrop alone — also
+    // check rotation and zoom.
+    const hasCropArea =
+      cropData !== null && cropData.pixelCrop.width > 0 && cropData.pixelCrop.height > 0;
+    const hasRotation = cropData !== null && (cropData.rotation ?? 0) !== 0;
+    const hasZoom = cropData !== null && (cropData.zoom ?? 1) !== 1;
+    const hasEdits = hasCropArea || hasRotation || hasZoom;
+
+    if (hasEdits && cropData !== null) {
       try {
-        await getCroppedImage(phase.imageUrl, cropData.pixelCrop, cropData.rotation ?? 0);
-        // getCroppedImage result is not used directly — the upload effect handles the imageData
-        // from the EDIT_CONFIRM transition which passes the original URL as imageData
+        // getCroppedImage handles zero-sized pixelCrop (rotate/zoom-only
+        // edits) by using the full rotated canvas as the crop area.
+        const croppedBlob = await getCroppedImage(
+          phase.imageUrl,
+          cropData.pixelCrop,
+          cropData.rotation ?? 0,
+        );
+        // Upload the cropped/rotated image as a new file. The upload effect
+        // will call onUpload(blob) → S3 → return the new CDN URL.
+        dispatch({ type: 'EDIT_CONFIRM', croppedBlob });
+        return;
       } catch {
-        // Fall back to original URL if cropping fails
+        // Canvas crop failed (e.g. CORS taint on localhost without CloudFront
+        // CORS). Fall through to confirm with the original URL unchanged.
       }
     }
+    // No edits or crop failed — confirm with the original URL as-is.
     dispatch({ type: 'EDIT_CONFIRM' });
   }, [phase]);
 

--- a/src/types/canary/utilities/get-cropped-image.ts
+++ b/src/types/canary/utilities/get-cropped-image.ts
@@ -32,23 +32,29 @@ export async function getCroppedImage(
   ctx.translate(-image.width / 2, -image.height / 2);
   ctx.drawImage(image, 0, 0);
 
-  // Extract the crop region
+  // Extract the crop region. When pixelCrop has zero dimensions (rotate-only
+  // or zoom-only edit), use the full rotated canvas as the crop area.
+  const effectiveCrop =
+    pixelCrop.width > 0 && pixelCrop.height > 0
+      ? pixelCrop
+      : { x: 0, y: 0, width: bBoxWidth, height: bBoxHeight };
+
   const croppedCanvas = document.createElement('canvas');
   const croppedCtx = croppedCanvas.getContext('2d');
   if (!croppedCtx) throw new Error('Failed to obtain 2D canvas context for crop');
-  croppedCanvas.width = pixelCrop.width;
-  croppedCanvas.height = pixelCrop.height;
+  croppedCanvas.width = effectiveCrop.width;
+  croppedCanvas.height = effectiveCrop.height;
 
   croppedCtx.drawImage(
     canvas,
-    pixelCrop.x,
-    pixelCrop.y,
-    pixelCrop.width,
-    pixelCrop.height,
+    effectiveCrop.x,
+    effectiveCrop.y,
+    effectiveCrop.width,
+    effectiveCrop.height,
     0,
     0,
-    pixelCrop.width,
-    pixelCrop.height,
+    effectiveCrop.width,
+    effectiveCrop.height,
   );
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Fix: `handleEditConfirm` in `ImageUploadDialog` discarded the `getCroppedImage` blob and confirmed with the original URL unchanged (`skipUpload: true`). Crop, rotate, and zoom edits in edit-existing mode were silently lost.
- Now: cropped blob is uploaded as a new image; new CDN URL returned via `onConfirm`. Falls back to original URL only if canvas crop fails.

## Test plan

- [ ] `make check` passes
- [ ] `make test` — all vitest tests pass
- [ ] Manual: open edit dialog on existing image → rotate → Accept → grid cell updates with new (rotated) image

> [!note]
> Authored by Claude Code for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)