### PR TITLE
feat: ItemCardEditor auto-mirrors ORDER from MINIMUM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [5.4.0] - 2026-05-25
+
+### Added
+- **ItemCardEditor MINIMUM → ORDER auto-mirror** — typing in MINIMUM (qty or unit) auto-fills the matching ORDER cell until the user diverges it; quantity and unit are tracked independently. Diverged values loaded from existing items stay diverged.
+- **`formInstanceKey` prop on ItemCardEditor** — optional identity key; whenever it changes, the editor reseeds its internal touched-state tracking from the current `fields`. Hosts that mount the editor once and async-load data should bump this on every load/duplicate/reset path.
+
 ## [5.3.0] - 2026-05-16
 
 ### Added

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.stories.tsx
@@ -68,3 +68,25 @@ export const EditExisting: StoryObj = {
     />
   ),
 };
+
+/**
+ * Edit an item whose MINIMUM and ORDER values already match. Because the
+ * cells are not diverged at load, MINIMUM edits auto-mirror into ORDER
+ * (each cell tracked independently). Editing ORDER away from MINIMUM
+ * stops mirroring on that cell only.
+ */
+export const EditWithEqualValues: StoryObj = {
+  render: () => (
+    <ItemCardEditorDemo
+      initialFields={{
+        title: 'Hex Bolt M10x30',
+        minQty: '100',
+        minUnit: 'each',
+        orderQty: '100',
+        orderUnit: 'each',
+        imageUrl: MOCK_ITEM_IMAGE,
+        accentColor: 'BLUE',
+      }}
+    />
+  ),
+};

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
@@ -36,7 +36,22 @@ vi.mock('@/components/canary/organisms/shared/image-upload-dialog/image-upload-d
 }));
 
 vi.mock('@/components/canary/molecules/typeahead-input/typeahead-input', () => ({
-  TypeaheadInput: () => null,
+  TypeaheadInput: ({
+    value,
+    onValueChange,
+    placeholder,
+  }: {
+    value: string;
+    onValueChange: (val: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="typeahead-input"
+      aria-label={placeholder}
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    />
+  ),
 }));
 
 // Mock ImageDropZone so tests can synthesize file/url/error inputs without
@@ -284,5 +299,219 @@ describe('ItemCardEditor — drop-zone direct upload via ImageUploader Context',
       expect(screen.getByTestId('image-upload-dialog')).toBeInTheDocument();
     });
     expect(lastDialogProps?.existingImageUrl).toBe('https://cdn.example.com/existing.jpg');
+  });
+});
+
+describe('ItemCardEditor — MINIMUM → ORDER auto-mirror', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function getMinQtyInput(): HTMLInputElement {
+    return screen.getByPlaceholderText('Min qty') as HTMLInputElement;
+  }
+  function getOrderQtyInput(): HTMLInputElement {
+    return screen.getByPlaceholderText('Order qty') as HTMLInputElement;
+  }
+  function getUnitInputs(): HTMLInputElement[] {
+    return screen.getAllByTestId('typeahead-input') as HTMLInputElement[];
+  }
+
+  it('mirrors minQty into orderQty while the cell is untouched', () => {
+    const onChange = vi.fn();
+    renderEditor({
+      fields: { ...EMPTY_ITEM_CARD_FIELDS, minQty: '', orderQty: '' },
+      onChange,
+    });
+
+    fireEvent.change(getMinQtyInput(), { target: { value: '5' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ minQty: '5', orderQty: '5' }));
+  });
+
+  it('mirrors minUnit into orderUnit while the cell is untouched', () => {
+    const onChange = vi.fn();
+    renderEditor({
+      fields: { ...EMPTY_ITEM_CARD_FIELDS, minUnit: '', orderUnit: '' },
+      onChange,
+    });
+
+    const [minUnitInput] = getUnitInputs();
+    fireEvent.change(minUnitInput!, { target: { value: 'box' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ minUnit: 'box', orderUnit: 'box' }),
+    );
+  });
+
+  it('tracks qty and unit independently: touching orderQty does not stop unit mirroring', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderEditor({
+      fields: {
+        ...EMPTY_ITEM_CARD_FIELDS,
+        minQty: '5',
+        orderQty: '5',
+        minUnit: 'box',
+        orderUnit: 'box',
+      },
+      onChange,
+    });
+
+    // User diverges ORDER qty.
+    fireEvent.change(getOrderQtyInput(), { target: { value: '10' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '5', orderQty: '10' }),
+    );
+
+    // Parent re-renders with the new state.
+    rerender(
+      <ItemCardEditor
+        imageConfig={CONFIG}
+        unitLookup={async () => []}
+        fields={{
+          ...EMPTY_ITEM_CARD_FIELDS,
+          minQty: '5',
+          orderQty: '10',
+          minUnit: 'box',
+          orderUnit: 'box',
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    // qty no longer mirrors…
+    fireEvent.change(getMinQtyInput(), { target: { value: '6' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '6', orderQty: '10' }),
+    );
+
+    // …but unit still mirrors.
+    rerender(
+      <ItemCardEditor
+        imageConfig={CONFIG}
+        unitLookup={async () => []}
+        fields={{
+          ...EMPTY_ITEM_CARD_FIELDS,
+          minQty: '6',
+          orderQty: '10',
+          minUnit: 'box',
+          orderUnit: 'box',
+        }}
+        onChange={onChange}
+      />,
+    );
+    const [minUnitInput] = getUnitInputs();
+    fireEvent.change(minUnitInput!, { target: { value: 'pallet' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minUnit: 'pallet', orderUnit: 'pallet' }),
+    );
+  });
+
+  it('does not mirror when initial fields are already diverged', () => {
+    const onChange = vi.fn();
+    renderEditor({
+      fields: { ...EMPTY_ITEM_CARD_FIELDS, minQty: '5', orderQty: '10' },
+      onChange,
+    });
+
+    fireEvent.change(getMinQtyInput(), { target: { value: '6' } });
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '6', orderQty: '10' }),
+    );
+  });
+
+  it('reseeds touched state when formInstanceKey changes (mirror resumes for equal new fields)', () => {
+    const onChange = vi.fn();
+    const baseProps = {
+      imageConfig: CONFIG,
+      unitLookup: async () => [],
+      onChange,
+    };
+
+    // Start diverged → mirror is dormant.
+    const { rerender } = render(
+      <ItemCardEditor
+        {...baseProps}
+        fields={{ ...EMPTY_ITEM_CARD_FIELDS, minQty: '5', orderQty: '10' }}
+        formInstanceKey="item-A"
+      />,
+    );
+    fireEvent.change(getMinQtyInput(), { target: { value: '6' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '6', orderQty: '10' }),
+    );
+
+    // Switch to a new form instance with equal fields — mirror should resume.
+    rerender(
+      <ItemCardEditor
+        {...baseProps}
+        fields={{ ...EMPTY_ITEM_CARD_FIELDS, minQty: '', orderQty: '' }}
+        formInstanceKey="item-B"
+      />,
+    );
+    fireEvent.change(getMinQtyInput(), { target: { value: '7' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '7', orderQty: '7' }),
+    );
+  });
+
+  it('does not auto-update touched state when fields change without a formInstanceKey bump (documented limitation)', () => {
+    const onChange = vi.fn();
+    const baseProps = {
+      imageConfig: CONFIG,
+      unitLookup: async () => [],
+      onChange,
+    };
+
+    // Mount with equal fields — touched seeded to false.
+    const { rerender } = render(<ItemCardEditor {...baseProps} fields={EMPTY_ITEM_CARD_FIELDS} />);
+
+    // Parent swaps in already-diverged fields without bumping the key.
+    rerender(
+      <ItemCardEditor
+        {...baseProps}
+        fields={{ ...EMPTY_ITEM_CARD_FIELDS, minQty: '5', orderQty: '10' }}
+      />,
+    );
+
+    // Typing minQty still mirrors and overwrites the diverged orderQty — this
+    // is the documented behavior: hosts must bump formInstanceKey to reseed.
+    fireEvent.change(getMinQtyInput(), { target: { value: '7' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '7', orderQty: '7' }),
+    );
+  });
+
+  it('does not mark touched when user types orderQty equal to current minQty', () => {
+    const onChange = vi.fn();
+    const baseProps = {
+      imageConfig: CONFIG,
+      unitLookup: async () => [],
+      onChange,
+    };
+
+    // User types orderQty equal to minQty — no divergence.
+    const { rerender } = render(
+      <ItemCardEditor
+        {...baseProps}
+        fields={{ ...EMPTY_ITEM_CARD_FIELDS, minQty: '5', orderQty: '5' }}
+      />,
+    );
+    fireEvent.change(getOrderQtyInput(), { target: { value: '5' } });
+
+    // Subsequent minQty change must still mirror — touched should not have flipped.
+    rerender(
+      <ItemCardEditor
+        {...baseProps}
+        fields={{ ...EMPTY_ITEM_CARD_FIELDS, minQty: '5', orderQty: '5' }}
+      />,
+    );
+    fireEvent.change(getMinQtyInput(), { target: { value: '8' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minQty: '8', orderQty: '8' }),
+    );
   });
 });

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -78,6 +78,23 @@ export interface ItemCardEditorRuntimeProps {
     iconColor?: string;
     fields: Partial<Record<keyof ItemCardFields, () => void>>;
   };
