### PR TITLE
feat(item-card-editor): Google search icon next to title input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [6.1.0] - 2026-06-22
+
+### Added
+- **ItemCardEditor title search icon** — when the item name is non-empty, an `ExternalLink` icon appears next to the title input. Clicking it opens `google.com/search?q=<title>` in a new tab so the user can quickly look the item up while creating it. Includes `referrerPolicy="no-referrer"` to avoid leaking the app URL.
+
 ## [6.0.0] - 2026-06-12
 
 ### Added
@@ -66,7 +71,6 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 ### Fixed
 - Cell-editor search no longer stalls under React StrictMode.
 - Multiselect collapses to a single line; `defaultOne` click closes the dropdown; the typeahead cell editor fills the cell cleanly.
-
 ## [5.3.0] - 2026-05-16
 
 ### Added

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx
@@ -145,6 +145,34 @@ describe('ItemCardEditor — QR placeholder (#750 issue 3)', () => {
   });
 });
 
+describe('ItemCardEditor — title search link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastDialogProps = undefined;
+  });
+
+  it('hides the Google search link when the title is empty', () => {
+    renderEditor();
+
+    expect(screen.queryByRole('link', { name: /search google for this item/i })).toBeNull();
+  });
+
+  it('renders a privacy-preserving Google search link for a non-empty title', () => {
+    renderEditor({
+      fields: {
+        ...EMPTY_ITEM_CARD_FIELDS,
+        title: '  Hex Bolt M10x30  ',
+      },
+    });
+
+    const link = screen.getByRole('link', { name: /search google for this item/i });
+    expect(link).toHaveAttribute('href', 'https://www.google.com/search?q=Hex%20Bolt%20M10x30');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveAttribute('referrerpolicy', 'no-referrer');
+  });
+});
+
 describe('ItemCardEditor — drop-zone direct upload via ImageUploader Context', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
+++ b/src/components/canary/organisms/item-card-editor/item-card-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PackageMinus, Package, Crop, Trash2, Loader2 } from 'lucide-react';
+import { PackageMinus, Package, Crop, Trash2, Loader2, ExternalLink } from 'lucide-react';
 
 import { ColorPicker, getColorHex } from '@/components/canary/atoms/color-picker/color-picker';
 import { ImageDropZone } from '@/components/canary/molecules/image-drop-zone/image-drop-zone';
@@ -238,6 +238,7 @@ export function ItemCardEditor({
       unitPlaceholder: 'Units',
     },
   ];
+  const trimmedTitle = fields.title.trim();
 
   return (
     <>
@@ -261,6 +262,19 @@ export function ItemCardEditor({
               className="font-extrabold text-lg h-10 rounded-lg border-input"
             />
           </AutoFillField>
+          {trimmedTitle.length > 0 && (
+            <a
+              href={`https://www.google.com/search?q=${encodeURIComponent(trimmedTitle)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              referrerPolicy="no-referrer"
+              aria-label="Search Google for this item"
+              title="Search Google for this item"
+              className="flex-shrink-0 h-10 w-7 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          )}
           <div className="flex flex-col items-center flex-shrink-0 h-10 justify-between">
             <img src={resolvedQrSrc} alt="QR" className="w-7 h-7 object-contain" />
             <span className="text-[9px] font-semibold text-muted-foreground leading-none">


### PR DESCRIPTION
## Summary

When the item name is non-empty, `ItemCardEditor` now renders a small `ExternalLink` icon between the title input and the QR code. Clicking it opens `google.com/search?q=<title>` in a new tab so the user can quickly look up the item they're entering.

- New tab via `target="_blank"`, hardened with `rel="noopener noreferrer"` and `referrerPolicy="no-referrer"` so the app URL doesn't leak to Google.
- Hidden whenever the trimmed item title is empty.
- CHANGELOG bumped to **6.1.0** (Added -> minor release trigger).
- Added unit coverage for empty-title visibility, URL encoding, and privacy attributes.

## Files changed

- `src/components/canary/organisms/item-card-editor/item-card-editor.tsx` — adds `ExternalLink` import, single-sources the trimmed title, and renders the search anchor in the header row.
- `src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx` — covers search-link visibility and attributes.
- `CHANGELOG.md` — new 6.1.0 entry.

## Test plan

- [x] `npm run lint -- src/components/canary/organisms/item-card-editor/item-card-editor.tsx src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx`
- [x] `npx vitest --run src/components/canary/organisms/item-card-editor/item-card-editor.test.tsx`
- [x] `make typecheck`

## Remaining external check

- Vercel still requires a team member to authorize the deployment for this forked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)