### PR TITLE
feat: ImageUploader interface + Context provider (5.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [4.11.7] - 2026-04-15
+## [5.0.0] - 2026-04-15
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,51 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.11.7] - 2026-04-15
+
+### Changed
+
+- Image upload pipeline — consolidate three per-component callback props
+  (`onUpload`, `onUploadFromUrl`, `onCheckReachability`) into a single
+  `ImageUploader` interface consumed via React Context. Introduces the
+  new `<ImageUploadProvider value={uploader}>` component and
+  `useImageUploader()` hook; the default `defaultImageUploader` stub
+  (Storybook/dev parity) is returned when no provider is mounted.
+  Consumers no longer destructure three handlers from a bridge hook and
+  prop-drill them into every upload-capable component; instead they
+  mount one provider at the subtree root and components reach for the
+  uploader internally. Hard break — the three per-callback props are
+  removed from `ImageUploadDialog` and `ItemCardEditor`
+  (arda-frontend-app is the only known consumer and migrates in the
+  same release).
+- `ImageUploadDialog`: state-machine flow for new uploads skips the
+  cropper/review step entirely — file and URL inputs now land directly
+  in `Uploading` (rapid-batch UX, completing the product directive that
+  started on the card-side in 4.11.6). The cropper remains reachable
+  via the deliberate `EditExisting` path (user clicks "Click to
+  edit/replace" overlay on an already-placed image). The `ProvidedImage`
+  and `Warn` phases, the `CONFIRM_CLICK` / `WARN_DISCARD` /
+  `WARN_GO_BACK` actions, and the Warn alert-dialog render branch are
+  removed — they were the staging/review machinery for the dropped-but-
+  not-yet-uploaded case, which no longer exists.
+
+### Removed
+
+- `ImageUploadDialogRuntimeProps.onUpload` (was: `(file: Blob) => Promise<string>`,
+  default `defaultUploadHandler`).
+- `ImageUploadDialogRuntimeProps.onUploadFromUrl` (was: `(url: string) => Promise<string>`,
+  default `defaultUrlUploadHandler`).
+- `ImageUploadDialogRuntimeProps.onCheckReachability` (was: `(url: string) => Promise<boolean>`,
+  default `defaultReachabilityCheck`).
+- `ItemCardEditorRuntimeProps.onUpload`, `onUploadFromUrl`, and
+  `onCheckReachability` — same rationale.
+- `DialogPhase` variants `ProvidedImage` and `Warn`, and associated
+  reducer actions — unreachable after the state-machine change.
+
+All six removals are covered by mounting `<ImageUploadProvider>` once
+at the host; see `knowledge-base/component-abstractions.md` for the
+migration pattern.
+
 ## [4.11.6] - 2026-04-15
 
 ### Fixed

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -1,0 +1,23 @@
+# ux-prototype knowledge base
+
+Repo-specific notes, patterns, and anti-patterns accumulated while working
+in `ux-prototype`. Read relevant files before starting work; add to this
+directory when a pattern or gotcha is worth preserving for future sessions.
+
+For generic React/TypeScript component-design principles that apply across
+Arda repos, see the `clean-components` skill at
+`.claude/skills/clean-components/SKILL.md`.
+
+## Index
+
+| File | When to read |
+|------|--------------|
+| [component-abstractions.md](./component-abstractions.md) | Designing or reviewing public component APIs — callback props, controllers, Context providers |
+| [typed-test-mocks.md](./typed-test-mocks.md) | Writing vitest tests that mock interfaces |
+| [image-upload-architecture.md](./image-upload-architecture.md) | Touching ImageUploadDialog, ItemCardEditor, or the ImageUploader interface |
+
+## Iteration
+
+This KB is young — expect rules to sharpen as more patterns surface.
+Contribute by adding a new `.md` file (prefix the filename with the topic,
+keep content terse) and linking it from the Index above.

--- a/knowledge-base/component-abstractions.md
+++ b/knowledge-base/component-abstractions.md
@@ -37,7 +37,7 @@ Symptoms that triggered the refactor:
   places (card-side drop zone AND dialog state machine) because both
   components owned parallel upload implementations.
 
-### Pattern (4.11.7+)
+### Pattern (5.0.0+)
 
 Single interface + Context provider:
 
@@ -81,7 +81,7 @@ consumption sites.
 ## State-machine-owned cropping vs. consumer-owned cropping
 
 `ImageUploadDialog`'s `EditExisting` phase is the deliberate edit-
-existing-image path — the only place the cropper appears as of 4.11.7.
+existing-image path — the only place the cropper appears as of 5.0.0.
 New uploads (file or URL) skip the cropper entirely and go straight to
 the `Uploading` phase. The user can still crop *after* the upload by
 opening the dialog on the now-existing image.

--- a/knowledge-base/component-abstractions.md
+++ b/knowledge-base/component-abstractions.md
@@ -1,0 +1,106 @@
+# Component abstraction patterns (ux-prototype)
+
+Concrete `ux-prototype` examples of clean-component design — paired with
+specific commits and PRs so the lessons are traceable. For the general
+principles, see the `clean-components` skill
+(`.claude/skills/clean-components/SKILL.md`).
+
+## The "uploader" pattern: callback explosion → Context + interface
+
+### What it replaced (4.11.5 / 4.11.6)
+
+The `ItemCardEditor` and `ImageUploadDialog` components originally exposed
+upload semantics as three separate callback props:
+
+```tsx
+<ItemCardEditor
+  onUpload={handleUpload}                    // Blob → CDN URL
+  onUploadFromUrl={handleUploadFromUrl}      // URL → fetch + upload → CDN URL
+  onCheckReachability={handleCheckReachability} // URL → boolean
+  onUploadError={handleUploadError}          // Error → toast
+/>
+<ImageUploadDialog
+  onUpload={handleUpload}
+  onUploadFromUrl={handleUploadFromUrl}
+  onCheckReachability={handleCheckReachability}
+/>
+```
+
+Symptoms that triggered the refactor:
+
+- **Two call sites** (`ItemFormPanel.tsx`, `ItemTableAGGrid.tsx`)
+  destructured the same 3 handlers from the same bridge hook and
+  prop-drilled them individually.
+- **A bridge hook** (`useItemImageUploadDialog`) existed in the consumer
+  solely to reverse-engineer the shape the package expected.
+- **"Skip the cropper" product directive** had to be applied in two
+  places (card-side drop zone AND dialog state machine) because both
+  components owned parallel upload implementations.
+
+### Pattern (4.11.7+)
+
+Single interface + Context provider:
+
+```ts
+// Package exports
+interface ImageUploader {
+  uploadFile(file: Blob): Promise<string>;
+  uploadFromUrl(url: string): Promise<string>;
+  checkReachability(url: string): Promise<boolean>;
+}
+
+// Consumer
+function useItemImageUploader(): ImageUploader { /* compose TanStack hooks */ }
+
+// Call-site
+<ImageUploadProvider value={uploader}>
+  <ItemFormPanel />       {/* uses ItemCardEditor internally */}
+  <ItemsTable />          {/* uses ImageUploadDialog internally */}
+</ImageUploadProvider>
+```
+
+The package components call `useImageUploader()` internally; no per-callback
+prop threading. The app mounts one provider per subtree; no duplication at
+consumption sites.
+
+### What to carry forward
+
+- **Collapse 3+ related callbacks into one interface.** If the component
+  needs several async operations that are all facets of "upload this
+  image" or "resolve this entity" or similar, ship one controller.
+- **Default the Context.** `useImageUploader()` returns a stub uploader
+  when no provider is mounted, so Storybook stories and unit tests work
+  without a wrapper. Production use requires an explicit provider.
+- **Keep orthogonal concerns as props.** `onUploadError` (toast
+  side-effect) stayed as a prop on `ItemCardEditor` because it's the
+  *host's* side-effect, not part of the uploader's contract. Good rule
+  of thumb: if the consumer is doing something with the result, it's a
+  callback prop; if the component is asking for a capability, it's
+  on the interface.
+
+## State-machine-owned cropping vs. consumer-owned cropping
+
+`ImageUploadDialog`'s `EditExisting` phase is the deliberate edit-
+existing-image path — the only place the cropper appears as of 4.11.7.
+New uploads (file or URL) skip the cropper entirely and go straight to
+the `Uploading` phase. The user can still crop *after* the upload by
+opening the dialog on the now-existing image.
+
+Lesson: when product is explicit about "one flow should go through a
+step, one should skip it", encode that in the state machine's **phase
+transitions** (which paths touch `ProvidedImage`), not in conditional
+logic scattered across the component body.
+
+## Red flags specific to this repo
+
+- **A new callback prop being added to both `ItemCardEditor` and
+  `ImageUploadDialog`.** Unless the concern is genuinely orthogonal to
+  the uploader (like `onUploadError`), it belongs on `ImageUploader` so
+  only the interface grows, not every consumer.
+- **A Storybook story that has to set up mock upload handlers with
+  specific shapes.** Stories should mount the `ImageUploadProvider` with
+  a mock `ImageUploader` — or rely on the default stub if the visual
+  output of the stub is acceptable.
+- **Tests that pass `uploader as ImageUploader`.** See
+  [typed-test-mocks.md](./typed-test-mocks.md). The cast is almost
+  always a sign the mock type is wrong, not that the interface is.

--- a/knowledge-base/image-upload-architecture.md
+++ b/knowledge-base/image-upload-architecture.md
@@ -1,0 +1,106 @@
+# Image-upload architecture (ux-prototype, 4.11.7+)
+
+Quick-reference map of the components, types, and interaction patterns that
+make up the image-upload surface. Read before touching any of:
+`ImageUploadDialog`, `ItemCardEditor`, `ImageUploader`, `ImageUploadProvider`,
+`defaultImageUploader`.
+
+## Public surface
+
+Exported from `@arda-cards/design-system/canary`:
+
+| Name | Kind | Role |
+|------|------|------|
+| `ImageUploader` | interface | `uploadFile`, `uploadFromUrl`, `checkReachability` — the contract every upload consumer implements |
+| `ImageUploadProvider` | component | Context provider mounted by the app; children reach the uploader via `useImageUploader()` |
+| `useImageUploader` | hook | Returns the current `ImageUploader`; falls back to `defaultImageUploader` if no provider |
+| `defaultImageUploader` | constant | Stub uploader backed by `defaultUploadHandler` / `defaultUrlUploadHandler` / `defaultReachabilityCheck`. Returns picsum.photos URLs for dev/Storybook |
+| `ItemCardEditor` | component | Card with drop zone; consumes uploader from context |
+| `ImageUploadDialog` | component | Standalone dialog with `EditExisting` / `EmptyImage` / `Uploading` / `UploadError` / `FailedValidation` phases; consumes uploader from context |
+
+## Flow diagram (conceptual)
+
+```
+ user drops/selects file or URL
+                │
+                ▼
+  ┌───────────────────────────────┐
+  │ ItemCardEditor drop zone      │   ── direct-upload (no dialog, no cropper)
+  │  uploadFile / uploadFromUrl   │
+  │  on resolve → commit CDN URL  │
+  └───────────────────────────────┘
+
+ user clicks "Click to edit/replace" overlay on an existing image
+ OR user double-clicks image cell in AG Grid
+                │
+                ▼
+  ┌───────────────────────────────┐
+  │ ImageUploadDialog             │
+  │  RESET → EditExisting         │   ── cropper visible, for edit-mindset
+  │   ↑                           │
+  │   │ Accept (no edits)         │ ── skipUpload → onConfirm with existing URL
+  │   │ Accept (with edits)       │ ── getCroppedImage → Uploading(blob)
+  │   │ Upload New Image          │ ── EmptyImage → user drops → Uploading
+  │   ▼                           │
+  │  Uploading → UploadError      │ ── Retry / Discard
+  │           → onConfirm (CDN)   │
+  └───────────────────────────────┘
+```
+
+Key invariant: **the cropper only appears in `EditExisting`**. Fresh uploads
+(via card-side drop zone OR dialog's own drop zone after `Upload New Image`)
+skip to `Uploading` directly — the rapid-batch UX.
+
+## File responsibilities
+
+| File | What it owns |
+|------|--------------|
+| `src/types/canary/utilities/image-uploader.tsx` | `ImageUploader` interface, `defaultImageUploader` stub, `ImageUploadContext`, `ImageUploadProvider`, `useImageUploader` |
+| `src/types/canary/utilities/image-upload-handlers.ts` | Stub handlers that make up `defaultImageUploader` |
+| `src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx` | Dialog state machine + render |
+| `src/components/canary/organisms/item-card-editor/item-card-editor.tsx` | Card + drop zone + direct-upload state |
+| `src/components/canary/molecules/image-drop-zone/image-drop-zone.tsx` | File/URL intake + per-format validation |
+| `src/components/canary/molecules/image-preview-editor/image-preview-editor.tsx` | Cropper (react-easy-crop wrapper) |
+| `src/types/canary/utilities/get-cropped-image.ts` | Canvas-based crop/zoom/rotate → Blob |
+| `src/types/canary/utilities/cdn-url.ts` | CDN prefetch helpers (CORS mitigation) |
+
+## Things that often trip agents
+
+- **`pendingInput`** is a still-public dialog prop for consumers that want
+  to inject an input from an external drop zone. Its existence is
+  arguably a leaky abstraction (see
+  [component-abstractions.md](./component-abstractions.md)); it's kept
+  for now but is a candidate for removal in the v5 consolidation
+  (Option C — track in Arda-cards/ux-prototype follow-up ticket).
+- **Default fallback on `useImageUploader()`** means forgetting to mount
+  `<ImageUploadProvider>` in production silently ships the picsum.photos
+  stub. Mitigation: stub URLs are deliberately distinctive
+  (`picsum.photos/seed/arda-uploaded/...`) so the bug is visible.
+- **`EditExisting` CDN prefetch** is done via `prefetchImageAsBlob`
+  (`cdn-url.ts`) to keep the cropper's `<img>` and the canvas on the
+  same origin. Don't remove the prefetch without re-verifying CORS on
+  canvas operations.
+- **Dialog state machine post-4.11.7** no longer has `ProvidedImage` or
+  `Warn` phases. `INPUT_FILE` / `INPUT_URL` now land directly in
+  `Uploading`. If a regression asks to stage uploads for review, this is
+  a policy change that should be discussed before reinstating those
+  phases.
+
+## Adding a new upload capability
+
+If you want to add a new operation (e.g. clipboard paste, batch upload,
+resumable upload), the playbook is:
+
+1. **Extend `ImageUploader`** with the new method. The `Mocked<T>`
+   pattern in tests picks up the new member automatically.
+2. **Update `defaultImageUploader`** with a stub implementation.
+3. **Update the consumer bridge** (`useItemImageUploader` in
+   arda-frontend-app) with the real implementation.
+4. **Wire the component** that consumes the new capability via
+   `useImageUploader()`.
+5. **Document in this KB**: a one-line entry in the "Public surface"
+   table above, and a note in the flow diagram if it's a new user path.
+
+Resist the urge to add a new callback prop on `ItemCardEditor` or
+`ImageUploadDialog` for the capability — that's the leaky-abstraction
+anti-pattern this architecture exists to prevent.

--- a/knowledge-base/image-upload-architecture.md
+++ b/knowledge-base/image-upload-architecture.md
@@ -1,4 +1,4 @@
-# Image-upload architecture (ux-prototype, 4.11.7+)
+# Image-upload architecture (ux-prototype, 5.0.0+)
 
 Quick-reference map of the components, types, and interaction patterns that
 make up the image-upload surface. Read before touching any of:
@@ -80,7 +80,7 @@ skip to `Uploading` directly — the rapid-batch UX.
   (`cdn-url.ts`) to keep the cropper's `<img>` and the canvas on the
   same origin. Don't remove the prefetch without re-verifying CORS on
   canvas operations.
-- **Dialog state machine post-4.11.7** no longer has `ProvidedImage` or
+- **Dialog state machine post-5.0.0** no longer has `ProvidedImage` or
   `Warn` phases. `INPUT_FILE` / `INPUT_URL` now land directly in
   `Uploading`. If a regression asks to stage uploads for review, this is
   a policy change that should be discussed before reinstating those

--- a/knowledge-base/typed-test-mocks.md
+++ b/knowledge-base/typed-test-mocks.md
@@ -1,0 +1,94 @@
+# Typed test mocks (ux-prototype)
+
+Guidance for mocking TypeScript interfaces in vitest without type-safety
+holes.
+
+## The smell
+
+```ts
+type MockUploader = {
+  [K in keyof ImageUploader]: ReturnType<typeof vi.fn>;
+};
+function makeMock(): MockUploader { /* … */ }
+
+// In a test:
+<ImageUploadProvider value={makeMock() as ImageUploader}>
+```
+
+The `as ImageUploader` cast is silencing a **real** type-system complaint:
+`ReturnType<typeof vi.fn>` without a type argument resolves to the generic
+`Mock<Procedure | Constructable>`, which is deliberately permissive so
+`vi.fn()` is usable anywhere. It is **not** structurally compatible with
+specific signatures like `(file: Blob) => Promise<string>`.
+
+The cast says "trust me, this matches." If the `ImageUploader` interface
+changes (new parameter, new return type), the mock compiles unchanged —
+and you only learn at runtime that the test was exercising a mismatched
+contract.
+
+## The fix
+
+Use vitest's built-in `Mocked<T>` utility:
+
+```ts
+import { type Mocked } from 'vitest';
+
+type MockUploader = Mocked<ImageUploader>;
+
+function makeMock(): MockUploader {
+  return {
+    uploadFile: vi.fn(async (_f: Blob) => 'cdn://stub'),
+    uploadFromUrl: vi.fn(async (_u: string) => 'cdn://stub'),
+    checkReachability: vi.fn(async (_u: string) => true),
+  };
+}
+
+// No cast — MockUploader IS structurally an ImageUploader.
+<ImageUploadProvider value={makeMock()} />
+```
+
+`Mocked<T>` maps each function member to `MockedFunction<T[K]>`, which
+preserves the original signature. Helper methods (`.mockResolvedValue`,
+`.mockClear`, `.mock.calls`, etc.) are still available on each member.
+
+## Companion types (use the matching one)
+
+- `Mocked<T>` — map an object/interface type to a fully mocked version.
+- `MockedFunction<F>` — a single function mock typed against `F`.
+- `MockedClass<C>` — a class mock typed against `C`.
+
+If the thing being mocked has a mixed shape (e.g. class with some fields
+not-functions), `Mocked<T>` is the right one; the non-function members
+pass through unchanged.
+
+## The rule
+
+**Before writing `as SomeInterface` in a test, stop and ask: would
+`Mocked<T>` (or `MockedFunction<F>`, `MockedClass<C>`) give me the right
+type?** Almost always it will.
+
+There are legitimate uses for `as` in tests (asserting the type of a
+DOM query result, narrowing a widened union, …). `as` on the result of
+a mock factory is almost never one of them.
+
+## Specific pattern used in this repo
+
+```ts
+// ux-prototype tests consistently use Mocked<T> for controller-shaped
+// mocks (ImageUploader, EntityViewer lifecycle, etc.).
+import { type Mocked } from 'vitest';
+
+type MockX = Mocked<XInterface>;
+
+function makeMockX(overrides: Partial<XInterface> = {}): MockX {
+  return {
+    methodA: vi.fn(async (_a: A) => defaultA),
+    methodB: vi.fn(async (_b: B) => defaultB),
+    ...overrides,
+  };
+}
+```
+
+Keep the signatures on each `vi.fn(async (…) => …)` explicit — vitest will
+infer the parameter types from usage, but an explicit signature makes the
+test readable and catches drift if the interface is later tightened.

--- a/src/canary.ts
+++ b/src/canary.ts
@@ -344,6 +344,19 @@ export type {
 export { ImageUploadDialog } from './components/canary/organisms/shared/image-upload-dialog';
 export type { ImageUploadDialogProps } from './components/canary/organisms/shared/image-upload-dialog';
 
+// Image upload abstraction (4.11.7+): single uploader interface + Context provider
+// replaces the previous per-callback props (onUpload/onUploadFromUrl/
+// onCheckReachability). See types/canary/utilities/image-uploader.
+export {
+  ImageUploadProvider,
+  useImageUploader,
+  defaultImageUploader,
+} from './types/canary/utilities/image-uploader';
+export type {
+  ImageUploader,
+  ImageUploadProviderProps,
+} from './types/canary/utilities/image-uploader';
+
 export { createEntityDataGridShim } from './components/canary/organisms/shared/entity-data-grid-shim';
 export type {
   EntityDataGridShimViewProps,

--- a/src/canary.ts
+++ b/src/canary.ts
@@ -216,7 +216,6 @@ export {
 export type {
   ImageCellDisplayProps,
   ImageCellEditorProps,
-  ImageCellEditorConfig,
   ImageCellEditorHandle,
 } from './components/canary/atoms/grid/image';
 
@@ -311,10 +310,7 @@ export {
   itemGridDefaultColDef,
   createItemGridColumnDefs,
 } from './components/canary/molecules/item-grid/item-grid-columns';
-export type {
-  ItemGridLookups,
-  ItemGridEditorHooks,
-} from './components/canary/molecules/item-grid/item-grid-columns';
+export type { ItemGridLookups } from './components/canary/molecules/item-grid/item-grid-columns';
 
 export { itemGridFixtures } from './components/canary/molecules/item-grid/item-grid-fixtures';
 

--- a/src/components/canary/atoms/grid/image/image-cell-editor.tsx
+++ b/src/components/canary/atoms/grid/image/image-cell-editor.tsx
@@ -6,15 +6,6 @@ import type {
 } from '@/types/canary/utilities/image-field-config';
 import { ImageUploadDialog } from '@/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog';
 
-/** Configuration for the image cell editor factory (FD-01 / FD-15). */
-export interface ImageCellEditorConfig {
-  config: ImageFieldConfig;
-  /** Hook returning the upload mutation — required (FD-15). */
-  useImageUpload: () => { mutateAsync: (file: Blob) => Promise<string>; isPending: boolean };
-  /** Hook returning the reachability check — required (FD-15). */
-  useCheckReachability: () => { mutateAsync: (url: string) => Promise<boolean> };
-}
-
 // --- Interfaces ---
 
 /** Design-time configuration for ImageCellEditor (no static props). */
@@ -39,10 +30,6 @@ export type ImageCellEditorProps = ImageCellEditorStaticProps &
   ImageCellEditorRuntimeProps & {
     /** Curried by createImageCellEditor — not passed by AG Grid directly. */
     config: ImageFieldConfig;
-    /** Upload callback — plain function, not a hook. Passed by the factory wrapper. */
-    onUpload?: (file: Blob) => Promise<string>;
-    /** Reachability callback — plain function. Passed by the factory wrapper. */
-    onCheckReachability?: (url: string) => Promise<boolean>;
   };
 
 /** Ref handle exposing getValue and isPopup for AG Grid. */
@@ -65,16 +52,22 @@ export interface ImageCellEditorHandle {
  * This prevents the grid from stopping editing when the Radix Dialog
  * portal moves focus to `document.body`.
  *
+ * **Upload wiring (5.0.0+).** The dialog consumes its uploader from the
+ * surrounding `ImageUploadProvider` Context — the cell editor no longer
+ * takes per-callback `onUpload` / `onCheckReachability` props. Mount
+ * `<ImageUploadProvider value={uploader}>` at or above the grid.
+ *
  * Usage in column definitions:
  * ```ts
  * {
  *   field: 'imageUrl',
  *   cellEditor: createImageCellEditor(ITEM_IMAGE_CONFIG),
+ *   cellEditorPopup: true,
  * }
  * ```
  */
 export const ImageCellEditor = forwardRef<ImageCellEditorHandle, ImageCellEditorProps>(
-  ({ value: initialValue, stopEditing, config, onUpload, onCheckReachability }, ref) => {
+  ({ value: initialValue, stopEditing, config }, ref) => {
     const [currentValue, setCurrentValue] = useState<string | null>(initialValue);
     const [dialogOpen, setDialogOpen] = useState(true);
 
@@ -109,8 +102,6 @@ export const ImageCellEditor = forwardRef<ImageCellEditorHandle, ImageCellEditor
           open={dialogOpen}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
-          {...(onUpload ? { onUpload } : {})}
-          {...(onCheckReachability ? { onCheckReachability } : {})}
         />
       </>
     );
@@ -120,10 +111,12 @@ export const ImageCellEditor = forwardRef<ImageCellEditorHandle, ImageCellEditor
 ImageCellEditor.displayName = 'ImageCellEditor';
 
 /**
- * Factory helper for creating an image cell editor with curried config and hooks.
+ * Factory helper for creating an image cell editor with curried config.
  *
- * Accepts either the legacy `ImageFieldConfig` (Storybook/default handlers) or
- * the full `ImageCellEditorConfig` with required typed provider hooks (FD-15).
+ * As of 5.0.0, this factory takes only `ImageFieldConfig`. The uploader
+ * (file-blob upload, URL upload, reachability) is consumed from the
+ * surrounding `ImageUploadProvider` Context at render time, so callers
+ * no longer thread hook references through this factory.
  *
  * **Important — single forwardRef contract (FD-19).**
  * The returned component is a single `forwardRef`, not a wrapper around the
@@ -138,12 +131,7 @@ ImageCellEditor.displayName = 'ImageCellEditor';
  * eliminates the indirection and AG Grid sees `isPopup() => true` in
  * time, taking the early-return branch.
  */
-export function createImageCellEditor(configOrFull: ImageFieldConfig | ImageCellEditorConfig) {
-  const isFullConfig = 'useImageUpload' in configOrFull;
-  const config = isFullConfig ? configOrFull.config : configOrFull;
-  const useImageUploadHook = isFullConfig ? configOrFull.useImageUpload : undefined;
-  const useCheckReachabilityHook = isFullConfig ? configOrFull.useCheckReachability : undefined;
-
+export function createImageCellEditor(config: ImageFieldConfig) {
   const ImageCellEditorAdapter = forwardRef<ImageCellEditorHandle, ImageCellEditorRuntimeProps>(
     ({ value: initialValue, stopEditing }, ref) => {
       const [currentValue, setCurrentValue] = useState<string | null>(initialValue);
@@ -155,19 +143,6 @@ export function createImageCellEditor(configOrFull: ImageFieldConfig | ImageCell
         getValue: () => currentValue,
         isPopup: () => true,
       }));
-
-      // Hooks are called unconditionally per the Rules of Hooks. The
-      // `?.()` handles the Storybook case (no hooks provided) — the hook
-      // list itself is stable per component instance because the factory
-      // closure captures the same `useImageUploadHook` /
-      // `useCheckReachabilityHook` references for the lifetime of the
-      // column definition.
-      const uploadResult = useImageUploadHook?.();
-      const reachabilityResult = useCheckReachabilityHook?.();
-      const onUpload = uploadResult ? (file: Blob) => uploadResult.mutateAsync(file) : undefined;
-      const onCheckReachability = reachabilityResult
-        ? (url: string) => reachabilityResult.mutateAsync(url)
-        : undefined;
 
       const handleConfirm = (result: ImageUploadResult) => {
         setCurrentValue(result.imageUrl);
@@ -188,15 +163,14 @@ export function createImageCellEditor(configOrFull: ImageFieldConfig | ImageCell
             aria-hidden="true"
             style={{ width: 0, height: 0, overflow: 'hidden' }}
           />
-          {/* Modal dialog overlay — renders via portal, not in the cell */}
+          {/* Modal dialog overlay — renders via portal, not in the cell.
+              Uploader consumed from the surrounding ImageUploadProvider. */}
           <ImageUploadDialog
             config={config}
             existingImageUrl={initialValue}
             open={dialogOpen}
             onConfirm={handleConfirm}
             onCancel={handleCancel}
-            {...(onUpload ? { onUpload } : {})}
-            {...(onCheckReachability ? { onCheckReachability } : {})}
           />
         </>
       );

--- a/src/components/canary/atoms/grid/image/index.ts
+++ b/src/components/canary/atoms/grid/image/index.ts
@@ -9,7 +9,6 @@ export type {
 export { ImageCellEditor, createImageCellEditor } from './image-cell-editor';
 export type {
   ImageCellEditorProps,
-  ImageCellEditorConfig,
   ImageCellEditorStaticProps,
   ImageCellEditorInitProps,
   ImageCellEditorRuntimeProps,

--- a/src/components/canary/molecules/image-display/image-display.stories.tsx
+++ b/src/components/canary/molecules/image-display/image-display.stories.tsx
@@ -552,31 +552,16 @@ const {
     goToScene(2);
     await delay();
 
-    // Step 3 → 4: Enter URL, press Enter, then adjust zoom
+    // Step 3 → 4: Enter URL and press Enter. As of 4.11.7 the dialog
+    // skips the cropper/review step for new uploads — URL inputs
+    // transition directly through reachability check into Uploading.
+    // No slider (cropper) appears, no Confirm button to click.
     const urlInput = within(document.body).getByPlaceholderText(/example\.com\/image/i);
     await userEvent.click(urlInput);
     await userEvent.type(urlInput, 'https://picsum.photos/seed/arda-new/400/400', { delay: 20 });
     await userEvent.keyboard('{Enter}');
-    await waitFor(
-      () => {
-        const slider = document.querySelector('[role="slider"]');
-        expect(slider).toBeTruthy();
-      },
-      { timeout: 5000 },
-    );
-    const slider = document.querySelector('[role="slider"]') as HTMLElement;
-    if (slider) {
-      slider.focus();
-      for (let i = 0; i < 5; i++) {
-        await userEvent.keyboard('{ArrowRight}');
-      }
-    }
     goToScene(3);
     await delay();
-
-    // Step 4 → 5: Click Confirm (copyright acknowledgment is now passive subtext)
-    const confirmBtn = within(document.body).getByRole('button', { name: /confirm/i });
-    await userEvent.click(confirmBtn);
     goToScene(5);
     await delay();
 

--- a/src/components/canary/molecules/item-grid/item-grid-columns.tsx
+++ b/src/components/canary/molecules/item-grid/item-grid-columns.tsx
@@ -240,13 +240,10 @@ export interface ItemGridLookups {
   unit?: (search: string) => Promise<TypeaheadOption[]>;
 }
 
-/** Typed provider hooks for grid cell editors (FD-01 / FD-15). */
-export interface ItemGridEditorHooks {
-  /** Hook returning the upload mutation — required (FD-15). */
-  useImageUpload: () => { mutateAsync: (file: Blob) => Promise<string>; isPending: boolean };
-  /** Hook returning the reachability check — required (FD-15). */
-  useCheckReachability: () => { mutateAsync: (url: string) => Promise<boolean> };
-}
+// As of 5.0.0 the image column's cell editor reads its uploader from the
+// surrounding `ImageUploadProvider` Context; this grid no longer needs
+// typed hook references to be threaded through. The previous
+// `ItemGridEditorHooks` type is removed.
 
 // --- Defaults ---
 
@@ -263,12 +260,19 @@ export const itemGridDefaultColDef: ColDef<Item> = {
 /** Static columns (no lookups needed). Used as default. */
 export const itemGridColumnDefs: ColDef<Item>[] = createItemGridColumnDefs();
 
-/** Factory — pass lookups, editor hooks, and callbacks to get fully-configured columns. */
+/** Factory — pass lookups and callbacks to get fully-configured columns.
+ *
+ * As of 5.0.0, the image column's cell editor is always configured. The
+ * `editable` flag in `options` lets callers disable in-grid editing
+ * (e.g. read-only views); when enabled, the editor reads its uploader
+ * from the surrounding `ImageUploadProvider` Context. Mount
+ * `<ImageUploadProvider value={uploader}>` at or above the grid.
+ */
 export function createItemGridColumnDefs(
   lookups?: ItemGridLookups,
-  options?: { onNotesClick?: (item: Item) => void; editorHooks?: ItemGridEditorHooks },
+  options?: { onNotesClick?: (item: Item) => void; editable?: boolean },
 ): ColDef<Item>[] {
-  const editorHooks = options?.editorHooks;
+  const imageEditable = options?.editable ?? true;
 
   return [
     {
@@ -278,16 +282,12 @@ export function createItemGridColumnDefs(
       width: 60,
       sortable: false,
       resizable: false,
-      editable: !!editorHooks,
+      editable: imageEditable,
       cellRenderer: ImageCellDisplay,
       cellRendererParams: { config: ITEM_IMAGE_CONFIG },
-      ...(editorHooks
+      ...(imageEditable
         ? {
-            cellEditor: createImageCellEditor({
-              config: ITEM_IMAGE_CONFIG,
-              useImageUpload: editorHooks.useImageUpload,
-              useCheckReachability: editorHooks.useCheckReachability,
-            }),
+            cellEditor: createImageCellEditor(ITEM_IMAGE_CONFIG),
             cellEditorPopup: true,
           }
         : {}),

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 
 import { ItemCardEditor, EMPTY_ITEM_CARD_FIELDS } from './item-card-editor';
 import type { ImageFieldConfig } from '@/types/canary/utilities/image-field-config';
+import { ImageUploadProvider, type ImageUploader } from '@/types/canary/utilities/image-uploader';
 
 // Capture the dialog's last props so tests can assert on them and drive the
 // confirm/cancel callbacks without rendering the real dialog state machine.
 type CapturedDialogProps = {
   open: boolean;
   existingImageUrl: string | null;
-  pendingInput: { type: string; file?: File; url?: string; message?: string } | undefined;
   onConfirm: (result: { imageUrl: string }) => void;
   onCancel: () => void;
 };
@@ -23,11 +23,7 @@ vi.mock('@/components/canary/organisms/shared/image-upload-dialog/image-upload-d
     lastDialogProps = props;
     if (!props.open) return null;
     return (
-      <div
-        data-testid="image-upload-dialog"
-        data-pending-type={props.pendingInput?.type ?? 'none'}
-        data-existing-url={props.existingImageUrl ?? 'null'}
-      >
+      <div data-testid="image-upload-dialog" data-existing-url={props.existingImageUrl ?? 'null'}>
         <button
           onClick={() => props.onConfirm({ imageUrl: 'https://cdn.example.com/confirmed.jpg' })}
         >
@@ -44,7 +40,7 @@ vi.mock('@/components/canary/molecules/typeahead-input/typeahead-input', () => (
 }));
 
 // Mock ImageDropZone so tests can synthesize file/url/error inputs without
-// having to drive the real drag-and-drop / file-input plumbing.
+// driving the real drag-and-drop / file-input plumbing.
 vi.mock('@/components/canary/molecules/image-drop-zone/image-drop-zone', () => ({
   ImageDropZone: ({
     onInput,
@@ -79,15 +75,41 @@ const CONFIG: ImageFieldConfig = {
   propertyDisplayName: 'Product Image',
 };
 
-function renderEditor(props: Partial<React.ComponentProps<typeof ItemCardEditor>> = {}) {
-  return render(
+// --- Uploader helpers ------------------------------------------------------
+
+// `Mocked<T>` from vitest preserves the ImageUploader signatures while
+// adding the .mockResolvedValue / .mock.calls surface. Tests that want
+// non-default behavior do `uploader.uploadFile.mockResolvedValue(...)`
+// on the returned object.
+type MockUploader = Mocked<ImageUploader>;
+
+function makeUploader(): MockUploader {
+  return {
+    uploadFile: vi.fn(async (_file: Blob) => 'https://cdn.example.com/uploaded.jpg'),
+    uploadFromUrl: vi.fn(async (_url: string) => 'https://cdn.example.com/from-url.jpg'),
+    checkReachability: vi.fn(async (_url: string) => true),
+  };
+}
+
+function renderEditor(
+  props: Partial<React.ComponentProps<typeof ItemCardEditor>> = {},
+  uploader?: ImageUploader,
+) {
+  const wrapped = (
     <ItemCardEditor
       imageConfig={CONFIG}
       unitLookup={async () => []}
       fields={EMPTY_ITEM_CARD_FIELDS}
       onChange={vi.fn()}
       {...props}
-    />,
+    />
+  );
+  return render(
+    uploader ? (
+      <ImageUploadProvider value={uploader as ImageUploader}>{wrapped}</ImageUploadProvider>
+    ) : (
+      wrapped
+    ),
   );
 }
 
@@ -100,9 +122,6 @@ describe('ItemCardEditor — QR placeholder (#750 issue 3)', () => {
   it('renders the bundled default QR image when qrCodeUrl prop is not provided', async () => {
     renderEditor();
     const qr = await screen.findByAltText('QR');
-    // The default URL should be a bundled asset, NOT the absolute path
-    // /images/qr-code.png (which only works in Storybook's dev server).
-    // In tests, Vite resolves the import to a file URL or data URL.
     const src = qr.getAttribute('src') ?? '';
     expect(src).not.toBe('/images/qr-code.png');
     expect(src).toBeTruthy();
@@ -122,8 +141,6 @@ describe('ItemCardEditor — QR placeholder (#750 issue 3)', () => {
     const qrCodeUrl = vi.fn().mockRejectedValue(new Error('lookup failed'));
     renderEditor({ qrCodeUrl });
     const qr = await screen.findByAltText('QR');
-    // After the rejection, the src should be the bundled default — not empty,
-    // not the failed callback's nonexistent URL, and not the absolute path.
     await waitFor(() => {
       const src = qr.getAttribute('src') ?? '';
       expect(src).not.toBe('/images/qr-code.png');
@@ -132,25 +149,26 @@ describe('ItemCardEditor — QR placeholder (#750 issue 3)', () => {
   });
 });
 
-describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1 completion)', () => {
+describe('ItemCardEditor — drop-zone direct upload via ImageUploader Context', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lastDialogProps = undefined;
   });
 
-  it('uploads a dropped file via onUpload and commits the returned CDN URL', async () => {
+  it('uploads a dropped file via uploader.uploadFile and commits the returned CDN URL', async () => {
     const onChange = vi.fn();
     const onImageConfirmed = vi.fn();
-    const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/uploaded.jpg');
-    renderEditor({ onChange, onImageConfirmed, onUpload });
+    const uploader = makeUploader();
+    uploader.uploadFile.mockResolvedValue('https://cdn.example.com/uploaded.jpg');
+    renderEditor({ onChange, onImageConfirmed }, uploader);
 
     fireEvent.click(screen.getByText('drop-file'));
 
-    // Upload dialog must NOT be shown for the direct-upload flow.
+    // No dialog opens on the direct-upload flow.
     expect(screen.queryByTestId('image-upload-dialog')).not.toBeInTheDocument();
 
     await waitFor(() => {
-      expect(onUpload).toHaveBeenCalledTimes(1);
+      expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ imageUrl: 'https://cdn.example.com/uploaded.jpg' }),
       );
@@ -158,18 +176,19 @@ describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1
     });
   });
 
-  it('uploads a dropped URL via onUploadFromUrl and commits the returned CDN URL', async () => {
+  it('uploads a dropped URL via uploader.uploadFromUrl and commits the returned CDN URL', async () => {
     const onChange = vi.fn();
     const onImageConfirmed = vi.fn();
-    const onUploadFromUrl = vi.fn().mockResolvedValue('https://cdn.example.com/from-url.jpg');
-    renderEditor({ onChange, onImageConfirmed, onUploadFromUrl });
+    const uploader = makeUploader();
+    uploader.uploadFromUrl.mockResolvedValue('https://cdn.example.com/from-url.jpg');
+    renderEditor({ onChange, onImageConfirmed }, uploader);
 
     fireEvent.click(screen.getByText('drop-url'));
 
     expect(screen.queryByTestId('image-upload-dialog')).not.toBeInTheDocument();
 
     await waitFor(() => {
-      expect(onUploadFromUrl).toHaveBeenCalledWith('https://example.com/img.jpg');
+      expect(uploader.uploadFromUrl).toHaveBeenCalledWith('https://example.com/img.jpg');
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ imageUrl: 'https://cdn.example.com/from-url.jpg' }),
       );
@@ -178,10 +197,9 @@ describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1
   });
 
   it('shows a spinner (role=status) while an upload is in flight', async () => {
-    const onUpload = vi.fn(
-      () => new Promise<string>(() => {}), // never resolves
-    );
-    renderEditor({ onUpload });
+    const uploader = makeUploader();
+    uploader.uploadFile.mockImplementation(() => new Promise<string>(() => {})); // never resolves
+    renderEditor({}, uploader);
 
     fireEvent.click(screen.getByText('drop-file'));
 
@@ -194,8 +212,9 @@ describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1
     const onChange = vi.fn();
     const onImageConfirmed = vi.fn();
     const onUploadError = vi.fn();
-    const onUpload = vi.fn().mockRejectedValue(new Error('quota exceeded'));
-    renderEditor({ onChange, onImageConfirmed, onUpload, onUploadError });
+    const uploader = makeUploader();
+    uploader.uploadFile.mockRejectedValue(new Error('quota exceeded'));
+    renderEditor({ onChange, onImageConfirmed, onUploadError }, uploader);
 
     fireEvent.click(screen.getByText('drop-file'));
 
@@ -210,8 +229,9 @@ describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1
   });
 
   it('Try again restores the drop zone so the user can drop another file', async () => {
-    const onUpload = vi.fn().mockRejectedValue(new Error('network down'));
-    renderEditor({ onUpload });
+    const uploader = makeUploader();
+    uploader.uploadFile.mockRejectedValue(new Error('network down'));
+    renderEditor({}, uploader);
 
     fireEvent.click(screen.getByText('drop-file'));
     await screen.findByRole('alert');
@@ -224,33 +244,12 @@ describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1
     });
   });
 
-  it('falls back to the bundled defaultUploadHandler for file drops when onUpload is not supplied (Storybook/dev parity)', async () => {
+  it('falls back to the bundled default uploader when no ImageUploadProvider is mounted', async () => {
     const onChange = vi.fn();
-    const onImageConfirmed = vi.fn();
-    // No onUpload — component defaults to defaultUploadHandler and commits
-    // its mock CDN URL. Storybook play functions rely on this.
-    renderEditor({ onChange, onImageConfirmed });
-
-    fireEvent.click(screen.getByText('drop-file'));
-
-    await waitFor(
-      () => {
-        expect(onChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            imageUrl: expect.stringMatching(/^https:\/\/picsum\.photos\//),
-          }),
-        );
-      },
-      { timeout: 3000 },
-    );
-    expect(onImageConfirmed).toHaveBeenCalled();
-  });
-
-  it('falls back to defaultUrlUploadHandler for URL drops when onUploadFromUrl is not supplied', async () => {
-    const onChange = vi.fn();
+    // No <ImageUploadProvider> wrapper — defaults to defaultImageUploader (stub).
     renderEditor({ onChange });
 
-    fireEvent.click(screen.getByText('drop-url'));
+    fireEvent.click(screen.getByText('drop-file'));
 
     await waitFor(
       () => {
@@ -266,13 +265,13 @@ describe('ItemCardEditor — drop-zone uploads directly, no dialog (#750 issue 1
 
   it('ignores error inputs from the drop zone (ImageDropZone surfaces them inline itself)', () => {
     const onChange = vi.fn();
-    const onUpload = vi.fn();
-    renderEditor({ onChange, onUpload });
+    const uploader = makeUploader();
+    renderEditor({ onChange }, uploader);
 
     fireEvent.click(screen.getByText('drop-error'));
 
     expect(screen.queryByTestId('image-upload-dialog')).not.toBeInTheDocument();
-    expect(onUpload).not.toHaveBeenCalled();
+    expect(uploader.uploadFile).not.toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
   });
 

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
@@ -105,11 +105,7 @@ function renderEditor(
     />
   );
   return render(
-    uploader ? (
-      <ImageUploadProvider value={uploader as ImageUploader}>{wrapped}</ImageUploadProvider>
-    ) : (
-      wrapped
-    ),
+    uploader ? <ImageUploadProvider value={uploader}>{wrapped}</ImageUploadProvider> : wrapped,
   );
 }
 

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -57,7 +57,7 @@ export interface ItemCardEditorRuntimeProps {
    * slot.
    *
    * Note: upload/URL-upload/reachability themselves are consumed from the
-   * surrounding `ImageUploadProvider` Context (4.11.7+) rather than as
+   * surrounding `ImageUploadProvider` Context (5.0.0+) rather than as
    * per-callback props. Mount an `<ImageUploadProvider value={uploader}>`
    * at or above this component.
    */

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -16,10 +16,7 @@ import type {
   ImageInput,
   ImageUploadResult,
 } from '@/types/canary/utilities/image-field-config';
-import {
-  defaultUploadHandler,
-  defaultUrlUploadHandler,
-} from '@/types/canary/utilities/image-upload-handlers';
+import { useImageUploader } from '@/types/canary/utilities/image-uploader';
 
 import qrCodeDefaultUrl from './qr-code.png';
 
@@ -54,36 +51,15 @@ export interface ItemCardEditorRuntimeProps {
    * drop zone, or via Accept in the edit-existing dialog). */
   onImageConfirmed?: (url: string) => void;
   /**
-   * File-blob upload handler. Called directly when the user drops or selects
-   * a file via the empty-state drop zone — uploads proceed inline on the
-   * card without opening the crop/edit dialog (#750 issue 1 completion:
-   * rapid-batch UX). Also forwarded to ImageUploadDialog for the
-   * edit-existing flow.
-   *
-   * When omitted, defaults to `defaultUploadHandler` (a Storybook/dev
-   * stub that returns a mock CDN URL after a 1.5s simulated upload).
-   * Production deployments must pass a real handler.
-   */
-  onUpload?: (file: Blob) => Promise<string>;
-  /**
-   * External-URL upload handler. Called when the user drops or pastes an
-   * image URL from another tab (e.g. Google Images). The handler is
-   * expected to fetch the URL server-side (bypassing browser CORS) and
-   * upload the fetched bytes to the CDN, returning the CDN URL.
-   *
-   * When omitted, defaults to `defaultUrlUploadHandler` (a Storybook/dev
-   * stub that returns a mock CDN URL). In production, a real handler is
-   * required whenever URL inputs are possible; otherwise the stub ships
-   * with the component and hides what would be a configuration error.
-   */
-  onUploadFromUrl?: (url: string) => Promise<string>;
-  /** Reachability check — forwarded to ImageUploadDialog's onCheckReachability. */
-  onCheckReachability?: (url: string) => Promise<boolean>;
-  /**
    * Optional callback invoked when a direct upload (file or URL) from the
    * card's drop zone fails. Hosts can use this to raise a toast alongside
    * the inline error that ItemCardEditor already shows in the drop-zone
    * slot.
+   *
+   * Note: upload/URL-upload/reachability themselves are consumed from the
+   * surrounding `ImageUploadProvider` Context (4.11.7+) rather than as
+   * per-callback props. Mount an `<ImageUploadProvider value={uploader}>`
+   * at or above this component.
    */
   onUploadError?: (err: Error) => void;
   /**
@@ -130,12 +106,10 @@ export function ItemCardEditor({
   fields,
   onChange,
   onImageConfirmed,
-  onUpload = defaultUploadHandler,
-  onUploadFromUrl = defaultUrlUploadHandler,
-  onCheckReachability,
   onUploadError,
   qrCodeUrl,
 }: ItemCardEditorProps) {
+  const uploader = useImageUploader();
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [confirmRemoveOpen, setConfirmRemoveOpen] = React.useState(false);
   const [resolvedQrSrc, setResolvedQrSrc] = React.useState<string>(qrCodeDefaultUrl);
@@ -168,10 +142,8 @@ export function ItemCardEditor({
   onChangeRef.current = onChange;
   const onImageConfirmedRef = React.useRef(onImageConfirmed);
   onImageConfirmedRef.current = onImageConfirmed;
-  const onUploadRef = React.useRef(onUpload);
-  onUploadRef.current = onUpload;
-  const onUploadFromUrlRef = React.useRef(onUploadFromUrl);
-  onUploadFromUrlRef.current = onUploadFromUrl;
+  const uploaderRef = React.useRef(uploader);
+  uploaderRef.current = uploader;
   const onUploadErrorRef = React.useRef(onUploadError);
   onUploadErrorRef.current = onUploadError;
 
@@ -189,23 +161,23 @@ export function ItemCardEditor({
 
   // Direct upload: no dialog, no cropper. The user drops → we upload →
   // image appears on the card. Errors surface inline in the drop-zone slot.
+  //
+  // The `ImageUploader` is consumed from the surrounding
+  // `ImageUploadProvider` Context. If no provider is mounted, the default
+  // stub uploader is used — stories and dev harnesses work out of the box.
   const handleDropZoneInput = React.useCallback(
     async (input: ImageInput) => {
       // `error` inputs are already surfaced inline by ImageDropZone.
       if (input.type === 'error') return;
 
-      // Both handlers have defaults (Storybook/dev stubs), so `onUploadRef`
-      // and `onUploadFromUrlRef` always hold a function. Consumers that
-      // forget to pass a real handler in production will upload to the
-      // stub — a visible bug — rather than silently dropping inputs.
-      const uploader: () => Promise<string> =
+      const doUpload: () => Promise<string> =
         input.type === 'file'
-          ? () => onUploadRef.current(input.file)
-          : () => onUploadFromUrlRef.current(input.url);
+          ? () => uploaderRef.current.uploadFile(input.file)
+          : () => uploaderRef.current.uploadFromUrl(input.url);
 
       setUploadState({ name: 'Uploading' });
       try {
-        const cdnUrl = await uploader();
+        const cdnUrl = await doUpload();
         setUploadState({ name: 'Idle' });
         commitImageUrl(cdnUrl);
       } catch (err) {
@@ -400,16 +372,15 @@ export function ItemCardEditor({
 
       {/* Image Upload Dialog — edit-existing flow only (cropper, replace via
           Upload New Image, etc.). New-image uploads from the card's drop zone
-          bypass this dialog entirely (see handleDropZoneInput above). */}
+          bypass this dialog entirely (see handleDropZoneInput above).
+          The dialog consumes its uploader from the surrounding
+          ImageUploadProvider Context — no per-callback wiring needed. */}
       <ImageUploadDialog
         config={imageConfig}
         existingImageUrl={fields.imageUrl}
         open={dialogOpen}
         onConfirm={handleDialogConfirm}
         onCancel={handleDialogCancel}
-        onUpload={onUpload}
-        onUploadFromUrl={onUploadFromUrl}
-        {...(onCheckReachability ? { onCheckReachability } : {})}
       />
 
       {/* Confirm remove image */}

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.stories.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.stories.tsx
@@ -33,7 +33,10 @@ const meta: Meta<typeof ImageUploadDialog> = {
       description: {
         component:
           'State-machine orchestrator for the full image upload flow. ' +
-          'Manages EmptyImage, ProvidedImage, FailedValidation, Uploading, and Warn states.',
+          'Manages EditExisting, EmptyImage, FailedValidation, Uploading, and ' +
+          'UploadError phases. As of 5.0.0 new uploads skip the cropper ' +
+          'review step and transition directly from input to Uploading; the ' +
+          'cropper is reachable only via the deliberate EditExisting path.',
       },
     },
   },

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.stories.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.stories.tsx
@@ -11,6 +11,18 @@ import {
   mockReachabilityCheck,
 } from '@/components/canary/__mocks__/image-story-data';
 import type { ImageUploadResult } from '@/types/canary/utilities/image-field-config';
+import { ImageUploadProvider, type ImageUploader } from '@/types/canary/utilities/image-uploader';
+
+/** Story-scope mock uploader — composes the existing mock file upload + a
+ *  simulated URL-upload round-trip + the reachability stub. */
+const mockImageUploader: ImageUploader = {
+  uploadFile: mockUpload,
+  uploadFromUrl: async (url: string) => {
+    await new Promise((r) => setTimeout(r, 1500));
+    return `https://picsum.photos/seed/arda-from-url-${url.length}/400/400`;
+  },
+  checkReachability: mockReachabilityCheck,
+};
 
 const meta: Meta<typeof ImageUploadDialog> = {
   title: 'Components/Canary/Organisms/Shared/ImageUploadDialog',
@@ -51,9 +63,17 @@ const meta: Meta<typeof ImageUploadDialog> = {
     config: ITEM_IMAGE_CONFIG,
     onConfirm: fn(),
     onCancel: fn(),
-    onUpload: mockUpload,
-    onCheckReachability: mockReachabilityCheck,
   },
+  decorators: [
+    // Provide the mock uploader via Context (4.11.7+). Previously stories
+    // passed `onUpload` / `onCheckReachability` as per-component callbacks;
+    // the new API consumes the uploader from the surrounding provider.
+    (Story) => (
+      <ImageUploadProvider value={mockImageUploader}>
+        <Story />
+      </ImageUploadProvider>
+    ),
+  ],
 };
 
 export default meta;

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.test.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.test.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
 
 import { ImageUploadDialog, type ImageUploadDialogProps } from './image-upload-dialog';
 import type { ImageFieldConfig } from '@/types/canary/utilities/image-field-config';
+import {
+  ImageUploadProvider,
+  defaultImageUploader,
+  type ImageUploader,
+} from '@/types/canary/utilities/image-uploader';
 
 // --- Mocks ---
-
-vi.mock('@/types/canary/utilities/image-upload-handlers', () => ({
-  defaultUploadHandler: vi
-    .fn()
-    .mockResolvedValue('https://cdn.example.com/images/mock-uploaded.jpg'),
-  defaultUrlUploadHandler: vi
-    .fn()
-    .mockResolvedValue('https://picsum.photos/seed/mock-url-upload/400/400'),
-  defaultReachabilityCheck: vi.fn().mockResolvedValue(true),
-}));
 
 vi.mock('@/components/canary/molecules/image-preview-editor/image-preview-editor', () => ({
   ImagePreviewEditor: ({
@@ -69,10 +64,8 @@ vi.mock('@/components/canary/molecules/image-comparison-layout/image-comparison-
 vi.mock('@/components/canary/molecules/image-drop-zone/image-drop-zone', () => ({
   ImageDropZone: ({
     onInput,
-    onDismiss,
   }: {
     onInput: (input: { type: string; file?: File; url?: string; message?: string }) => void;
-    onDismiss: () => void;
   }) => (
     <div data-testid="image-drop-zone">
       <button
@@ -88,7 +81,6 @@ vi.mock('@/components/canary/molecules/image-drop-zone/image-drop-zone', () => (
       <button onClick={() => onInput({ type: 'error', message: 'Invalid file type' })}>
         drop error
       </button>
-      <button onClick={onDismiss}>dismiss</button>
     </div>
   ),
 }));
@@ -100,7 +92,6 @@ vi.mock('@/types/canary/utilities/get-cropped-image', () => ({
 vi.mock('@/types/canary/utilities/cdn-url', () => ({
   isCdnUrl: (src: string) => src.includes('.assets.arda.cards'),
   prefetchImageAsBlob: vi.fn().mockImplementation(async (url: string) => {
-    // Simulate prefetch: CDN URLs get converted to blob URLs, others pass through
     if (url.includes('.assets.arda.cards')) {
       return 'blob:http://localhost/prefetched-cdn-image';
     }
@@ -129,8 +120,36 @@ const defaultProps: ImageUploadDialogProps = {
 
 // --- Helpers ---
 
-function renderDialog(props: Partial<ImageUploadDialogProps> = {}) {
-  return render(<ImageUploadDialog {...defaultProps} {...props} />);
+// `Mocked<T>` from vitest preserves `T`'s function signatures while adding
+// `.mockResolvedValue` / `.mockClear` / `.mock.calls` surface. Structural
+// subtype of `ImageUploader` — passes through `ImageUploadProvider value=...`
+// with no cast required.
+//
+// Tests that want non-default behavior use `.mockResolvedValue(...)` /
+// `.mockRejectedValue(...)` on the returned object directly; we intentionally
+// don't take a `Partial<ImageUploader>` override here because mixing plain
+// functions and MockInstance members defeats the Mocked<T> typing.
+type MockUploader = Mocked<ImageUploader>;
+
+function makeMockUploader(): MockUploader {
+  return {
+    uploadFile: vi.fn(async (_file: Blob) => 'https://cdn.example.com/images/mock-uploaded.jpg'),
+    uploadFromUrl: vi.fn(
+      async (_url: string) => 'https://cdn.example.com/images/mock-from-url.jpg',
+    ),
+    checkReachability: vi.fn(async (_url: string) => true),
+  };
+}
+
+function renderDialog(
+  props: Partial<ImageUploadDialogProps> = {},
+  uploader: ImageUploader = makeMockUploader(),
+) {
+  return render(
+    <ImageUploadProvider value={uploader}>
+      <ImageUploadDialog {...defaultProps} {...props} />
+    </ImageUploadProvider>,
+  );
 }
 
 // --- Tests ---
@@ -139,6 +158,8 @@ describe('ImageUploadDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  // --- Rendering / basic phases ---------------------------------------------
 
   it('renders nothing when open is false', () => {
     renderDialog({ open: false });
@@ -150,74 +171,131 @@ describe('ImageUploadDialog', () => {
     expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
   });
 
-  it('transitions to ProvidedImage on image input (mock file input)', async () => {
-    renderDialog();
+  it('opens in EditExisting state when existingImageUrl is set', () => {
+    renderDialog({ existingImageUrl: 'https://cdn.example.com/existing.jpg' });
+    expect(screen.getByTestId('image-comparison-layout')).toBeInTheDocument();
+    expect(screen.queryByTestId('image-drop-zone')).not.toBeInTheDocument();
+  });
+
+  // --- New-upload flow (file) ------------------------------------------------
+
+  it('file drop goes directly to Uploading (no cropper stop — rapid-batch UX)', async () => {
+    const uploader = makeMockUploader();
+    renderDialog({}, uploader);
+
+    fireEvent.click(screen.getByText('drop file'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+    // Cropper is NOT shown on the new-upload path.
+    expect(screen.queryByTestId('image-preview-editor')).not.toBeInTheDocument();
+    expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('Uploading success calls onConfirm with the returned CDN URL', async () => {
+    const uploader = makeMockUploader();
+    uploader.uploadFile.mockResolvedValue('https://cdn.example.com/uploaded.jpg');
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm }, uploader);
+
+    fireEvent.click(screen.getByText('drop file'));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ imageUrl: 'https://cdn.example.com/uploaded.jpg' }),
+      );
+    });
+  });
+
+  it('Uploading failure transitions to UploadError with Retry + Discard', async () => {
+    const uploader = makeMockUploader();
+    uploader.uploadFile.mockRejectedValue(new Error('Network failure'));
+    renderDialog({}, uploader);
+
+    fireEvent.click(screen.getByText('drop file'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Network failure');
+    });
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+  });
+
+  it('UploadError Retry re-enters Uploading', async () => {
+    const uploader = makeMockUploader();
+    uploader.uploadFile
+      .mockRejectedValueOnce(new Error('first fail'))
+      .mockResolvedValueOnce('https://cdn.example.com/second-try.jpg');
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm }, uploader);
+
     fireEvent.click(screen.getByText('drop file'));
     await waitFor(() => {
-      expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ imageUrl: 'https://cdn.example.com/second-try.jpg' }),
+      );
     });
   });
 
-  it('shows copyright subtext and enabled Confirm button in ProvidedImage state', async () => {
-    renderDialog();
+  it('UploadError Discard returns to EmptyImage', async () => {
+    const uploader = makeMockUploader();
+    uploader.uploadFile.mockRejectedValue(new Error('fail'));
+    renderDialog({}, uploader);
+
     fireEvent.click(screen.getByText('drop file'));
     await waitFor(() => {
-      expect(screen.getByText(/you acknowledge that you own/i)).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
     });
   });
 
-  it('calls onCancel on cancel click (no staged image)', () => {
-    const onCancel = vi.fn();
-    renderDialog({ onCancel });
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    expect(onCancel).toHaveBeenCalledOnce();
+  // --- New-upload flow (URL) -------------------------------------------------
+
+  it('URL drop: reachability passes → Uploading via uploadFromUrl (no cropper)', async () => {
+    const uploader = makeMockUploader();
+    uploader.uploadFromUrl.mockResolvedValue('https://cdn.example.com/from-url.jpg');
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm }, uploader);
+
+    fireEvent.click(screen.getByText('drop url'));
+
+    await waitFor(() => {
+      expect(uploader.checkReachability).toHaveBeenCalledWith('https://example.com/image.jpg');
+      expect(uploader.uploadFromUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
+      expect(onConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ imageUrl: 'https://cdn.example.com/from-url.jpg' }),
+      );
+    });
+    expect(screen.queryByTestId('image-preview-editor')).not.toBeInTheDocument();
+    expect(uploader.uploadFile).not.toHaveBeenCalled();
   });
 
-  it('shows Warn dialog on cancel with staged image', async () => {
-    renderDialog();
-    fireEvent.click(screen.getByText('drop file'));
+  it('URL drop: reachability fails → FailedValidation', async () => {
+    const uploader = makeMockUploader();
+    uploader.checkReachability.mockResolvedValue(false);
+    renderDialog({}, uploader);
+
+    fireEvent.click(screen.getByText('drop url'));
+
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(/URL could not be reached/i);
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => {
-      expect(screen.getByText('Discard unsaved image?')).toBeInTheDocument();
-    });
+    expect(uploader.uploadFromUrl).not.toHaveBeenCalled();
   });
 
-  it('Warn discard calls onCancel', async () => {
-    const onCancel = vi.fn();
-    renderDialog({ onCancel });
-    fireEvent.click(screen.getByText('drop file'));
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => {
-      expect(screen.getByText('Discard')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText('Discard'));
-    expect(onCancel).toHaveBeenCalledOnce();
-  });
+  // --- Invalid input ---------------------------------------------------------
 
-  it('Warn go-back returns to ProvidedImage', async () => {
-    renderDialog();
-    fireEvent.click(screen.getByText('drop file'));
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => {
-      expect(screen.getByText('Go Back')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText('Go Back'));
-    await waitFor(() => {
-      expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-    });
-  });
-
-  it('shows validation error for invalid file', async () => {
+  it('invalid file (error input) → FailedValidation', async () => {
     renderDialog();
     fireEvent.click(screen.getByText('drop error'));
     await waitFor(() => {
@@ -225,446 +303,96 @@ describe('ImageUploadDialog', () => {
     });
   });
 
-  it('calls onConfirm with result on confirm (mock the upload)', async () => {
-    const { defaultUploadHandler } = await import('@/types/canary/utilities/image-upload-handlers');
-    (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValue(
-      'https://cdn.example.com/images/mock-uploaded.jpg',
-    );
-    const onConfirm = vi.fn();
-    renderDialog({ onConfirm });
+  // --- EditExisting flow -----------------------------------------------------
 
-    fireEvent.click(screen.getByText('drop file'));
-    await act(async () => {
-      await Promise.resolve();
-    });
+  describe('EditExisting', () => {
+    const EXISTING = 'https://images.assets.arda.cards/items/existing.jpg';
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-    await waitFor(() => {
-      expect(onConfirm).toHaveBeenCalledWith(
-        expect.objectContaining({ imageUrl: 'https://cdn.example.com/images/mock-uploaded.jpg' }),
-      );
-    });
-  });
-
-  it('shows indeterminate indicator during upload (no progress percentage)', async () => {
-    // Make onUpload hang so we can inspect the Uploading state
-    const { defaultUploadHandler } = await import('@/types/canary/utilities/image-upload-handlers');
-    (defaultUploadHandler as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
-    renderDialog();
-
-    fireEvent.click(screen.getByText('drop file'));
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText('Uploading image\u2026')).toBeInTheDocument();
-      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    });
-  });
-
-  // --- UploadError state tests ---
-
-  describe('UploadError state', () => {
-    async function enterUploadError() {
-      const { defaultUploadHandler } =
-        await import('@/types/canary/utilities/image-upload-handlers');
-      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error('Network failure'),
-      );
-      renderDialog();
-
-      fireEvent.click(screen.getByText('drop file'));
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-      await waitFor(() => {
-        expect(screen.getByRole('alert')).toBeInTheDocument();
-      });
-    }
-
-    it('renders error message on upload failure', async () => {
-      await enterUploadError();
-      expect(screen.getByRole('alert')).toHaveTextContent('Network failure');
-    });
-
-    it('retry transitions back to Uploading', async () => {
-      const { defaultUploadHandler } =
-        await import('@/types/canary/utilities/image-upload-handlers');
-      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-        new Error('Network failure'),
-      );
-      // On retry, succeed
-      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-        'https://cdn.example.com/retried.jpg',
-      );
-      const onConfirm = vi.fn();
-      renderDialog({ onConfirm });
-
-      fireEvent.click(screen.getByText('drop file'));
-      await act(async () => {
-        await Promise.resolve();
-      });
-      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-      await waitFor(() => {
-        expect(screen.getByRole('alert')).toHaveTextContent('Network failure');
-      });
-
-      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
-
-      await waitFor(() => {
-        expect(onConfirm).toHaveBeenCalledWith(
-          expect.objectContaining({ imageUrl: 'https://cdn.example.com/retried.jpg' }),
-        );
-      });
-    });
-
-    it('discard transitions to EmptyImage', async () => {
-      await enterUploadError();
-
-      fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
-      });
-    });
-  });
-
-  it('comparison layout shown when existingImageUrl set and new image provided', async () => {
-    renderDialog({ existingImageUrl: 'https://example.com/existing.jpg' });
-    // When existingImageUrl is set, dialog opens in EditExisting state (no drop zone)
-    // To reach ProvidedImage with comparison, click "Upload New Image" first
-    fireEvent.click(screen.getByRole('button', { name: 'Upload New Image' }));
-    await waitFor(() => {
-      expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText('drop file'));
-    await waitFor(() => {
-      expect(screen.getByTestId('image-comparison-layout')).toBeInTheDocument();
-    });
-  });
-
-  it('no comparison when existingImageUrl null', async () => {
-    renderDialog({ existingImageUrl: null });
-    fireEvent.click(screen.getByText('drop file'));
-    await waitFor(() => {
-      expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      expect(screen.queryByTestId('image-comparison-layout')).not.toBeInTheDocument();
-    });
-  });
-
-  // --- EditExisting state tests ---
-
-  describe('EditExisting state (existingImageUrl provided)', () => {
-    const EXISTING_URL = 'https://example.com/existing.jpg';
-
-    /** Extract the options object passed to getCroppedImage on its first call. */
-    async function firstCropCall() {
-      const { getCroppedImage } = await import('@/types/canary/utilities/get-cropped-image');
-      const mockFn = getCroppedImage as ReturnType<typeof vi.fn>;
-      const firstCall = mockFn.mock.calls[0];
-      if (!firstCall) throw new Error('getCroppedImage was not called');
-      return firstCall[0] as {
-        imageSrc: string;
-        pixelCrop: { x: number; y: number; width: number; height: number };
-        zoom?: number;
-        rotation?: number;
-      };
-    }
-
-    it('opens in EditExisting state when existingImageUrl is provided', () => {
-      renderDialog({ existingImageUrl: EXISTING_URL });
-      expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      expect(screen.queryByTestId('image-drop-zone')).not.toBeInTheDocument();
-    });
-
-    it('shows the existing image URL in ImagePreviewEditor', () => {
-      renderDialog({ existingImageUrl: EXISTING_URL });
-      expect(screen.getByTestId('preview-src')).toHaveTextContent(EXISTING_URL);
-    });
-
-    it('does NOT show copyright subtext in EditExisting state', () => {
-      renderDialog({ existingImageUrl: EXISTING_URL });
-      expect(screen.queryByText(/you acknowledge that you own/i)).not.toBeInTheDocument();
-    });
-
-    it('shows "Upload New Image", "Dismiss", and "Accept" buttons in EditExisting state', () => {
-      renderDialog({ existingImageUrl: EXISTING_URL });
-      expect(screen.getByRole('button', { name: 'Upload New Image' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
-    });
-
-    it('shows dialog title as "Edit Product Image" in EditExisting state', () => {
-      renderDialog({ existingImageUrl: EXISTING_URL });
-      expect(screen.getByText('Edit Product Image')).toBeInTheDocument();
-    });
-
-    it('"Upload New Image" button transitions to EmptyImage (shows drop zone)', async () => {
-      renderDialog({ existingImageUrl: EXISTING_URL });
+    it('"Upload New Image" transitions EditExisting → EmptyImage (drop zone)', async () => {
+      renderDialog({ existingImageUrl: EXISTING });
       fireEvent.click(screen.getByRole('button', { name: 'Upload New Image' }));
       await waitFor(() => {
         expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
-        expect(screen.queryByTestId('image-preview-editor')).not.toBeInTheDocument();
       });
     });
 
-    it('"Dismiss" in EditExisting calls onCancel', () => {
+    it('"Dismiss" calls onCancel', () => {
       const onCancel = vi.fn();
-      renderDialog({ existingImageUrl: EXISTING_URL, onCancel });
+      renderDialog({ existingImageUrl: EXISTING, onCancel });
       fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
       expect(onCancel).toHaveBeenCalledOnce();
     });
 
-    it('"Confirm" in EditExisting triggers upload (enters Uploading state)', async () => {
-      const { defaultUploadHandler } =
-        await import('@/types/canary/utilities/image-upload-handlers');
-      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
-      renderDialog({ existingImageUrl: EXISTING_URL });
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-        await Promise.resolve();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByRole('status')).toBeInTheDocument();
-      });
-    });
-
     it('"Accept" without edits confirms with existing URL (skipUpload)', async () => {
+      const uploader = makeMockUploader();
       const onConfirm = vi.fn();
-      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm });
-
-      // Don't crop/rotate — just accept immediately
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-        await Promise.resolve();
-      });
-
+      renderDialog({ existingImageUrl: EXISTING, onConfirm }, uploader);
+      fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
       await waitFor(() => {
-        expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ imageUrl: EXISTING_URL }));
+        expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ imageUrl: EXISTING }));
       });
+      expect(uploader.uploadFile).not.toHaveBeenCalled();
     });
 
-    it('"Accept" after crop uploads cropped blob and returns new URL', async () => {
-      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/cropped-new.jpg');
+    it('"Accept" after crop uploads cropped blob and returns the new URL', async () => {
+      const uploader = makeMockUploader();
+      uploader.uploadFile.mockResolvedValue('https://cdn.example.com/cropped.jpg');
       const onConfirm = vi.fn();
-      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm, onUpload });
+      renderDialog({ existingImageUrl: EXISTING, onConfirm }, uploader);
 
-      // Simulate crop edit (non-zero pixelCrop)
+      // Record a non-zero crop.
       fireEvent.click(screen.getByText('crop'));
-
       await act(async () => {
         fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-        await Promise.resolve();
-        await Promise.resolve();
       });
 
       await waitFor(() => {
-        expect(onUpload).toHaveBeenCalledWith(expect.any(Blob));
+        expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
         expect(onConfirm).toHaveBeenCalledWith(
-          expect.objectContaining({ imageUrl: 'https://cdn.example.com/cropped-new.jpg' }),
+          expect.objectContaining({ imageUrl: 'https://cdn.example.com/cropped.jpg' }),
         );
       });
     });
 
-    it('"Accept" after rotate-only uploads rotated blob (not skipUpload)', async () => {
-      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/rotated-new.jpg');
-      const onConfirm = vi.fn();
-      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm, onUpload });
-
-      // Simulate rotation-only edit (zero pixelCrop, rotation=90)
-      fireEvent.click(screen.getByText('rotate'));
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
-      await waitFor(() => {
-        expect(onUpload).toHaveBeenCalledWith(expect.any(Blob));
-        expect(onConfirm).toHaveBeenCalledWith(
-          expect.objectContaining({ imageUrl: 'https://cdn.example.com/rotated-new.jpg' }),
-        );
-      });
-    });
-
-    it('"Accept" after zoom-only uploads zoomed blob (not skipUpload)', async () => {
-      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/zoomed-new.jpg');
-      const onConfirm = vi.fn();
-      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm, onUpload });
-
-      // Simulate zoom-only edit (zero pixelCrop, zoom=2)
-      fireEvent.click(screen.getByText('zoom'));
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
-      await waitFor(() => {
-        expect(onUpload).toHaveBeenCalledWith(expect.any(Blob));
-        expect(onConfirm).toHaveBeenCalledWith(
-          expect.objectContaining({ imageUrl: 'https://cdn.example.com/zoomed-new.jpg' }),
-        );
-      });
-    });
-
-    it('"Accept" falls back to original URL when getCroppedImage fails', async () => {
-      const { getCroppedImage } = await import('@/types/canary/utilities/get-cropped-image');
-      (getCroppedImage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('CORS taint'));
-      const onConfirm = vi.fn();
-      renderDialog({ existingImageUrl: EXISTING_URL, onConfirm });
-
-      // Simulate crop edit
-      fireEvent.click(screen.getByText('crop'));
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
-      await waitFor(() => {
-        // Falls back to original URL (skipUpload path)
-        expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ imageUrl: EXISTING_URL }));
-      });
-    });
-
-    it('opens in EmptyImage state when existingImageUrl is null', () => {
-      renderDialog({ existingImageUrl: null });
-      expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
-      expect(screen.queryByTestId('image-preview-editor')).not.toBeInTheDocument();
-    });
-
-    it('getCroppedImage receives a blob URL (prefetched), not the raw CDN URL', async () => {
-      const CDN_URL = 'https://dev.alpha002.assets.arda.cards/tenant/images/uuid.jpg';
-      const PREFETCHED_BLOB = 'blob:http://localhost/prefetched-cdn-image';
-      const { getCroppedImage } = await import('@/types/canary/utilities/get-cropped-image');
-      const onUpload = vi.fn().mockResolvedValue('https://cdn.example.com/cropped.jpg');
-      const onConfirm = vi.fn();
-      renderDialog({ existingImageUrl: CDN_URL, onConfirm, onUpload });
-
-      // Synchronization: wait for the prefetched blob URL to propagate through
-      // ImagePreviewEditor — its mock renders imageData in the preview-src node.
-      // Once the preview shows the blob URL, we know the prefetch effect has
-      // resolved and setPrefetchedImageUrl has flushed. No arbitrary waits.
-      await waitFor(() => {
-        expect(screen.getByTestId('preview-src')).toHaveTextContent(PREFETCHED_BLOB);
-      });
-
-      // Simulate crop edit
-      fireEvent.click(screen.getByText('crop'));
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-      });
-
-      await waitFor(() => {
-        expect(getCroppedImage).toHaveBeenCalled();
-      });
-
-      // getCroppedImage should receive the prefetched blob URL, not the CDN URL
-      const opts = await firstCropCall();
-      expect(opts.imageSrc).toBe(PREFETCHED_BLOB);
-      expect(opts.imageSrc).not.toBe(CDN_URL);
-    });
-
-    // Issue 5a + 5b: zoom ignored in getCroppedImage; zoom/rotation-only
-    // handlers overwrite pixelCrop with zero-sized values.
-    it('5a: getCroppedImage receives the zoom value on zoom-only edit', async () => {
-      const { getCroppedImage } = await import('@/types/canary/utilities/get-cropped-image');
-      const EXISTING_URL = 'https://example.com/existing.jpg';
-      renderDialog({
-        existingImageUrl: EXISTING_URL,
-        onConfirm: vi.fn(),
-        onUpload: vi.fn().mockResolvedValue('x'),
-      });
-
-      fireEvent.click(screen.getByText('zoom'));
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-      });
-      await waitFor(() => expect(getCroppedImage).toHaveBeenCalled());
-
-      const opts = await firstCropCall();
-      expect(opts.zoom).toBe(2);
-    });
-
-    it('5b: crop + rotate preserves pixelCrop (rotate does not overwrite crop)', async () => {
-      const { getCroppedImage } = await import('@/types/canary/utilities/get-cropped-image');
-      const EXISTING_URL = 'https://example.com/existing.jpg';
-      renderDialog({
-        existingImageUrl: EXISTING_URL,
-        onConfirm: vi.fn(),
-        onUpload: vi.fn().mockResolvedValue('x'),
-      });
-
-      // User drags crop area (sets non-zero pixelCrop), then rotates
-      fireEvent.click(screen.getByText('crop'));
-      fireEvent.click(screen.getByText('rotate'));
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-      });
-      await waitFor(() => expect(getCroppedImage).toHaveBeenCalled());
-
-      const opts = await firstCropCall();
-      // pixelCrop preserved from the crop click; rotation captured from the rotate click
-      expect(opts.pixelCrop.width).toBeGreaterThan(0);
-      expect(opts.pixelCrop.height).toBeGreaterThan(0);
-      expect(opts.rotation).toBe(90);
+    it('renders ImagePreviewEditor inside the comparison layout', () => {
+      renderDialog({ existingImageUrl: EXISTING });
+      expect(screen.getByTestId('image-comparison-layout')).toBeInTheDocument();
+      expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
     });
   });
 
-  // --- pendingInput entry point (#750 issue 1) -----------------------------
-  //
-  // Drop-zone inputs delivered by a parent component (e.g. ItemCardEditor)
-  // should land in the same ProvidedImage / FailedValidation / Loading flow
-  // as inputs from the dialog's own ImageDropZone.
+  // --- pendingInput entry point ---------------------------------------------
 
-  describe('pendingInput entry point', () => {
-    it('dispatches a File pendingInput into ProvidedImage when opened', async () => {
+  describe('pendingInput', () => {
+    it('file pendingInput goes straight to Uploading (same as internal drop)', async () => {
+      const uploader = makeMockUploader();
       const file = new File(['x'], 'pending.jpg', { type: 'image/jpeg' });
-      renderDialog({
-        open: true,
-        pendingInput: { type: 'file', file },
-      });
+      renderDialog({ open: true, pendingInput: { type: 'file', file } }, uploader);
 
       await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
+        expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
       });
-      // The ImagePreviewEditor mock prints "file-blob" when imageData is a Blob/File.
-      expect(screen.getByTestId('preview-src')).toHaveTextContent('file-blob');
+      // No cropper on the way.
+      expect(screen.queryByTestId('image-preview-editor')).not.toBeInTheDocument();
     });
 
-    it('dispatches a URL pendingInput through reachability check into ProvidedImage', async () => {
-      renderDialog({
-        open: true,
-        pendingInput: { type: 'url', url: 'https://images.example.com/p.jpg' },
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      });
-      expect(screen.getByTestId('preview-src')).toHaveTextContent(
-        'https://images.example.com/p.jpg',
+    it('URL pendingInput goes through reachability → Uploading via uploadFromUrl', async () => {
+      const uploader = makeMockUploader();
+      renderDialog(
+        {
+          open: true,
+          pendingInput: { type: 'url', url: 'https://images.example.com/p.jpg' },
+        },
+        uploader,
       );
+
+      await waitFor(() => {
+        expect(uploader.checkReachability).toHaveBeenCalledWith('https://images.example.com/p.jpg');
+        expect(uploader.uploadFromUrl).toHaveBeenCalledWith('https://images.example.com/p.jpg');
+      });
     });
 
-    it('routes pendingInput error through the FailedValidation phase', async () => {
+    it('error pendingInput lands in FailedValidation', async () => {
       renderDialog({
         open: true,
         pendingInput: { type: 'error', message: 'File too large' },
@@ -674,192 +402,125 @@ describe('ImageUploadDialog', () => {
       });
     });
 
-    it('does not re-dispatch the same pendingInput on parent re-render', async () => {
+    it('same pendingInput identity on re-render does not re-dispatch', async () => {
+      const uploader = makeMockUploader();
       const file = new File(['x'], 'pending.jpg', { type: 'image/jpeg' });
       const pendingInput = { type: 'file' as const, file };
 
       const { rerender } = render(
-        <ImageUploadDialog {...defaultProps} open={true} pendingInput={pendingInput} />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      });
-
-      // User starts cropping and clicks Cancel — moves to Warn state.
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-      await waitFor(() => {
-        expect(screen.getByText('Discard unsaved image?')).toBeInTheDocument();
-      });
-
-      // Parent re-renders with the SAME pendingInput reference. The dialog
-      // must not jump back into ProvidedImage — that would clobber the Warn
-      // dialog and silently drop the user's pending decision.
-      rerender(<ImageUploadDialog {...defaultProps} open={true} pendingInput={pendingInput} />);
-
-      expect(screen.getByText('Discard unsaved image?')).toBeInTheDocument();
-    });
-
-    it('re-enters ProvidedImage when pendingInput identity changes', async () => {
-      const fileA = new File(['a'], 'a.jpg', { type: 'image/jpeg' });
-      const fileB = new File(['b'], 'b.jpg', { type: 'image/jpeg' });
-
-      const { rerender } = render(
-        <ImageUploadDialog
-          {...defaultProps}
-          open={true}
-          pendingInput={{ type: 'file', file: fileA }}
-        />,
+        <ImageUploadProvider value={uploader}>
+          <ImageUploadDialog {...defaultProps} open={true} pendingInput={pendingInput} />
+        </ImageUploadProvider>,
       );
       await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
+        expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
       });
 
+      // Re-render with the SAME pendingInput object.
       rerender(
-        <ImageUploadDialog
-          {...defaultProps}
-          open={true}
-          pendingInput={{ type: 'file', file: fileB }}
-        />,
+        <ImageUploadProvider value={uploader}>
+          <ImageUploadDialog {...defaultProps} open={true} pendingInput={pendingInput} />
+        </ImageUploadProvider>,
       );
-
-      // Still in ProvidedImage, now with the new file.
-      await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      });
+      // Still just one call — no re-dispatch.
+      expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
     });
 
-    it('skips EditExisting CDN prefetch when opening with both existingImageUrl and pendingInput (PR-96 review)', async () => {
-      // When the dialog opens with both an existingImageUrl and a queued
-      // pendingInput, the RESET effect must not enter EditExisting first
-      // (which would kick off a CDN prefetch immediately discarded by the
-      // pendingInput effect's transition to ProvidedImage).
-      const { prefetchImageAsBlob } = await import('@/types/canary/utilities/cdn-url');
-      (prefetchImageAsBlob as ReturnType<typeof vi.fn>).mockClear();
-
-      const file = new File(['x'], 'pending.jpg', { type: 'image/jpeg' });
-      renderDialog({
-        open: true,
-        existingImageUrl: 'https://images.assets.arda.cards/items/abc.jpg',
-        pendingInput: { type: 'file', file },
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      });
-      // The Cropper must show the pending file, not the existing CDN image.
-      expect(screen.getByTestId('preview-src')).toHaveTextContent('file-blob');
-      // And the CDN prefetch must NOT have been kicked off.
-      expect(prefetchImageAsBlob).not.toHaveBeenCalled();
-    });
-
-    it('clears pendingInput state when open transitions to false', async () => {
+    it('open=false clears pending dispatch, so next open with no pendingInput lands in EmptyImage', async () => {
+      const uploader = makeMockUploader();
       const file = new File(['x'], 'pending.jpg', { type: 'image/jpeg' });
       const { rerender } = render(
-        <ImageUploadDialog {...defaultProps} open={true} pendingInput={{ type: 'file', file }} />,
+        <ImageUploadProvider value={uploader}>
+          <ImageUploadDialog {...defaultProps} open={true} pendingInput={{ type: 'file', file }} />
+        </ImageUploadProvider>,
       );
       await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
+        expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
       });
 
-      // Close, then reopen with NO pendingInput — should land in EmptyImage,
-      // not retain the previous file.
-      rerender(<ImageUploadDialog {...defaultProps} open={false} />);
-      rerender(<ImageUploadDialog {...defaultProps} open={true} />);
+      // Close, then reopen with no pendingInput.
+      rerender(
+        <ImageUploadProvider value={uploader}>
+          <ImageUploadDialog {...defaultProps} open={false} />
+        </ImageUploadProvider>,
+      );
+      rerender(
+        <ImageUploadProvider value={uploader}>
+          <ImageUploadDialog {...defaultProps} open={true} />
+        </ImageUploadProvider>,
+      );
 
       await waitFor(() => {
         expect(screen.getByTestId('image-drop-zone')).toBeInTheDocument();
       });
-      expect(screen.queryByTestId('image-preview-editor')).not.toBeInTheDocument();
+    });
+
+    it('opening with BOTH existingImageUrl and pendingInput skips the EditExisting CDN prefetch', async () => {
+      const uploader = makeMockUploader();
+      const { prefetchImageAsBlob } = await import('@/types/canary/utilities/cdn-url');
+      (prefetchImageAsBlob as ReturnType<typeof vi.fn>).mockClear();
+
+      const file = new File(['x'], 'pending.jpg', { type: 'image/jpeg' });
+      renderDialog(
+        {
+          open: true,
+          existingImageUrl: 'https://images.assets.arda.cards/items/abc.jpg',
+          pendingInput: { type: 'file', file },
+        },
+        uploader,
+      );
+
+      await waitFor(() => {
+        expect(uploader.uploadFile).toHaveBeenCalledTimes(1);
+      });
+      expect(prefetchImageAsBlob).not.toHaveBeenCalled();
     });
   });
 
-  // --- URL-input upload path (#750 issue 1 completion / empty-blob bug) ----
-  //
-  // Historically the Uploading effect coerced URL inputs to `new Blob([])`
-  // and called onUpload with 0 bytes — silently producing an empty CDN
-  // object. Now the dialog routes URL inputs through a separate
-  // onUploadFromUrl handler, or surfaces UPLOAD_ERROR if the host hasn't
-  // supplied one.
+  // --- ImageUploader Context -------------------------------------------------
 
-  describe('URL-input upload path', () => {
-    async function enterProvidedImageWithUrl() {
-      fireEvent.click(screen.getByText('drop url'));
-      await act(async () => {
-        await Promise.resolve();
-      });
-      await waitFor(() => {
-        expect(screen.getByTestId('image-preview-editor')).toBeInTheDocument();
-      });
-    }
-
-    it('routes URL input through onUploadFromUrl on Confirm', async () => {
-      const onUploadFromUrl = vi
-        .fn<(url: string) => Promise<string>>()
-        .mockResolvedValue('https://cdn.example.com/from-url.jpg');
-      const onUpload = vi.fn<(blob: Blob) => Promise<string>>();
+  describe('ImageUploader Context', () => {
+    it('uses the default stub uploader when no provider is mounted', async () => {
+      // Intentionally bypass renderDialog helper to omit the provider.
       const onConfirm = vi.fn();
-      renderDialog({ onUploadFromUrl, onUpload, onConfirm });
+      render(<ImageUploadDialog {...defaultProps} onConfirm={onConfirm} />);
 
-      await enterProvidedImageWithUrl();
-      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-      await waitFor(() => {
-        expect(onUploadFromUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
-        expect(onConfirm).toHaveBeenCalledWith(
-          expect.objectContaining({ imageUrl: 'https://cdn.example.com/from-url.jpg' }),
-        );
-      });
-      // The Blob-based onUpload is NOT called for URL input.
-      expect(onUpload).not.toHaveBeenCalled();
-    });
-
-    it('falls back to defaultUrlUploadHandler when the host does not supply onUploadFromUrl', async () => {
-      // Storybook/dev parity — both handlers have stub defaults. Previously
-      // URL confirms without a handler silently uploaded an empty blob
-      // (0-byte CDN object). Now the bundled stub fires and returns a
-      // visible mock URL.
-      const onUpload = vi.fn<(blob: Blob) => Promise<string>>();
-      const onConfirm = vi.fn();
-      renderDialog({ onUpload, onConfirm });
-
-      await enterProvidedImageWithUrl();
-      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
+      fireEvent.click(screen.getByText('drop file'));
+      // defaultImageUploader.uploadFile returns a picsum URL after a 1.5s delay;
+      // allow waitFor enough time.
       await waitFor(
         () => {
           expect(onConfirm).toHaveBeenCalledWith(
             expect.objectContaining({
-              imageUrl: expect.stringMatching(/^https:\/\/picsum\.photos\//),
+              imageUrl: expect.stringMatching(/picsum\.photos/),
             }),
           );
         },
         { timeout: 3000 },
       );
-      // File upload handler must not fire for URL input.
-      expect(onUpload).not.toHaveBeenCalled();
     });
 
-    it('does not touch onUploadFromUrl for File input — Blob path still uses onUpload', async () => {
-      const { defaultUploadHandler } =
-        await import('@/types/canary/utilities/image-upload-handlers');
-      (defaultUploadHandler as ReturnType<typeof vi.fn>).mockResolvedValue(
-        'https://cdn.example.com/images/mock-uploaded.jpg',
-      );
-      const onUploadFromUrl = vi.fn<(url: string) => Promise<string>>();
+    it('respects a provider-supplied uploader over the default', async () => {
+      const uploader = makeMockUploader();
+      uploader.uploadFile.mockResolvedValue('https://cdn.provider.arda.cards/uploaded.jpg');
       const onConfirm = vi.fn();
-      renderDialog({ onUploadFromUrl, onConfirm });
+      renderDialog({ onConfirm }, uploader);
 
       fireEvent.click(screen.getByText('drop file'));
-      await act(async () => {
-        await Promise.resolve();
-      });
-      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
       await waitFor(() => {
-        expect(onConfirm).toHaveBeenCalled();
+        expect(onConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: 'https://cdn.provider.arda.cards/uploaded.jpg' }),
+        );
       });
-      expect(onUploadFromUrl).not.toHaveBeenCalled();
+    });
+
+    it('defaultImageUploader is exported and callable (stories/dev safety)', async () => {
+      // Regression guard — if this export goes away, Storybook play functions
+      // that depend on the stub break in hard-to-diagnose ways.
+      expect(defaultImageUploader).toBeDefined();
+      expect(typeof defaultImageUploader.uploadFile).toBe('function');
+      expect(typeof defaultImageUploader.uploadFromUrl).toBe('function');
+      expect(typeof defaultImageUploader.checkReachability).toBe('function');
     });
   });
 });

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
@@ -79,7 +79,17 @@ type DialogPhase =
   | { name: 'EditExisting'; imageUrl: string }
   | { name: 'EmptyImage' }
   | { name: 'FailedValidation'; errorMessage: string }
-  | { name: 'Uploading'; imageData: File | Blob | string; skipUpload?: boolean }
+  | {
+      name: 'Uploading';
+      imageData: File | Blob | string;
+      skipUpload?: boolean;
+      /** Monotonic nonce so two back-to-back Uploading transitions re-fire
+       *  the upload effect. Without it, a `pendingInput` identity change
+       *  while already in `Uploading` keeps `phase.name === 'Uploading'`
+       *  and the effect (keyed on name alone) never re-runs, stranding the
+       *  second upload. */
+      uploadId: number;
+    }
   | { name: 'UploadError'; error: string; imageData: File | Blob | string };
 
 type DialogAction =
@@ -93,12 +103,22 @@ type DialogAction =
   | { type: 'UPLOAD_NEW' }
   | { type: 'RESET'; existingImageUrl: string | null };
 
+// Monotonic counter to stamp every Uploading-phase transition with a
+// unique `uploadId`. See the DialogPhase.Uploading.uploadId docstring for
+// why this is needed; the counter lives at module scope so React Strict
+// Mode's double-dispatch doesn't produce duplicate ids within one render.
+let nextUploadId = 0;
+function makeUploadId(): number {
+  nextUploadId += 1;
+  return nextUploadId;
+}
+
 function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
   switch (action.type) {
     case 'INPUT_FILE':
-      return { name: 'Uploading', imageData: action.file };
+      return { name: 'Uploading', imageData: action.file, uploadId: makeUploadId() };
     case 'INPUT_URL':
-      return { name: 'Uploading', imageData: action.url };
+      return { name: 'Uploading', imageData: action.url, uploadId: makeUploadId() };
     case 'INPUT_ERROR':
       return { name: 'FailedValidation', errorMessage: action.message };
     case 'UPLOAD_ERROR': {
@@ -109,7 +129,7 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
     }
     case 'UPLOAD_RETRY': {
       if (state.name === 'UploadError') {
-        return { name: 'Uploading', imageData: state.imageData };
+        return { name: 'Uploading', imageData: state.imageData, uploadId: makeUploadId() };
       }
       return state;
     }
@@ -124,9 +144,18 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
         // If the action carries a cropped blob, upload it as a new image.
         // If no blob (crop failed or no edits), confirm with the original URL.
         if (action.croppedBlob) {
-          return { name: 'Uploading', imageData: action.croppedBlob };
+          return {
+            name: 'Uploading',
+            imageData: action.croppedBlob,
+            uploadId: makeUploadId(),
+          };
         }
-        return { name: 'Uploading', imageData: state.imageUrl, skipUpload: true };
+        return {
+          name: 'Uploading',
+          imageData: state.imageUrl,
+          skipUpload: true,
+          uploadId: makeUploadId(),
+        };
       }
       return state;
     }
@@ -293,20 +322,44 @@ export function ImageUploadDialog({
     return () => {
       cancelled = true;
     };
-  }, [phase.name]); // Intentionally deps on phase.name only — fires once on entering Uploading
+    // Depends on `phase.name` AND the Uploading-state `uploadId` nonce
+    // so back-to-back Uploading transitions (e.g. a new pendingInput
+    // identity arriving while a previous upload is still in flight)
+    // re-fire this effect and start the new upload. The stale-closure
+    // cancel flag guards against the first upload's late resolution.
+  }, [phase.name, phase.name === 'Uploading' ? phase.uploadId : 0]);
+
+  // Track `open` in a ref so async reachability resolutions don't
+  // dispatch into a closed dialog.
+  const isOpenRef = React.useRef(open);
+  React.useEffect(() => {
+    isOpenRef.current = open;
+  }, [open]);
 
   const handleInput = React.useCallback((input: ImageInput) => {
     if (input.type === 'file') {
       dispatch({ type: 'INPUT_FILE', file: input.file });
     } else if (input.type === 'url') {
-      // Reachability check; transition optimistically
-      uploaderRef.current.checkReachability(input.url).then((reachable) => {
-        if (reachable) {
-          dispatch({ type: 'INPUT_URL', url: input.url });
-        } else {
-          dispatch({ type: 'INPUT_ERROR', message: 'URL could not be reached' });
-        }
-      });
+      // Reachability check; transition optimistically on success, surface
+      // the reachability error through FailedValidation on failure.
+      uploaderRef.current
+        .checkReachability(input.url)
+        .then((reachable) => {
+          if (!isOpenRef.current) return;
+          if (reachable) {
+            dispatch({ type: 'INPUT_URL', url: input.url });
+          } else {
+            dispatch({ type: 'INPUT_ERROR', message: 'URL could not be reached' });
+          }
+        })
+        .catch((err: unknown) => {
+          if (!isOpenRef.current) return;
+          const message =
+            err instanceof Error && err.message
+              ? `Could not validate the URL: ${err.message}`
+              : 'Could not validate the URL';
+          dispatch({ type: 'INPUT_ERROR', message });
+        });
     } else {
       dispatch({ type: 'INPUT_ERROR', message: input.message });
     }

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
@@ -8,28 +8,14 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/canary/atoms/dialog/dialog';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogAction,
-  AlertDialogCancel,
-} from '@/components/canary/primitives/alert-dialog';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/canary/primitives/button';
 import { ImageDropZone } from '@/components/canary/molecules/image-drop-zone/image-drop-zone';
 import { ImagePreviewEditor } from '@/components/canary/molecules/image-preview-editor/image-preview-editor';
 import { ImageComparisonLayout } from '@/components/canary/molecules/image-comparison-layout/image-comparison-layout';
-import {
-  defaultUploadHandler,
-  defaultUrlUploadHandler,
-  defaultReachabilityCheck,
-} from '@/types/canary/utilities/image-upload-handlers';
 import { getCroppedImage } from '@/types/canary/utilities/get-cropped-image';
 import { prefetchImageAsBlob } from '@/types/canary/utilities/cdn-url';
+import { useImageUploader } from '@/types/canary/utilities/image-uploader';
 import type {
   ImageFieldConfig,
   ImageInput,
@@ -49,6 +35,11 @@ export interface ImageUploadDialogInitProps {
 /**
  * Runtime props for ImageUploadDialog.
  * Confirm/cancel callbacks follow `EditLifecycleCallbacks<ImageUploadResult>`.
+ *
+ * As of 4.11.7, upload/URL-upload/reachability are provided by the
+ * `ImageUploader` on the surrounding `ImageUploadProvider` Context — no
+ * longer wired per-callback here. See the `useImageUploader` hook and
+ * the `ImageUploadProvider` component.
  */
 export interface ImageUploadDialogRuntimeProps {
   existingImageUrl: string | null;
@@ -56,29 +47,12 @@ export interface ImageUploadDialogRuntimeProps {
   open: boolean;
   onCancel: () => void;
   /**
-   * Upload handler &#8212; receives the image blob, returns the CDN URL.
-   * Defaults to `defaultUploadHandler` (Storybook/dev stub).
-   */
-  onUpload?: (file: Blob) => Promise<string>;
-  /**
-   * Upload-from-URL handler &#8212; receives an external image URL, performs
-   * the server-side fetch + upload round-trip, and returns the CDN URL.
-   * Defaults to `defaultUrlUploadHandler` (Storybook/dev stub); production
-   * consumers must pass a real handler.
-   */
-  onUploadFromUrl?: (url: string) => Promise<string>;
-  /**
-   * URL reachability check &#8212; returns true if the URL is reachable.
-   * Defaults to `defaultReachabilityCheck`.
-   */
-  onCheckReachability?: (url: string) => Promise<boolean>;
-  /**
    * Externally-supplied image input &#8212; typically forwarded from the host's
-   * own drop zone (e.g. ItemCardEditor). When defined while `open` is true,
-   * the input is dispatched through the same state-machine path as the
-   * dialog's internal `ImageDropZone`: file inputs land synchronously in
-   * `ProvidedImage`; URL inputs go through reachability check first; error
-   * inputs land in `FailedValidation`.
+   * own drop zone. When defined while `open` is true, the input is
+   * dispatched through the same state-machine path as the dialog's
+   * internal `ImageDropZone`: file inputs land directly in `Uploading`
+   * (no cropper review step — rapid-batch UX); URL inputs go through
+   * reachability check first; error inputs land in `FailedValidation`.
    *
    * A new identity (referential inequality) is treated as a new dispatch.
    * The host should clear this prop on confirm/cancel to avoid re-entry on
@@ -93,27 +67,28 @@ export type ImageUploadDialogProps = ImageUploadDialogStaticProps &
   ImageUploadDialogRuntimeProps;
 
 // --- State machine ---
+//
+// As of 4.11.7 the dialog does NOT stop in a cropper review step on new
+// uploads (completing the #750 issue 1 "rapid-batch" directive across
+// both ItemCardEditor and this dialog). File/URL inputs land directly
+// in `Uploading`. The cropper only appears in the `EditExisting` phase
+// — the deliberate edit-existing-image flow where the user has asked
+// to crop/zoom/rotate an already-placed image.
 
 type DialogPhase =
   | { name: 'EditExisting'; imageUrl: string }
   | { name: 'EmptyImage' }
-  | { name: 'ProvidedImage'; imageData: File | Blob | string }
   | { name: 'FailedValidation'; errorMessage: string }
   | { name: 'Uploading'; imageData: File | Blob | string; skipUpload?: boolean }
-  | { name: 'UploadError'; error: string; imageData: File | Blob | string }
-  | { name: 'Warn'; imageData: File | Blob | string };
+  | { name: 'UploadError'; error: string; imageData: File | Blob | string };
 
 type DialogAction =
   | { type: 'INPUT_FILE'; file: File }
   | { type: 'INPUT_URL'; url: string }
   | { type: 'INPUT_ERROR'; message: string }
-  | { type: 'CANCEL_CLICK' }
-  | { type: 'CONFIRM_CLICK' }
   | { type: 'UPLOAD_ERROR'; error: string }
   | { type: 'UPLOAD_RETRY' }
   | { type: 'UPLOAD_DISCARD' }
-  | { type: 'WARN_DISCARD' }
-  | { type: 'WARN_GO_BACK' }
   | { type: 'EDIT_CONFIRM'; croppedBlob?: Blob }
   | { type: 'UPLOAD_NEW' }
   | { type: 'RESET'; existingImageUrl: string | null };
@@ -121,23 +96,11 @@ type DialogAction =
 function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
   switch (action.type) {
     case 'INPUT_FILE':
-      return { name: 'ProvidedImage', imageData: action.file };
+      return { name: 'Uploading', imageData: action.file };
     case 'INPUT_URL':
-      return { name: 'ProvidedImage', imageData: action.url };
+      return { name: 'Uploading', imageData: action.url };
     case 'INPUT_ERROR':
       return { name: 'FailedValidation', errorMessage: action.message };
-    case 'CANCEL_CLICK': {
-      if (state.name === 'ProvidedImage') {
-        return { name: 'Warn', imageData: state.imageData };
-      }
-      return state;
-    }
-    case 'CONFIRM_CLICK': {
-      if (state.name === 'ProvidedImage') {
-        return { name: 'Uploading', imageData: state.imageData };
-      }
-      return state;
-    }
     case 'UPLOAD_ERROR': {
       if (state.name === 'Uploading') {
         return { name: 'UploadError', error: action.error, imageData: state.imageData };
@@ -153,14 +116,6 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
     case 'UPLOAD_DISCARD': {
       if (state.name === 'UploadError') {
         return { name: 'EmptyImage' };
-      }
-      return state;
-    }
-    case 'WARN_DISCARD':
-      return { name: 'EmptyImage' };
-    case 'WARN_GO_BACK': {
-      if (state.name === 'Warn') {
-        return { name: 'ProvidedImage', imageData: state.imageData };
       }
       return state;
     }
@@ -194,10 +149,13 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
 // --- Component ---
 
 /**
- * ImageUploadDialog &#8212; state-machine orchestrator for the full image upload flow.
+ * ImageUploadDialog — state-machine orchestrator for the full image upload flow.
  *
- * Manages the EditExisting / EmptyImage &#8594; ProvidedImage &#8594; Uploading lifecycle plus
- * FailedValidation and Warn guard states.
+ * As of 4.11.7:
+ * - Uploader is consumed from `ImageUploadProvider` via `useImageUploader`.
+ * - New file/URL inputs skip the cropper review step and go directly to
+ *   `Uploading` (rapid-batch UX). The cropper is reachable only via
+ *   `EditExisting` when an existing image is already on record.
  */
 export function ImageUploadDialog({
   config,
@@ -205,11 +163,9 @@ export function ImageUploadDialog({
   onConfirm,
   open,
   onCancel,
-  onUpload = defaultUploadHandler,
-  onUploadFromUrl = defaultUrlUploadHandler,
-  onCheckReachability = defaultReachabilityCheck,
   pendingInput,
 }: ImageUploadDialogProps) {
+  const uploader = useImageUploader();
   const [phase, dispatch] = React.useReducer(dialogReducer, { name: 'EmptyImage' });
   // Independent refs for crop/zoom/rotation — kept separate so zoom and
   // rotation changes don't clobber the last valid pixelCrop (#750 issue 5b).
@@ -227,13 +183,11 @@ export function ImageUploadDialog({
   // blob URL for both display and canvas operations.
   const [prefetchedImageUrl, setPrefetchedImageUrl] = React.useState<string | null>(null);
 
-  // Stable refs for callbacks used in effects to avoid stale closures.
+  // Stable refs for callbacks/uploader used in effects to avoid stale closures.
   const onConfirmRef = React.useRef(onConfirm);
   onConfirmRef.current = onConfirm;
-  const onUploadRef = React.useRef(onUpload);
-  onUploadRef.current = onUpload;
-  const onUploadFromUrlRef = React.useRef(onUploadFromUrl);
-  onUploadFromUrlRef.current = onUploadFromUrl;
+  const uploaderRef = React.useRef(uploader);
+  uploaderRef.current = uploader;
 
   // Reset state when dialog opens/closes
   const resetEditRefs = React.useCallback(() => {
@@ -244,7 +198,7 @@ export function ImageUploadDialog({
   React.useEffect(() => {
     // When the dialog opens with a pendingInput already queued, skip the
     // EditExisting initial state — the pendingInput effect will dispatch
-    // INPUT_FILE/INPUT_URL into ProvidedImage on the same render. Starting
+    // INPUT_FILE/INPUT_URL into Uploading on the same render. Starting
     // in EditExisting would kick off a CDN prefetch that immediately gets
     // discarded, wasting a network round-trip.
     const initialExistingUrl = open && !pendingInput ? existingImageUrl : null;
@@ -304,22 +258,20 @@ export function ImageUploadDialog({
       };
     }
 
-    // For new uploads, the two input kinds take different paths:
+    // For new uploads, the two input kinds take different paths on the
+    // ImageUploader interface:
     //
-    // - Blob/File: send the bytes directly via `onUpload`.
-    // - string URL: route through `onUploadFromUrl`, which is expected to
-    //   fetch the external URL server-side (bypassing browser CORS) and
-    //   then upload the fetched bytes.
+    // - Blob/File → `uploader.uploadFile(bytes)`.
+    // - string URL → `uploader.uploadFromUrl(url)`, which performs the
+    //   server-side fetch + upload round-trip.
     //
-    // Both handlers have bundled defaults (`defaultUploadHandler` and
-    // `defaultUrlUploadHandler`) so Storybook and dev harnesses work out
-    // of the box. Production consumers must pass real handlers to avoid
-    // shipping the stubs — the defaults return picsum.photos URLs that
-    // would be very visible in the rendered card.
+    // If no `ImageUploadProvider` is mounted, `useImageUploader` returns
+    // the bundled default stub — so stories and dev harnesses work out
+    // of the box. Production consumers must mount a real provider.
     const uploadPromise: Promise<string> =
       typeof imageData === 'string'
-        ? onUploadFromUrlRef.current(imageData)
-        : onUploadRef.current(imageData);
+        ? uploaderRef.current.uploadFromUrl(imageData)
+        : uploaderRef.current.uploadFile(imageData);
 
     const originalSize = typeof imageData === 'string' ? 0 : imageData.size;
     uploadPromise
@@ -343,25 +295,22 @@ export function ImageUploadDialog({
     };
   }, [phase.name]); // Intentionally deps on phase.name only — fires once on entering Uploading
 
-  const handleInput = React.useCallback(
-    (input: ImageInput) => {
-      if (input.type === 'file') {
-        dispatch({ type: 'INPUT_FILE', file: input.file });
-      } else if (input.type === 'url') {
-        // Reachability check; transition optimistically
-        onCheckReachability(input.url).then((reachable) => {
-          if (reachable) {
-            dispatch({ type: 'INPUT_URL', url: input.url });
-          } else {
-            dispatch({ type: 'INPUT_ERROR', message: 'URL could not be reached' });
-          }
-        });
-      } else {
-        dispatch({ type: 'INPUT_ERROR', message: input.message });
-      }
-    },
-    [onCheckReachability],
-  );
+  const handleInput = React.useCallback((input: ImageInput) => {
+    if (input.type === 'file') {
+      dispatch({ type: 'INPUT_FILE', file: input.file });
+    } else if (input.type === 'url') {
+      // Reachability check; transition optimistically
+      uploaderRef.current.checkReachability(input.url).then((reachable) => {
+        if (reachable) {
+          dispatch({ type: 'INPUT_URL', url: input.url });
+        } else {
+          dispatch({ type: 'INPUT_ERROR', message: 'URL could not be reached' });
+        }
+      });
+    } else {
+      dispatch({ type: 'INPUT_ERROR', message: input.message });
+    }
+  }, []);
 
   // Forward externally-supplied pendingInput through the same state-machine
   // path as the dialog's internal ImageDropZone. Tracked by referential
@@ -379,20 +328,6 @@ export function ImageUploadDialog({
       handleInput(pendingInput);
     }
   }, [open, pendingInput, handleInput]);
-
-  const handleCancelClick = React.useCallback(() => {
-    if (phase.name === 'ProvidedImage') {
-      dispatch({ type: 'CANCEL_CLICK' });
-    } else {
-      onCancel();
-    }
-  }, [phase.name, onCancel]);
-
-  const handleConfirmClick = React.useCallback(() => {
-    if (phase.name === 'ProvidedImage') {
-      dispatch({ type: 'CONFIRM_CLICK' });
-    }
-  }, [phase.name]);
 
   const handleEditConfirm = React.useCallback(async () => {
     if (phase.name !== 'EditExisting') return;
@@ -426,8 +361,8 @@ export function ImageUploadDialog({
           rotation,
           zoom,
         });
-        // Upload the cropped/rotated image as a new file. The upload effect
-        // will call onUpload(blob) → S3 → return the new CDN URL.
+        // Upload the cropped/rotated image as a new file via the
+        // uploader; the Uploading effect picks up the Blob imageData.
         dispatch({ type: 'EDIT_CONFIRM', croppedBlob });
         return;
       } catch {
@@ -439,231 +374,123 @@ export function ImageUploadDialog({
     dispatch({ type: 'EDIT_CONFIRM' });
   }, [phase, prefetchedImageUrl]);
 
-  const handleWarnDiscard = React.useCallback(() => {
-    dispatch({ type: 'WARN_DISCARD' });
-    onCancel();
-  }, [onCancel]);
-
-  const handleWarnGoBack = React.useCallback(() => {
-    dispatch({ type: 'WARN_GO_BACK' });
-  }, []);
-
   const handleOpenChange = React.useCallback(
     (isOpen: boolean) => {
-      if (!isOpen) {
-        if (phase.name === 'ProvidedImage') {
-          dispatch({ type: 'CANCEL_CLICK' });
-        } else {
-          onCancel();
-        }
-      }
+      if (!isOpen) onCancel();
     },
-    [phase.name, onCancel],
+    [onCancel],
   );
 
   const isUploading = phase.name === 'Uploading';
-  const isUploadError = phase.name === 'UploadError';
-  const isProvidedOrUploading =
-    phase.name === 'ProvidedImage' || phase.name === 'Uploading' || phase.name === 'Warn';
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent
-          data-slot="image-upload-dialog"
-          className={cn(
-            'bg-background border-border rounded-lg p-4 sm:p-6 sm:max-w-2xl w-full overflow-hidden',
-          )}
-          showCloseButton={false}
-        >
-          <DialogHeader>
-            <DialogTitle>
-              {phase.name === 'EditExisting'
-                ? `Edit ${config.propertyDisplayName}`
-                : isProvidedOrUploading
-                  ? `Edit ${config.propertyDisplayName}`
-                  : `Add ${config.propertyDisplayName}`}
-            </DialogTitle>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        data-slot="image-upload-dialog"
+        className={cn(
+          'bg-background border-border rounded-lg p-4 sm:p-6 sm:max-w-2xl w-full overflow-hidden',
+        )}
+        showCloseButton={false}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {phase.name === 'EditExisting'
+              ? `Edit ${config.propertyDisplayName}`
+              : phase.name === 'Uploading'
+                ? `Upload ${config.propertyDisplayName}`
+                : `Add ${config.propertyDisplayName}`}
+          </DialogTitle>
+        </DialogHeader>
 
-          {/* EditExisting state — side-by-side with baked-in action buttons */}
-          {phase.name === 'EditExisting' && (
-            <ImageComparisonLayout
-              existingImageUrl={phase.imageUrl}
-              entityTypeDisplayName={config.entityTypeDisplayName}
-              propertyDisplayName={config.propertyDisplayName}
-              onAccept={() => void handleEditConfirm()}
-              onDismiss={onCancel}
-              onUploadNew={() => dispatch({ type: 'UPLOAD_NEW' })}
-            >
-              <ImagePreviewEditor
-                aspectRatio={config.aspectRatio}
-                imageData={prefetchedImageUrl ?? phase.imageUrl}
-                onCropComplete={(pc) => {
-                  pixelCropRef.current = pc;
-                }}
-                onZoomChange={(z) => {
-                  zoomRef.current = z;
-                }}
-                onRotationChange={(r) => {
-                  rotationRef.current = r;
-                }}
-                onReset={resetEditRefs}
-              />
-            </ImageComparisonLayout>
-          )}
+        {/* EditExisting state — side-by-side with baked-in action buttons */}
+        {phase.name === 'EditExisting' && (
+          <ImageComparisonLayout
+            existingImageUrl={phase.imageUrl}
+            entityTypeDisplayName={config.entityTypeDisplayName}
+            propertyDisplayName={config.propertyDisplayName}
+            onAccept={() => void handleEditConfirm()}
+            onDismiss={onCancel}
+            onUploadNew={() => dispatch({ type: 'UPLOAD_NEW' })}
+          >
+            <ImagePreviewEditor
+              aspectRatio={config.aspectRatio}
+              imageData={prefetchedImageUrl ?? phase.imageUrl}
+              onCropComplete={(pc) => {
+                pixelCropRef.current = pc;
+              }}
+              onZoomChange={(z) => {
+                zoomRef.current = z;
+              }}
+              onRotationChange={(r) => {
+                rotationRef.current = r;
+              }}
+              onReset={resetEditRefs}
+            />
+          </ImageComparisonLayout>
+        )}
 
-          {/* EmptyImage state */}
-          {phase.name === 'EmptyImage' && (
+        {/* EmptyImage state */}
+        {phase.name === 'EmptyImage' && (
+          <ImageDropZone acceptedFormats={config.acceptedFormats} onInput={handleInput} />
+        )}
+
+        {/* FailedValidation state */}
+        {phase.name === 'FailedValidation' && (
+          <div className="flex flex-col gap-3">
+            <p className={cn('text-sm text-destructive')} role="alert">
+              {phase.errorMessage}
+            </p>
             <ImageDropZone acceptedFormats={config.acceptedFormats} onInput={handleInput} />
-          )}
+          </div>
+        )}
 
-          {/* FailedValidation state */}
-          {phase.name === 'FailedValidation' && (
-            <div className="flex flex-col gap-3">
-              <p className={cn('text-sm text-destructive')} role="alert">
-                {phase.errorMessage}
-              </p>
-              <ImageDropZone acceptedFormats={config.acceptedFormats} onInput={handleInput} />
-            </div>
-          )}
+        {/* Uploading state — indeterminate spinner (FD-04) */}
+        {phase.name === 'Uploading' && (
+          <div className="flex flex-col items-center gap-4 py-8" role="status">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
+            <p className="text-sm text-muted-foreground">Uploading image&#8230;</p>
+          </div>
+        )}
 
-          {/* ProvidedImage state */}
-          {phase.name === 'ProvidedImage' && (
-            <div className="flex flex-col gap-4">
-              {existingImageUrl ? (
-                <ImageComparisonLayout
-                  existingImageUrl={existingImageUrl}
-                  entityTypeDisplayName={config.entityTypeDisplayName}
-                  propertyDisplayName={config.propertyDisplayName}
-                >
-                  <ImagePreviewEditor
-                    aspectRatio={config.aspectRatio}
-                    imageData={phase.imageData}
-                    onCropComplete={(pc) => {
-                      pixelCropRef.current = pc;
-                    }}
-                    onZoomChange={(z) => {
-                      zoomRef.current = z;
-                    }}
-                    onRotationChange={(r) => {
-                      rotationRef.current = r;
-                    }}
-                    onReset={resetEditRefs}
-                  />
-                </ImageComparisonLayout>
-              ) : (
-                <ImagePreviewEditor
-                  aspectRatio={config.aspectRatio}
-                  imageData={phase.imageData}
-                  onCropComplete={(pc) => {
-                    pixelCropRef.current = pc;
-                  }}
-                  onZoomChange={(z) => {
-                    zoomRef.current = z;
-                  }}
-                  onRotationChange={(r) => {
-                    rotationRef.current = r;
-                  }}
-                  onReset={resetEditRefs}
-                />
-              )}
-            </div>
-          )}
-
-          {/* Uploading state — indeterminate spinner (FD-04) */}
-          {phase.name === 'Uploading' && (
-            <div className="flex flex-col items-center gap-4 py-8" role="status">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
-              <p className="text-sm text-muted-foreground">Uploading image&#8230;</p>
-            </div>
-          )}
-
-          {/* UploadError state — error message with retry/discard */}
-          {phase.name === 'UploadError' && (
-            <div className="flex flex-col gap-4">
-              <p className={cn('text-sm text-destructive')} role="alert">
-                {phase.error}
-              </p>
-              <div className="flex justify-end gap-2">
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => dispatch({ type: 'UPLOAD_DISCARD' })}
-                >
-                  Discard
-                </Button>
-                <Button type="button" onClick={() => dispatch({ type: 'UPLOAD_RETRY' })}>
-                  Retry
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Footer — shown only for ProvidedImage */}
-          {/* EditExisting footer is baked into ImageComparisonLayout above */}
-          {!isUploading &&
-            !isUploadError &&
-            phase.name !== 'EmptyImage' &&
-            phase.name !== 'FailedValidation' &&
-            phase.name !== 'EditExisting' &&
-            phase.name !== 'Warn' && (
-              <DialogFooter className="flex flex-col gap-2">
-                <p className="text-xs text-muted-foreground text-center">
-                  By confirming, you acknowledge that you own or have a license to use this image.
-                </p>
-                <div className="flex justify-end gap-2">
-                  <Button type="button" variant="secondary" onClick={handleCancelClick}>
-                    Cancel
-                  </Button>
-                  <Button type="button" onClick={handleConfirmClick}>
-                    Confirm
-                  </Button>
-                </div>
-              </DialogFooter>
-            )}
-
-          {/* Footer for empty/failed states — just dismiss */}
-          {(phase.name === 'EmptyImage' || phase.name === 'FailedValidation') && (
-            <DialogFooter>
-              <Button type="button" variant="secondary" onClick={onCancel}>
-                Cancel
+        {/* UploadError state — error message with retry/discard */}
+        {phase.name === 'UploadError' && (
+          <div className="flex flex-col gap-4">
+            <p className={cn('text-sm text-destructive')} role="alert">
+              {phase.error}
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => dispatch({ type: 'UPLOAD_DISCARD' })}
+              >
+                Discard
               </Button>
-            </DialogFooter>
-          )}
-
-          {/* Uploading footer */}
-          {isUploading && (
-            <DialogFooter>
-              <Button type="button" variant="secondary" disabled>
-                Uploading&#8230;
+              <Button type="button" onClick={() => dispatch({ type: 'UPLOAD_RETRY' })}>
+                Retry
               </Button>
-            </DialogFooter>
-          )}
-        </DialogContent>
-      </Dialog>
+            </div>
+          </div>
+        )}
 
-      {/* Warn AlertDialog */}
-      <AlertDialog open={phase.name === 'Warn'}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Discard unsaved image?</AlertDialogTitle>
-            <AlertDialogDescription>
-              You have an image staged that has not been saved. Discarding will remove it
-              permanently.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={handleWarnGoBack}>Go Back</AlertDialogCancel>
-            <AlertDialogAction
-              className={cn('bg-destructive text-destructive-foreground hover:bg-destructive/90')}
-              onClick={handleWarnDiscard}
-            >
-              Discard
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+        {/* Footer for empty/failed states — just dismiss */}
+        {(phase.name === 'EmptyImage' || phase.name === 'FailedValidation') && (
+          <DialogFooter>
+            <Button type="button" variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        )}
+
+        {/* Uploading footer */}
+        {isUploading && (
+          <DialogFooter>
+            <Button type="button" variant="secondary" disabled>
+              Uploading&#8230;
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
+++ b/src/components/canary/organisms/shared/image-upload-dialog/image-upload-dialog.tsx
@@ -36,7 +36,7 @@ export interface ImageUploadDialogInitProps {
  * Runtime props for ImageUploadDialog.
  * Confirm/cancel callbacks follow `EditLifecycleCallbacks<ImageUploadResult>`.
  *
- * As of 4.11.7, upload/URL-upload/reachability are provided by the
+ * As of 5.0.0, upload/URL-upload/reachability are provided by the
  * `ImageUploader` on the surrounding `ImageUploadProvider` Context — no
  * longer wired per-callback here. See the `useImageUploader` hook and
  * the `ImageUploadProvider` component.
@@ -68,7 +68,7 @@ export type ImageUploadDialogProps = ImageUploadDialogStaticProps &
 
 // --- State machine ---
 //
-// As of 4.11.7 the dialog does NOT stop in a cropper review step on new
+// As of 5.0.0 the dialog does NOT stop in a cropper review step on new
 // uploads (completing the #750 issue 1 "rapid-batch" directive across
 // both ItemCardEditor and this dialog). File/URL inputs land directly
 // in `Uploading`. The cropper only appears in the `EditExisting` phase
@@ -151,7 +151,7 @@ function dialogReducer(state: DialogPhase, action: DialogAction): DialogPhase {
 /**
  * ImageUploadDialog — state-machine orchestrator for the full image upload flow.
  *
- * As of 4.11.7:
+ * As of 5.0.0:
  * - Uploader is consumed from `ImageUploadProvider` via `useImageUploader`.
  * - New file/URL inputs skip the cropper review step and go directly to
  *   `Uploading` (rapid-batch UX). The cropper is reachable only via

--- a/src/types/canary/utilities/image-uploader.tsx
+++ b/src/types/canary/utilities/image-uploader.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import {
+  defaultUploadHandler,
+  defaultUrlUploadHandler,
+  defaultReachabilityCheck,
+} from './image-upload-handlers';
+
+/**
+ * Contract for the full image-upload pipeline.
+ *
+ * A single object instead of three separate callback props — before
+ * 4.11.7 consumers had to wire `onUpload`, `onUploadFromUrl`, and
+ * `onCheckReachability` separately on every component that needed them.
+ * That shape made the application reverse-engineer which operations
+ * the component performed and in what order, and duplicated the wiring
+ * across every call site.
+ *
+ * The three operations are intentionally orthogonal:
+ *
+ * - `uploadFile` takes bytes the app already has (drag-dropped file,
+ *   clipboard Blob, cropped Blob from the editor) and returns the
+ *   persisted CDN URL.
+ * - `uploadFromUrl` takes an external URL the app does NOT have bytes
+ *   for and handles the full fetch-plus-upload round-trip server-side
+ *   (to bypass browser CORS).
+ * - `checkReachability` is an optional pre-flight on URLs so callers
+ *   can fail fast before attempting a full upload.
+ */
+export interface ImageUploader {
+  /** Upload a File/Blob; resolves to the persisted CDN URL. */
+  uploadFile(file: Blob): Promise<string>;
+  /** Fetch + upload an external URL; resolves to the persisted CDN URL. */
+  uploadFromUrl(url: string): Promise<string>;
+  /** HEAD-style check: is the URL fetchable? Returns false for obvious bad URLs. */
+  checkReachability(url: string): Promise<boolean>;
+}
+
+/**
+ * Default uploader used when no provider is mounted and no override is
+ * passed. Backed by the stubbed handlers in `image-upload-handlers.ts`
+ * so Storybook / dev harnesses work out of the box.
+ */
+export const defaultImageUploader: ImageUploader = {
+  uploadFile: defaultUploadHandler,
+  uploadFromUrl: defaultUrlUploadHandler,
+  checkReachability: defaultReachabilityCheck,
+};
+
+// --- React context ---
+
+const ImageUploadContext = React.createContext<ImageUploader>(defaultImageUploader);
+
+export interface ImageUploadProviderProps {
+  value: ImageUploader;
+  children: React.ReactNode;
+}
+
+/**
+ * Provide an `ImageUploader` to every design-system component in the
+ * subtree (`ItemCardEditor`, `ImageUploadDialog`, and any future
+ * component that needs upload semantics). Mount once at or above the
+ * level where upload-capable components live.
+ *
+ * @example
+ * ```tsx
+ * const uploader = useItemImageUploader();    // app hook
+ * return (
+ *   <ImageUploadProvider value={uploader}>
+ *     <ItemFormPanel />
+ *     <ItemsTable />
+ *   </ImageUploadProvider>
+ * );
+ * ```
+ */
+export function ImageUploadProvider({ value, children }: ImageUploadProviderProps) {
+  return <ImageUploadContext.Provider value={value}>{children}</ImageUploadContext.Provider>;
+}
+
+/**
+ * Access the current `ImageUploader`. Returns the default stub
+ * uploader if no `ImageUploadProvider` is mounted — keeps stories,
+ * dev pages, and isolated tests working without a wrapper.
+ */
+export function useImageUploader(): ImageUploader {
+  return React.useContext(ImageUploadContext);
+}

--- a/src/types/canary/utilities/image-uploader.tsx
+++ b/src/types/canary/utilities/image-uploader.tsx
@@ -10,7 +10,7 @@ import {
  * Contract for the full image-upload pipeline.
  *
  * A single object instead of three separate callback props — before
- * 4.11.7 consumers had to wire `onUpload`, `onUploadFromUrl`, and
+ * 5.0.0 consumers had to wire `onUpload`, `onUploadFromUrl`, and
  * `onCheckReachability` separately on every component that needed them.
  * That shape made the application reverse-engineer which operations
  * the component performed and in what order, and duplicated the wiring

--- a/src/use-cases/general-behaviors/entity-media/set-entity-image/0001-set-image/happy-path.stories.tsx
+++ b/src/use-cases/general-behaviors/entity-media/set-entity-image/0001-set-image/happy-path.stories.tsx
@@ -253,27 +253,22 @@ const { Interactive, Stepwise, Automated } = createUseCaseStories<ImageFormData>
       return el;
     });
     await userEvent.upload(fileInput, MOCK_FILE_JPEG);
+    // As of 4.11.7 the dialog skips the cropper/review stop for new
+    // uploads — file input dispatches directly into Uploading (no
+    // intermediate ProvidedImage phase, no Confirm button). The narrative
+    // scenes 3 & 4 are retained for the wizard's step labels but the
+    // automated play function no longer needs to click Confirm.
     goToScene(2);
     await delay();
-
-    // Scene 3 — ProvidedImage state: Confirm is enabled (copyright is passive subtext)
     goToScene(3);
     await delay();
 
-    // Scene 4 — click Confirm to begin upload
-    const confirmBtn = await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /^confirm$/i });
-      expect(btn).not.toBeDisabled();
-      return btn;
-    });
-    await userEvent.click(confirmBtn);
-
-    // Wait for the upload to complete (dialog closes, onConfirm fires)
+    // Scene 4/5 — wait for upload to complete (dialog closes, onConfirm fires)
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       },
-      { timeout: 4000 },
+      { timeout: 6000 },
     );
 
     goToScene(4);

--- a/src/use-cases/general-behaviors/entity-media/set-entity-image/0006-confirm-and-persist/cancel-no-change.stories.tsx
+++ b/src/use-cases/general-behaviors/entity-media/set-entity-image/0006-confirm-and-persist/cancel-no-change.stories.tsx
@@ -410,6 +410,14 @@ export const WarnOnDiscardPathStepwise: StoryObj = {
 
 export const WarnOnDiscardPathAutomated: StoryObj = {
   ...WarnOnDiscardAutomated,
-
+  // The automated play function exercises the Warn alert dialog shown when
+  // a user cancels a staged-but-not-yet-uploaded image. As of 4.11.7 that
+  // phase (ProvidedImage) was removed — drops commit directly via
+  // Uploading, so there is no "unsaved staged image" to warn about. The
+  // scenario is unreachable in the current product. Play-test is skipped
+  // in CI; the Interactive/Stepwise variants remain as historical
+  // documentation of the removed UX. Delete in v5 when the story is
+  // formally retired.
+  tags: ['skip-ci'],
   name: 'Warn on Discard (Automated)',
 };

--- a/src/use-cases/general-behaviors/entity-media/set-entity-image/0006-confirm-and-persist/external-url.stories.tsx
+++ b/src/use-cases/general-behaviors/entity-media/set-entity-image/0006-confirm-and-persist/external-url.stories.tsx
@@ -259,37 +259,27 @@ const {
       { timeout: 5000 },
     );
 
-    // Type the URL and press Enter
+    // Type the URL and press Enter. 4.11.7 skips the cropper/review
+    // step for new uploads — the URL input dispatches directly through
+    // reachability check into Uploading, then onConfirm, then the
+    // dialog closes. No Confirm button to click.
     const urlInput = screen.getByPlaceholderText(/example\.com\/image/i);
     await userEvent.clear(urlInput);
     await userEvent.type(urlInput, MOCK_EXTERNAL_URL);
     goToScene(1);
     await userEvent.keyboard('{Enter}');
 
-    // Wait for ProvidedImage state (Confirm is enabled, copyright is passive subtext)
-    await waitFor(
-      () => {
-        expect(screen.getByRole('button', { name: /confirm/i })).not.toBeDisabled();
-      },
-      { timeout: 5000 },
-    );
-
     goToScene(2);
     await delay();
-
-    // Click confirm
-    const confirmBtn = screen.getByRole('button', { name: /confirm/i });
-    await userEvent.click(confirmBtn);
-
     goToScene(3);
     await delay();
 
-    // Wait for dialog to close
+    // Wait for dialog to close (Uploading → onConfirm → unmount).
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       },
-      { timeout: 5000 },
+      { timeout: 6000 },
     );
 
     goToScene(4);

--- a/src/use-cases/general-behaviors/entity-media/set-entity-image/0006-confirm-and-persist/managed-upload.stories.tsx
+++ b/src/use-cases/general-behaviors/entity-media/set-entity-image/0006-confirm-and-persist/managed-upload.stories.tsx
@@ -303,27 +303,15 @@ const {
     });
     await userEvent.upload(fileInput, MOCK_FILE_JPEG);
 
-    // Wait for ProvidedImage state (Confirm is enabled, copyright is passive subtext)
-    await waitFor(
-      () => {
-        expect(screen.getByRole('button', { name: /confirm/i })).not.toBeDisabled();
-      },
-      { timeout: 5000 },
-    );
-
+    // 4.11.7 skips the cropper/review stop — the file input dispatches
+    // directly into Uploading, then onConfirm, then the dialog closes.
+    // No Confirm button appears.
     goToScene(1);
     await delay();
-
     goToScene(2);
     await delay();
-
-    // Click confirm
-    const confirmBtn = screen.getByRole('button', { name: /confirm/i });
-    await userEvent.click(confirmBtn);
-
     goToScene(3);
     await delay();
-
     goToScene(4);
     await delay();
 


### PR DESCRIPTION
## Summary

Replaces three per-component callback props with a single `ImageUploader` interface consumed via React Context. Also completes the rapid-batch UX directive by skipping the cropper review step for **all** new uploads (previously applied to `ItemCardEditor` in 4.11.6; now also applied to `ImageUploadDialog`'s state machine).

**Hard API break**: the three per-callback props (`onUpload`, `onUploadFromUrl`, `onCheckReachability`) are removed from `ItemCardEditor` and `ImageUploadDialog`. Consumers migrate by mounting `<ImageUploadProvider value={uploader}>` once per subtree. arda-frontend-app is the only known consumer; companion PR on that side in a separate commit.

## Why

See `knowledge-base/component-abstractions.md` in this patch for the full rationale. Short version: two consumers were destructuring the same 3 callbacks from the same bridge hook and prop-drilling them into sibling design-system components. Product directives applied to one component had to be mirrored in the other (parallel-implementation drift). The `skip cropper on upload` directive was the smoking-gun symptom; this PR consolidates the upload pipeline into one interface + one provider.

## API shape

```ts
interface ImageUploader {
  uploadFile(file: Blob): Promise<string>;
  uploadFromUrl(url: string): Promise<string>;
  checkReachability(url: string): Promise<boolean>;
}

<ImageUploadProvider value={uploader}>
  <ItemFormPanel />
  <ItemsTable />
</ImageUploadProvider>
```

## Test plan

- [x] 25 unit tests on `ImageUploadDialog` rewritten against the new state machine
- [x] 11 unit tests on `ItemCardEditor` rewritten
- [x] Mocks use `Mocked<T>` from vitest (no `as` casts)
- [x] Full `npm test` green: 1311/1311
- [x] `make ci` green: lint + typecheck + Storybook play functions + VRT
- [x] Obsolete `WarnOnDiscard` scenario unreachable post-4.11.7; Automated play-test marked `skip-ci` with migration note
- [x] New skill at `.claude/skills/clean-components/SKILL.md` capturing the lessons
- [x] ux-prototype `knowledge-base/` seeded with 4 concrete reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)