+  /**
+   * Identity key for the form instance currently being edited (e.g. an item
+   * id, or `'new'` for an empty form). Whenever its value changes, the
+   * editor reseeds its internal "user diverged ORDER from MINIMUM"
+   * tracking from the current `fields`:
+   *
+   * - cells where `minQty === orderQty` (and `minUnit === orderUnit`) resume
+   *   auto-mirroring on subsequent MINIMUM edits;
+   * - cells that already differ are treated as user-diverged and stay
+   *   independent until reseed.
+   *
+   * Required for any host that mounts the editor once and then loads data
+   * asynchronously — `fields` arriving after mount does NOT by itself
+   * change the touched flags. Bump this key on every load/duplicate/reset
+   * path so the editor knows to re-derive.
+   */
+  formInstanceKey?: string | number;
 }
 
 /** Combined props for ItemCardEditor. */
@@ -116,6 +133,7 @@ export function ItemCardEditor({
   onUploadError,
   qrCodeUrl,
   autoFill,
+  formInstanceKey,
 }: ItemCardEditorProps) {
   const uploader = useImageUploader();
   const [dialogOpen, setDialogOpen] = React.useState(false);
@@ -155,9 +173,54 @@ export function ItemCardEditor({
   const onUploadErrorRef = React.useRef(onUploadError);
   onUploadErrorRef.current = onUploadError;
 
+  // Track whether the user has manually diverged the ORDER side of the card
+  // from MINIMUM, per-cell (qty and unit independent). While a cell is not
+  // touched, MINIMUM edits auto-mirror into ORDER. Seeded from the initial
+  // `fields` and reseeded whenever `formInstanceKey` changes.
+  const orderQtyTouchedRef = React.useRef(fields.minQty !== fields.orderQty);
+  const orderUnitTouchedRef = React.useRef(fields.minUnit !== fields.orderUnit);
+
+  // Reseed from the current `fields` prop on form-identity changes. We omit
+  // `fields` from deps intentionally — async `fields` updates that arrive
+  // without an identity bump must NOT silently re-derive touched flags (that
+  // would let a host's just-typed values reset divergence tracking).
+  React.useEffect(() => {
+    orderQtyTouchedRef.current = fields.minQty !== fields.orderQty;
+    orderUnitTouchedRef.current = fields.minUnit !== fields.orderUnit;
+  }, [formInstanceKey]);
+
   const updateField = React.useCallback(
     <K extends keyof ItemCardFields>(key: K, value: ItemCardFields[K]) => {
-      onChangeRef.current({ ...fieldsRef.current, [key]: value });
+      const current = fieldsRef.current;
+
+      // ORDER edits: mark the matching cell as diverged once the user
+      // changes it to a value that differs from the current MINIMUM.
+      if (key === 'orderQty' && value !== current.minQty) {
+        orderQtyTouchedRef.current = true;
+      } else if (key === 'orderUnit' && value !== current.minUnit) {
+        orderUnitTouchedRef.current = true;
+      }
+
+      // MINIMUM edits: auto-mirror into ORDER while the matching cell is
+      // still linked. Emits a single `onChange` with both fields set.
+      if (key === 'minQty' && !orderQtyTouchedRef.current) {
+        onChangeRef.current({
+          ...current,
+          minQty: value as string,
+          orderQty: value as string,
+        });
+        return;
+      }
+      if (key === 'minUnit' && !orderUnitTouchedRef.current) {
+        onChangeRef.current({
+          ...current,
+          minUnit: value as string,
+          orderUnit: value as string,
+        });
+        return;
+      }
+
+      onChangeRef.current({ ...current, [key]: value });
     },
     [],
   );


### PR DESCRIPTION
## Summary
- `ItemCardEditor` now auto-fills ORDER from MINIMUM as the user types (qty and unit, tracked independently) until the user manually diverges a cell.
- New optional `formInstanceKey` prop reseeds internal touched-state tracking from the current `fields` whenever its identity changes — hosts that mount the editor once and async-load data must bump it on every load/duplicate/reset path.
- Diverged values loaded from existing items stay diverged.

## Why
Every consumer of `ItemCardEditor` was implementing the same MIN→ORDER auto-fill UX outside the component (most recently `arda-frontend-app`). Moving it inside is the natural home and removes duplication; the touched-state machinery becomes a private concern of the editor.

## Behavior, in one paragraph
On mount the editor seeds two per-cell "touched" flags from `fields`: a cell is touched iff its MIN value already differs from its ORDER value. While a cell is untouched, edits to MIN emit a single `onChange` with both MIN and ORDER set to the new value. Editing ORDER to a value that differs from the current MIN flips that cell's touched flag to `true`; editing ORDER to the same value as MIN does **not** flip it. The flags persist across re-renders. To re-derive them from new `fields` (e.g. user opens a different item), bump `formInstanceKey` — async `fields` updates without an identity bump do not touch the flags by design (otherwise typing in MIN could quietly reset divergence tracking).

## Test coverage (7 new cases)
1. Equal initial fields, type `minQty` → `onChange` includes mirrored `orderQty`.
2. Equal initial fields, type `minUnit` → `onChange` includes mirrored `orderUnit`.
3. Per-cell independence: touching `orderQty` stops qty mirroring but `minUnit` still mirrors.
4. Initial fields already diverged → typing `minQty` does not mirror.
5. `formInstanceKey` change with equal new fields → mirror resumes.
6. Documented limitation: `fields` change without a `formInstanceKey` bump does not auto-update touched flags.
7. Typing `orderQty` equal to current `minQty` does not flip touched.

## CHANGELOG
## CHANGELOG

### Added
- **ItemCardEditor MINIMUM → ORDER auto-mirror** — typing in MINIMUM (qty or unit) auto-fills the matching ORDER cell until the user diverges it; quantity and unit are tracked independently. Diverged values loaded from existing items stay diverged.
- **`formInstanceKey` prop on ItemCardEditor** — optional identity key; whenever it changes, the editor reseeds its internal touched-state tracking from the current `fields`. Hosts that mount the editor once and async-load data should bump this on every load/duplicate/reset path.

## Test plan
- [x] `make check` (lint + typecheck) clean.
- [x] `npx vitest run src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx` — 18/18 pass.
- [ ] Manual: storybook `Components/Canary/Organisms/ItemCardEditor` — verify `CreateNew`, `EditExisting` (diverged → dormant), and the new `EditWithEqualValues` (equal → live mirror) stories.
- [ ] Visual regression: no expected snapshot changes (new story creates a new baseline only).

## Follow-up (separate PR in arda-frontend-app)
Once this is published, a deletion-only PR there will: bump the dep, remove the host-side mirror logic from `ItemFormPanel.tsx`, and pass `formInstanceKey={itemEditEntityId ?? 'new'}` to consume the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)