### PR TITLE
Add tooltipDelay prop to Button and SplitButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [5.2.1] - 2026-05-08
+
+### Fixed
+
+- Button `tooltipDelay` prop — controls delay in milliseconds before tooltip
+  appears, overriding the provider default per-button
+- SplitButton forwards `tooltipDelay` to its primary Button
+
 ## [5.2.0] - 2026-05-07
 
 ### Added

--- a/src/components/canary/atoms/button/button.stories.tsx
+++ b/src/components/canary/atoms/button/button.stories.tsx
@@ -155,6 +155,7 @@ export const Playground: Story = {
     children: { control: 'text' },
     tooltip: { control: 'text' },
     tooltipSide: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+    tooltipDelay: { control: 'number' },
     asChild: { table: { disable: true } },
   },
   args: {

--- a/src/components/canary/atoms/button/button.tsx
+++ b/src/components/canary/atoms/button/button.tsx
@@ -59,6 +59,8 @@ export interface ArdaButtonStaticConfig extends VariantProps<typeof buttonVarian
   tooltip?: string;
   /** Side of the button the tooltip appears on. Defaults to `'top'`. */
   tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
+  /** Delay in milliseconds before the tooltip appears. Defaults to the provider's value (0). */
+  tooltipDelay?: number;
 }
 
 /** Runtime configuration for Button. */
@@ -104,6 +106,7 @@ export function Button({
   disabled,
   tooltip,
   tooltipSide = 'top',
+  tooltipDelay,
   ...props
 }: ButtonProps) {
   const Comp = asChild ? Slot.Root : 'button';
@@ -148,7 +151,7 @@ export function Button({
   const trigger = isDisabled ? <span className="inline-flex">{button}</span> : button;
 
   return (
-    <Tooltip>
+    <Tooltip {...(tooltipDelay !== undefined ? { delayDuration: tooltipDelay } : {})}>
       <TooltipTrigger asChild>{trigger}</TooltipTrigger>
       <TooltipContent side={tooltipSide}>{tooltip}</TooltipContent>
     </Tooltip>

--- a/src/components/canary/atoms/split-button/split-button.tsx
+++ b/src/components/canary/atoms/split-button/split-button.tsx
@@ -53,6 +53,8 @@ export interface ArdaSplitButtonStaticConfig {
   tooltip?: string;
   /** Side of the button the tooltip appears on. Defaults to `'top'`. */
   tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
+  /** Delay in milliseconds before the tooltip appears. */
+  tooltipDelay?: number;
 }
 
 /** Runtime configuration for SplitButton. */
@@ -91,6 +93,7 @@ export function SplitButton({
   showDivider = false,
   tooltip,
   tooltipSide,
+  tooltipDelay,
   onClick,
   loading,
   disabled,
@@ -115,6 +118,7 @@ export function SplitButton({
           {...(disabled !== undefined ? { disabled } : {})}
           {...(tooltip ? { tooltip } : {})}
           {...(tooltipSide ? { tooltipSide } : {})}
+          {...(tooltipDelay !== undefined ? { tooltipDelay } : {})}
         >
           {children}
         </Button>


### PR DESCRIPTION
## Summary

- Add `tooltipDelay` prop to Button — per-button control over tooltip appearance delay, overriding the provider default
- SplitButton forwards `tooltipDelay` to its primary Button
- Added to Playground controls in Storybook

## Test plan

- [x] `make check` passes (lint + typecheck)
- [x] Button and SplitButton tests pass (21 tests)
- [ ] Storybook Playground: tooltipDelay control works

> [!note]
> Authored by Claude Opus 4.6 for sebrandwarren

🤖 Generated with [Claude Code](https://claude.com/claude-code)