### PR TITLE
fix: center canvas export when zoom < 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [5.0.1] - 2026-04-16
+## [5.1.1] - 2026-04-16
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   source coordinates to the available pixel bounds and offsets the destination
   rectangle so the cropped output matches the editor preview. Previously,
   `drawImage` silently clipped negative source coords to 0, pegging the
-  result to the top-left corner instead of centering it
+  result to the top-left corner instead of centering it.
   (Arda-cards/arda-frontend-app#750).
 
 ## [5.1.0] - 2026-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [5.0.1] - 2026-04-16
+
+### Fixed
+
+- Canvas export centers the image when zoom < 1. `getCroppedImage` now clamps
+  source coordinates to the available pixel bounds and offsets the destination
+  rectangle so the cropped output matches the editor preview. Previously,
+  `drawImage` silently clipped negative source coords to 0, pegging the
+  result to the top-left corner instead of centering it
+  (Arda-cards/arda-frontend-app#750).
+
 ## [5.1.0] - 2026-04-15
 
 ### Added

--- a/src/types/canary/utilities/get-cropped-image.test.ts
+++ b/src/types/canary/utilities/get-cropped-image.test.ts
@@ -137,4 +137,26 @@ describe('getCroppedImage', () => {
     expect(capturedWidth).toBe(101);
     expect(capturedHeight).toBe(101);
   });
+
+  it('centers the image when crop extends beyond bounds (zoom < 1)', async () => {
+    const { ctx } = installCanvasMock('image/jpeg');
+
+    // Simulate zoom < 1: crop area is larger than the 1×1 image, with
+    // negative offsets (crop extends beyond the rotated image bounds).
+    const oversizedCrop: PixelCrop = { x: -1, y: -1, width: 3, height: 3 };
+    await runCrop({ pixelCrop: oversizedCrop });
+
+    // The second drawImage call extracts the crop region.
+    // Source coords should be clamped (sx=0, sy=0) and destination offset
+    // by the clamped amount (dx=1, dy=1) to center the image.
+    const cropDraw = ctx.drawImage.mock.calls[1]!;
+    // drawImage(canvas, sx, sy, sw, sh, dx, dy, dw, dh)
+    const [, sx, sy, sw, sh, dx, dy] = cropDraw;
+    expect(sx).toBe(0); // clamped from -1
+    expect(sy).toBe(0); // clamped from -1
+    expect(dx).toBe(1); // offset = 0 - (-1) = 1
+    expect(dy).toBe(1); // offset = 0 - (-1) = 1
+    expect(sw).toBe(1); // clamped to available width
+    expect(sh).toBe(1); // clamped to available height
+  });
 });

--- a/src/types/canary/utilities/get-cropped-image.ts
+++ b/src/types/canary/utilities/get-cropped-image.ts
@@ -88,23 +88,31 @@ export async function getCroppedImage(options: GetCroppedImageOptions): Promise<
         }
       : { x: 0, y: 0, width: bBoxWidth, height: bBoxHeight };
 
+  // Extract the crop region.
+  // When zoom < 1 the crop area reported by react-easy-crop extends beyond
+  // the rotated image bounds (negative x/y or size > image). A plain
+  // drawImage clips to the available source pixels, pegging the result to
+  // the top-left corner. Clamp the source rect to the actual image and
+  // offset the destination so the image stays centered in the output.
   const croppedCanvas = document.createElement('canvas');
   const croppedCtx = croppedCanvas.getContext('2d');
   if (!croppedCtx) throw new Error('Failed to obtain 2D canvas context for crop');
   croppedCanvas.width = effectiveCrop.width;
   croppedCanvas.height = effectiveCrop.height;
 
-  croppedCtx.drawImage(
-    canvas,
-    effectiveCrop.x,
-    effectiveCrop.y,
-    effectiveCrop.width,
-    effectiveCrop.height,
-    0,
-    0,
-    effectiveCrop.width,
-    effectiveCrop.height,
-  );
+  // Clamp source coordinates to available pixels
+  const sx = Math.max(0, effectiveCrop.x);
+  const sy = Math.max(0, effectiveCrop.y);
+  const sRight = Math.min(bBoxWidth, effectiveCrop.x + effectiveCrop.width);
+  const sBottom = Math.min(bBoxHeight, effectiveCrop.y + effectiveCrop.height);
+  const sw = Math.max(0, sRight - sx);
+  const sh = Math.max(0, sBottom - sy);
+
+  // Offset destination so the drawn region is centered
+  const dx = sx - effectiveCrop.x;
+  const dy = sy - effectiveCrop.y;
+
+  croppedCtx.drawImage(canvas, sx, sy, sw, sh, dx, dy, sw, sh);
 
   return new Promise((resolve, reject) => {
     croppedCanvas.toBlob(

--- a/src/types/canary/utilities/get-cropped-image.ts
+++ b/src/types/canary/utilities/get-cropped-image.ts
@@ -112,7 +112,13 @@ export async function getCroppedImage(options: GetCroppedImageOptions): Promise<
   const dx = sx - effectiveCrop.x;
   const dy = sy - effectiveCrop.y;
 
-  croppedCtx.drawImage(canvas, sx, sy, sw, sh, dx, dy, sw, sh);
+  // If the requested crop lies completely outside the rotated image bounds,
+  // there is nothing to draw. Leave the output canvas blank/transparent and
+  // still export it, rather than calling drawImage() with a zero source size
+  // (which throws IndexSizeError in browsers).
+  if (sw > 0 && sh > 0) {
+    croppedCtx.drawImage(canvas, sx, sy, sw, sh, dx, dy, sw, sh);
+  }
 
   return new Promise((resolve, reject) => {
     croppedCanvas.toBlob(


### PR DESCRIPTION
## Summary

- When zoom < 1 in the image editor, `getCroppedImage` now clamps source
  coordinates to available pixel bounds and offsets the destination rectangle
  so the cropped output matches the editor preview. Previously, `drawImage`
  silently clipped negative source coords to 0, pegging the result to the
  top-left corner instead of centering it.
- Added unit test verifying the centering behavior with oversized crop rects.

## Test plan

- [x] `make lint` — 0 errors
- [x] `make typecheck` — pass
- [x] `npx vitest run` — 10/10 in get-cropped-image, 1309 total pass (3 pre-existing failures on main confirmed)
- [x] Storybook play functions — 215 suites / 940 tests pass
- [ ] CI pipeline

> [!note]
> Authored by Claude for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)