### PR TITLE
ci: add preview publish + cleanup workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,22 @@ jobs:
         with:
           mode: test
           tag: ${{ steps.clq-extract.outputs.tag }}
+      - name: Reject pre-release on PR to a release branch
+        if: |
+          github.event_name == 'pull_request'
+          && steps.changelog-check.outputs.modified == 'true'
+          && steps.clq-extract.outputs.status != 'released'
+        env:
+          TAG: ${{ steps.clq-extract.outputs.tag }}
+        run: |
+          {
+            echo "## Version Validation Error"
+            echo "PRs to a release branch must use a stable version, not a pre-release."
+            echo "Got: \`${TAG}\`"
+            echo "Swap the changelog entry to a stable \`x.y.z\` version before merging."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::PRs to a release branch require a stable version (got: ${TAG})"
+          exit 1
 
   tag:
     if: github.event_name == 'push' && needs.validate-release.outputs.changelog-modified == 'true'

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,124 @@
+---
+name: Cleanup Preview Versions
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List candidates without deleting'
+        type: boolean
+        default: true
+
+permissions: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    env:
+      ORG: Arda-cards
+      PACKAGE: design-system
+      RETENTION: 3
+      GRACE_HOURS: 24
+      # Default to dry-run for scheduled runs unless explicitly disabled via dispatch
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+    steps:
+      - name: Fetch all package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "/orgs/${ORG}/packages/npm/${PACKAGE}/versions" --paginate \
+            | jq -s 'add' > all-versions.json
+          echo "Fetched $(jq 'length' all-versions.json) versions total"
+
+      - name: Compute deletion candidates
+        run: |
+          NOW_EPOCH="$(date -u +%s)"
+
+          jq \
+            --argjson retention "$RETENTION" \
+            --argjson grace_hours "$GRACE_HOURS" \
+            --argjson now "$NOW_EPOCH" \
+            '
+            # Tag a version as preview if name matches X.Y.Z-<series>-<numeric uid>
+            def tag_preview:
+              if (.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+-.+-[0-9]+$")) then
+                . + (.name | capture("^(?<base>[0-9]+\\.[0-9]+\\.[0-9]+)-(?<series>.+)-(?<uid>[0-9]+)$"))
+                  + {is_preview: true}
+              # Stable: pure X.Y.Z
+              elif (.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) then
+                . + {is_preview: false, base: .name}
+              # Anything else (e.g. unrelated pre-release format) — leave alone
+              else
+                . + {is_preview: null}
+              end;
+
+            map(tag_preview) as $all
+            | ($all | map(select(.is_preview == false) | .base) | unique) as $stable_bases
+            | ($all | map(select(.is_preview == true))) as $previews
+
+            # Pass 1: previews whose stable base shipped → obsolete
+            | ($previews | map(select(.base as $b | $stable_bases | index($b)))) as $obsolete
+
+            # Pass 2: active series (stable not yet shipped) → keep top N by uid
+            | ($previews | map(select(.base as $b | $stable_bases | index($b) | not))) as $active
+            | ($active
+                | group_by(.base + "|" + .series)
+                | map(sort_by(.uid | tonumber) | reverse | .[$retention:])
+                | flatten) as $excess
+
+            # Combine, dedupe, apply grace period, and sanity-check is_preview
+            | ($obsolete + $excess)
+            | unique_by(.id)
+            | map(select(.is_preview == true))
+            | map(select(($now - ((.created_at | fromdate))) > ($grace_hours * 3600)))
+            | .[] | [.id, .name] | @tsv
+            ' all-versions.json > to-delete.tsv
+
+          COUNT="$(wc -l < to-delete.tsv | tr -d ' ')"
+          echo "Marked ${COUNT} version(s) for deletion"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "----- DELETION CANDIDATES -----"
+            cat to-delete.tsv
+            echo "-------------------------------"
+          fi
+
+      - name: Safety check — refuse to delete stable versions
+        run: |
+          # Any candidate whose name does NOT contain a "-" would be a stable version
+          if awk -F'\t' '$2 !~ /-/' to-delete.tsv | grep -q .; then
+            echo "::error::Candidate list contains stable versions (no pre-release suffix). Refusing to proceed."
+            awk -F'\t' '$2 !~ /-/' to-delete.tsv
+            exit 1
+          fi
+          # Any candidate whose name does not end in -<digits> isn't one of ours
+          if awk -F'\t' '$2 !~ /-[0-9]+$/' to-delete.tsv | grep -q .; then
+            echo "::error::Candidate list contains versions not matching our preview UID format. Refusing to proceed."
+            awk -F'\t' '$2 !~ /-[0-9]+$/' to-delete.tsv
+            exit 1
+          fi
+
+      - name: Delete versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY_RUN=true — no deletions performed"
+            exit 0
+          fi
+
+          if [ ! -s to-delete.tsv ]; then
+            echo "Nothing to delete"
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r id name; do
+            echo "Deleting ${name} (id=${id})"
+            gh api -X DELETE "/orgs/${ORG}/packages/npm/${PACKAGE}/versions/${id}"
+          done < to-delete.tsv
+
+          echo "::notice::Deleted $(wc -l < to-delete.tsv | tr -d ' ') version(s)"

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -24,7 +24,7 @@ jobs:
       PACKAGE: design-system
       RETENTION: 3
       GRACE_HOURS: 24
-      # Default to dry-run for scheduled runs unless explicitly disabled via dispatch
+      # Manual dispatch defaults to dry-run for safety; scheduled runs perform real deletions
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
     steps:
       - name: Fetch all package versions

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,95 @@
+---
+name: Publish Preview to GitHub Packages
+
+on:
+  push:
+    branches-ignore: [main]
+
+permissions: {}
+
+jobs:
+  publish-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if CHANGELOG.md was modified
+        id: changelog-check
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            DIFF_RANGE="origin/main...HEAD"
+          else
+            DIFF_RANGE="${BEFORE_SHA}..HEAD"
+          fi
+          if git diff --name-only "$DIFF_RANGE" | grep -q '^CHANGELOG.md$'; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "modified=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CHANGELOG.md not modified — skipping preview publish"
+          fi
+
+      - name: Extract version from changelog
+        if: steps.changelog-check.outputs.modified == 'true'
+        uses: denisa/clq-action@v1
+        id: clq-extract
+        with:
+          changeMap: .github/clq/changemap.json
+
+      - name: Validate pre-release and derive dist-tag
+        if: steps.changelog-check.outputs.modified == 'true'
+        id: prerelease
+        env:
+          TAG: ${{ steps.clq-extract.outputs.tag }}
+          STATUS: ${{ steps.clq-extract.outputs.status }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          BASE="${TAG#v}"
+
+          if [ "$STATUS" != "prereleased" ]; then
+            echo "::notice::Changelog version ${BASE} is not a pre-release — skipping (stable releases publish from main)"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DIST_TAG="${BASE#*-}"
+          if [ "$BASE" = "$DIST_TAG" ]; then
+            echo "::error::Pre-release status detected but no pre-release identifier in version ${BASE}"
+            exit 1
+          fi
+
+          VERSION="${BASE}-${RUN_NUMBER}"
+
+          echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${VERSION} with dist-tag '${DIST_TAG}'"
+
+      - uses: actions/setup-node@v6
+        if: steps.prerelease.outputs.is_prerelease == 'true'
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: '@arda-cards'
+
+      - if: steps.prerelease.outputs.is_prerelease == 'true'
+        run: npm ci
+
+      - name: Set package version
+        if: steps.prerelease.outputs.is_prerelease == 'true'
+        run: npm version "${{ steps.prerelease.outputs.version }}" --no-git-tag-version
+
+      - if: steps.prerelease.outputs.is_prerelease == 'true'
+        run: npm run build:lib
+
+      - name: Publish with dist-tag
+        if: steps.prerelease.outputs.is_prerelease == 'true'
+        run: npm publish --tag "${{ steps.prerelease.outputs.dist_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches-ignore: [main]
 
+# Cancel any in-flight publish for the same branch — last push wins, dist-tag
+# always points at the newest code rather than a slow-finishing older run.
+concurrency:
+  group: publish-preview-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [5.1.0-jmpicnic-preview-enablement] - 2026-04-15
+## [5.1.0] - 2026-04-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   trims active series to the last 3 versions per dist-tag. Includes safety
   guards: never deletes stable versions, applies a 24h grace period since
   publish, and refuses to proceed if candidates fail the preview pattern.
+- Storybook docs: `src/docs/workflows/preview-publishing.mdx` brief
+  operational summary of the new preview publish + cleanup flows, with a
+  link to the canonical integration contract in the documentation site
+  (`https://arda-cards.github.io/documentation/process/design-system-integration/`).
 
 ## [5.0.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [5.1.0-jmpicnic-preview-enablement] - 2026-04-15
+
+### Added
+
+- `publish-preview.yml` workflow publishes pre-release versions to GitHub
+  Packages from any branch when CHANGELOG.md is modified with a pre-release
+  version like `x.y.z-<author>-<id>`. Each push appends `github.run_number`
+  for uniqueness; consumers install via the dist-tag derived from the
+  changelog (e.g. `npm install @arda-cards/design-system@<author>-<id>`).
+  Stable releases continue to publish only from `main` via `publish.yml`.
+- `cleanup-preview.yml` workflow (daily 03:00 UTC cron, plus manual
+  dispatch with dry-run default) removes obsolete preview versions from
+  GitHub Packages: marks any preview whose stable base has shipped, and
+  trims active series to the last 3 versions per dist-tag. Includes safety
+  guards: never deletes stable versions, applies a 24h grace period since
+  publish, and refuses to proceed if candidates fail the preview pattern.
+
 ## [5.0.0] - 2026-04-15
 
 ### Changed
@@ -91,7 +108,6 @@ migration pattern.
   => Promise<string>` prop; if the host hasn't supplied a handler, the
   dialog dispatches `UPLOAD_ERROR` with "URL upload not supported"
   instead of silently uploading empty bytes.
-
 ## [4.11.5] - 2026-04-14
 
 ### Fixed

--- a/src/docs/workflows/preview-publishing.mdx
+++ b/src/docs/workflows/preview-publishing.mdx
@@ -1,0 +1,81 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Workflows/Preview Publishing" />
+
+# Preview Publishing
+
+`@arda-cards/design-system` supports publishing **preview** versions from any branch, in addition to stable releases from `main`. This page is a brief operational summary; for the full integration contract (consumer setup, cleanup, all workflows), see the canonical doc:
+
+📖 **[Design System Integration — full reference](https://arda-cards.github.io/documentation/process/design-system-integration/)**
+
+## What gets published, when
+
+| Workflow file | Trigger | What it publishes | dist-tag |
+| --- | --- | --- | --- |
+| `publish.yml` | push to `main` | Stable release (e.g. `4.12.0`) | `latest` |
+| `publish-preview.yml` | push to any branch, when CHANGELOG.md is modified with a pre-release entry | Preview build (e.g. `4.12.0-alice-FD42-7`) | derived from changelog (e.g. `alice-FD42`) |
+| `cleanup-preview.yml` | daily 03:00 UTC + manual dispatch | (deletes obsolete preview versions) | n/a |
+
+## How to publish a preview
+
+1. Branch off `main`.
+2. Add a CHANGELOG.md entry with a **pre-release** version of the form `x.y.z-<author>-<id>`:
+
+   ```markdown
+   ## [4.12.0-alice-FD42] - 2026-04-15
+
+   ### Added
+
+   - Short description of the change.
+   ```
+
+3. Push. The `publish-preview.yml` workflow:
+   - Detects CHANGELOG.md was modified.
+   - Validates the entry is a CLQ pre-release (otherwise skips).
+   - Publishes `4.12.0-alice-FD42-<github.run_number>` with dist-tag `alice-FD42`.
+4. The dist-tag advances with every push that modifies CHANGELOG.md.
+
+## How to consume a preview
+
+In the consuming app (e.g. `arda-frontend-app`), once the package registry is configured:
+
+```bash
+npm install @arda-cards/design-system@alice-FD42
+```
+
+Re-running this command picks up the latest push in the `alice-FD42` series.
+
+When the design-system PR ships stable and the consumer is ready, swap to:
+
+```bash
+npm install @arda-cards/design-system@latest
+```
+
+## Before merging the design-system PR
+
+Swap the changelog entry from the pre-release form (`4.12.0-alice-FD42`) to a stable form (`4.12.0`). Otherwise:
+
+- The `validate-release` job in `ci.yml` will **fail** the PR — by design, to prevent merging a preview as stable.
+- `publish-preview.yml` will keep republishing on every push (you don't want this once the change is final).
+
+After the swap:
+
+- `validate-release` passes.
+- `publish-preview.yml` correctly skips (the entry is no longer a pre-release).
+- On merge, `publish.yml` ships the stable version.
+
+## Cleanup
+
+Preview versions accumulate in GitHub Packages. The `cleanup-preview.yml` workflow runs nightly and:
+
+- **Deletes obsolete previews**: any `4.12.x-*-*` once stable `4.12.x` has shipped.
+- **Trims active series** to the last 3 versions per dist-tag.
+- **Never deletes stable versions** (hard refused — workflow fails if a stable would be deleted).
+- **24h grace period** since publish, to protect in-flight CI runs.
+
+For the manual-dispatch dry-run mode and operating procedure, see the [reference page](https://arda-cards.github.io/documentation/process/design-system-integration/reference/#cleanup-contract) of the canonical doc.
+
+## See also
+
+- [Publishing](?path=/docs/docs-workflows-publishing--docs) — the older stable-only publishing doc (still relevant for the `latest` dist-tag flow).
+- [Canonical doc](https://arda-cards.github.io/documentation/process/design-system-integration/) — full integration contract including consumer-side setup, all four supported workflows, and the cleanup contract.


### PR DESCRIPTION
## Summary

Adds two new GitHub Actions workflows that enable publishing pre-release versions of `@arda-cards/design-system` from feature branches to GitHub Packages, periodic cleanup of accumulated pre-release versions, and tightens `validate-release` to reject pre-release versions on PRs to release branches.

### `publish-preview.yml`

Triggers on push to any branch except `main`. When the top CHANGELOG.md entry is a pre-release (CLQ status `prereleased`) — e.g. `## [4.12.0-jmpicnic-preview-enablement]` — the workflow:

1. Skips if CHANGELOG.md was not modified in the push (handles new-branch first push by diffing against `origin/main`)
2. Derives the npm dist-tag from the version (everything after the first `-`, e.g. `jmpicnic-preview-enablement`)
3. Appends `github.run_number` for guaranteed uniqueness across pushes (e.g. final version `4.12.0-jmpicnic-preview-enablement-487`)
4. Publishes via `npm publish --tag {dist-tag}` so `latest` is never touched

`concurrency` group keyed by `${{ github.ref }}` with `cancel-in-progress: true` ensures two quick pushes to the same branch don't leave the dist-tag pointing at older code.

Consumers install via:

```bash
npm install @arda-cards/design-system@{author}-{id}
```

Re-running the same command picks up the latest push in that series.

### `cleanup-preview.yml`

Runs daily at 03:00 UTC (and on-demand via `workflow_dispatch` with `dry_run` default true). Scans all package versions in GitHub Packages and:

- **Obsolete-stable pass**: marks any preview `{base}-{series}-{uid}` for deletion when stable `{base}` exists in the registry
- **Retention pass**: per `{base}-{series}` group, keeps last 3 versions, marks the rest for deletion
- **Safety guards**: refuses to delete any version without a pre-release suffix, refuses anything not matching the preview UID pattern, applies a 24h grace period since publish

### `ci.yml` — `validate-release` tightening

Adds a step that fails the `validate-release` job when, on a `pull_request` to a protected (release) branch, the changelog's top entry is a pre-release. Prevents merging a feature/preview version (e.g. `4.12.0-foo-bar`) to `main`. Mirrors the gate `operations` enforces via `Arda-cards/gradle-build-pipeline-action`. Push events to feature branches are unaffected.

## Test plan

- [x] CI passes on this branch (final commit `58d104b`)
- [x] `publish-preview.yml` runs on push and publishes preview versions:
  - `4.12.0-jmpicnic-preview-enablement-1` (initial push)
  - `4.12.0-jmpicnic-preview-enablement-3` (after merge with main)
  - dist-tag `jmpicnic-preview-enablement`
- [x] Package versions visible at https://github.com/Arda-cards/ux-prototype/pkgs/npm/design-system
- [x] `validate-release` correctly **rejected** the pre-release version (`12e70ad` push) and **accepts** the stable version (`58d104b` push)
- [ ] Manually dispatch `cleanup-preview.yml` with `dry_run=true` (recommended before the first scheduled cron at 2026-04-16 03:00 UTC)

> [!note]
> Authored by Claude Code for jmpicnic