### PR TITLE
feat(canary): typeahead foundation — Checkbox, TypeaheadInput, MultiSelect, TokenList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [5.4.0] - 2026-06-08
+
+### Added
+- **`Checkbox` canary atom** — Arda-styled wrapper around the canary primitive (Figma node `46:112`) with `shadow-sm`, optional `label` + `description` + `required` layout, and `[&_svg]:size-4` so the Lucide checkmark fills the 16px box. Exported from `canary.ts` as `Checkbox` / `CheckboxProps`.
+- **`TypeaheadInput` and `MultiSelectTypeaheadInput` molecules** — debounced async lookup, allowCreate, keyboard navigation (arrow keys, Enter, Escape, Home/End, Tab), `defaultOne`, expand-on-edit, `maxResults`, `clearOnFocus`, array lookup, click-to-open.
+- **Typeahead cell-editor factories** — `createTypeaheadCellEditor` and `createMultiSelectCellEditor` adapt the inputs as AG Grid popup editors via a shared `useCellEditorGeometry` hook.
+- **`TokenList` molecule** — pill renderer for tagged values.
+- **Mobile keyboard on cell-editor open** — `TypeaheadInput` sets `autoFocus` while in `cellEditorMode` so iOS Safari reliably brings up the keyboard (the existing `useEffect`-on-mount `focus()` fell outside the user-gesture window).
+- **Mobile typeahead option select** — typeahead options now select on `onPointerDown` instead of `onMouseDown`. On iOS the synthesized mousedown could fire on the document before reaching the option, letting the outside-click handler close the dropdown without selecting. PointerEvents normalize mouse + touch and fire before that race. Applied to both `TypeaheadInput` and `MultiSelectTypeaheadInput` (the latter also to the token-click handler).
+- **`Badge.onDismiss`** — accessible close affordance for dismissible badges.
+- `./css` package export for the `design-system.css` bundle.
+
+### Fixed
+- Cell-editor search no longer stalls under React StrictMode.
+- Multiselect collapses to a single line; `defaultOne` click closes the dropdown; the typeahead cell editor fills the cell cleanly.
+
 ## [5.3.0] - 2026-05-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "import": "./dist/types-extras-date-time.js",
       "require": "./dist/types-extras-date-time.cjs"
     },
+    "./css": "./dist/design-system.css",
     "./styles": "./dist/styles/globals.css",
     "./styles/*": "./dist/styles/*",
     "./assets/*": "./dist/assets/*"

--- a/src/canary.ts
+++ b/src/canary.ts
@@ -108,6 +108,10 @@ export type {
   ArdaButtonGroupStaticConfig,
 } from './components/canary/atoms/button-group/button-group';
 
+// Atoms: Checkbox (Arda-styled wrapper around the canary primitive)
+export { Checkbox } from './components/canary/atoms/checkbox/checkbox';
+export type { CheckboxProps } from './components/canary/atoms/checkbox/checkbox';
+
 // Atoms: SplitButton
 export { SplitButton } from './components/canary/atoms/split-button/split-button';
 export type {
@@ -366,6 +370,10 @@ export type { ImageComparisonLayoutProps } from './components/canary/molecules/i
 export { ImageFormField } from './components/canary/molecules/form/image';
 export type { ImageFormFieldProps } from './components/canary/molecules/form/image';
 
+// Molecules: TokenList
+export { TokenList } from './components/canary/molecules/token-list';
+export type { TokenListProps } from './components/canary/molecules/token-list';
+
 export { DataGrid, GridImage, useColumnPersistence } from './components/canary/molecules/data-grid';
 export type {
   DataGridRef,
@@ -507,11 +515,22 @@ export type {
 export { TypeaheadInput } from './components/canary/molecules/typeahead-input/typeahead-input';
 export type {
   TypeaheadOption,
+  TypeaheadSource,
   TypeaheadInputProps,
 } from './components/canary/molecules/typeahead-input/typeahead-input';
 
 export { createTypeaheadCellEditor } from './components/canary/molecules/typeahead-input/typeahead-cell-editor';
 export type { TypeaheadCellEditorConfig } from './components/canary/molecules/typeahead-input/typeahead-cell-editor';
+
+export { MultiSelectTypeaheadInput } from './components/canary/molecules/typeahead-input/multiselect-typeahead-input';
+export type {
+  MultiSelectOption,
+  MultiSelectSource,
+  MultiSelectTypeaheadInputProps,
+} from './components/canary/molecules/typeahead-input/multiselect-typeahead-input';
+
+export { createMultiSelectCellEditor } from './components/canary/molecules/typeahead-input/multiselect-cell-editor';
+export type { MultiSelectCellEditorConfig } from './components/canary/molecules/typeahead-input/multiselect-cell-editor';
 
 // --- Organisms — ItemCardEditor ---
 

--- a/src/components/canary/__mocks__/handlers/role-lookup.ts
+++ b/src/components/canary/__mocks__/handlers/role-lookup.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from 'msw';
+
+export const MOCK_ROLES = [
+  { eId: 'role-001', name: 'Vendor' },
+  { eId: 'role-002', name: 'Customer' },
+  { eId: 'role-003', name: 'Carrier' },
+  { eId: 'role-004', name: 'Operator' },
+  { eId: 'role-005', name: 'Distributor' },
+  { eId: 'role-006', name: 'Manufacturer' },
+  { eId: 'role-007', name: 'Broker' },
+  { eId: 'role-008', name: 'Consignee' },
+];
+
+export const roleLookupHandler = http.get(
+  '/api/arda/business-affiliate/lookup-roles',
+  ({ request }) => {
+    const url = new URL(request.url);
+    const name = url.searchParams.get('name') || '';
+
+    const filtered = name
+      ? MOCK_ROLES.filter((r) => r.name.toLowerCase().includes(name.toLowerCase()))
+      : MOCK_ROLES;
+
+    return HttpResponse.json({ ok: true, status: 200, data: filtered });
+  },
+);

--- a/src/components/canary/__mocks__/role-lookup.ts
+++ b/src/components/canary/__mocks__/role-lookup.ts
@@ -1,0 +1,12 @@
+import type { MultiSelectOption } from '@/components/canary/molecules/typeahead-input/multiselect-typeahead-input';
+
+/**
+ * Lookup function that calls the MSW-mocked role endpoint.
+ */
+export async function lookupRoles(search: string): Promise<MultiSelectOption[]> {
+  const params = new URLSearchParams({ name: search });
+  const res = await fetch(`/api/arda/business-affiliate/lookup-roles?${params}`);
+  const json = await res.json();
+  const data: { eId: string; name: string }[] = json.data ?? [];
+  return data.map((d) => ({ label: d.name, value: d.name }));
+}

--- a/src/components/canary/atoms/badge/badge.tsx
+++ b/src/components/canary/atoms/badge/badge.tsx
@@ -94,13 +94,6 @@ export function Badge({
             e.stopPropagation();
             onDismiss();
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              e.stopPropagation();
-              onDismiss();
-            }
-          }}
           className="ml-0.5 inline-flex h-3 w-3 items-center justify-center rounded-sm text-current opacity-60 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Remove"
         >

--- a/src/components/canary/atoms/badge/badge.tsx
+++ b/src/components/canary/atoms/badge/badge.tsx
@@ -28,6 +28,8 @@ export interface ArdaBadgeRuntimeConfig {
   count?: number;
   /** Content to render. Ignored when `count` is provided. */
   children?: React.ReactNode;
+  /** When set, renders a dismiss (×) button. Clicking it calls this callback. */
+  onDismiss?: () => void;
 }
 
 /** Combined props for Badge. */
@@ -61,6 +63,7 @@ export function Badge({
   iconColor,
   collapsible,
   children,
+  onDismiss,
   className,
   ...props
 }: BadgeProps) {
@@ -77,12 +80,40 @@ export function Badge({
       className={cn(
         isCount && 'font-mono tabular-nums',
         variant === 'default' && 'bg-sidebar-primary text-sidebar-primary-foreground',
+        onDismiss && 'pr-0.5 gap-0.5 inline-flex items-center',
         className,
       )}
       {...(isCount && { role: 'status' })}
       {...props}
     >
       {display}
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.stopPropagation();
+              onDismiss();
+            }
+          }}
+          className="ml-0.5 inline-flex h-3 w-3 items-center justify-center rounded-sm text-current opacity-60 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Remove"
+        >
+          <svg width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">
+            <path
+              d="M1 1L7 7M7 1L1 7"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
     </BadgeBase>
   );
 }

--- a/src/components/canary/atoms/checkbox/checkbox.mdx
+++ b/src/components/canary/atoms/checkbox/checkbox.mdx
@@ -1,0 +1,33 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as CheckboxStories from './checkbox.stories';
+
+<Meta of={CheckboxStories} />
+
+# Checkbox
+
+Arda checkbox atom — matches Figma node `46:112`. Wraps `canary/primitives/checkbox` (vanilla shadcn) with Arda styling (`shadow-sm`) and adds optional `label`, `description`, and `required` layout.
+
+## Why an atom (not a primitive)
+
+Canary primitives are stock shadcn/ui — never edited. When a primitive needs Arda colors, sizing, or layout variants, we promote it into an atom and apply the styling here. See the canary primitives docs page for the full rationale.
+
+## Variants
+
+<Canvas of={CheckboxStories.Bare} />
+<Canvas of={CheckboxStories.WithLabel} />
+<Canvas of={CheckboxStories.WithLabelAndDescription} />
+<Canvas of={CheckboxStories.Required} />
+<Canvas of={CheckboxStories.Disabled} />
+<Canvas of={CheckboxStories.Indeterminate} />
+<Canvas of={CheckboxStories.Controlled} />
+
+## Props
+
+<Controls of={CheckboxStories.WithLabelAndDescription} />
+
+## Typical uses
+
+- **Bare** — AG Grid selection-column body cells, header select-all cells, toolbar batch toggles.
+- **WithLabel** — form fields, single-choice options.
+- **WithLabelAndDescription** — settings dialogs, consent toggles, complex forms.
+- **`checked='indeterminate'`** — header select-all when *some* but not all rows are selected.

--- a/src/components/canary/atoms/checkbox/checkbox.stories.tsx
+++ b/src/components/canary/atoms/checkbox/checkbox.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Checkbox } from './checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Components/Canary/Atoms/Checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Arda checkbox atom matching the Figma spec (node 46:112). Wraps the canary primitive ' +
+          'with `shadow-sm` and an optional label + description + required layout. ' +
+          'Use the bare form for grid selection cells, table headers, and other tight surfaces; ' +
+          'use the labelled form in forms and dialogs.',
+      },
+    },
+  },
+  argTypes: {
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    required: { control: 'boolean' },
+    label: { control: 'text' },
+    description: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+export const Bare: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: 'No label / description — for grid cells and toolbar uses.',
+      },
+    },
+  },
+};
+
+export const Indeterminate: Story = {
+  args: { checked: 'indeterminate' },
+};
+
+export const WithLabel: Story = {
+  args: { label: 'Checkbox Text' },
+};
+
+export const WithLabelAndDescription: Story = {
+  args: {
+    label: 'Checkbox Text',
+    description: 'This is a checkbox description.',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Checkbox Text',
+    description: 'This is a checkbox description.',
+    required: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Checkbox Text',
+    description: 'This is a checkbox description.',
+    disabled: true,
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    function Demo() {
+      const [checked, setChecked] = useState<boolean | 'indeterminate'>(false);
+      return (
+        <div className="flex flex-col gap-3">
+          <Checkbox
+            checked={checked}
+            onCheckedChange={setChecked}
+            label="Toggle me"
+            description="State above the input is the React state of the parent."
+          />
+          <div className="text-xs text-muted-foreground">state = {String(checked)}</div>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};

--- a/src/components/canary/atoms/checkbox/checkbox.tsx
+++ b/src/components/canary/atoms/checkbox/checkbox.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import * as React from 'react';
+import { Checkbox as PrimitiveCheckbox } from '@/components/canary/primitives/checkbox';
+import { cn } from '@/types/canary/utilities/utils';
+
+type PrimitiveProps = React.ComponentProps<typeof PrimitiveCheckbox>;
+
+export interface CheckboxProps extends Omit<PrimitiveProps, 'children'> {
+  /** Optional label rendered next to the checkbox. */
+  label?: React.ReactNode;
+  /** Optional helper/description rendered beneath the label. */
+  description?: React.ReactNode;
+  /** Render a `*` after the label in destructive color. */
+  required?: boolean;
+  /** Extra classes for the outer wrapper when label/description are rendered. */
+  wrapperClassName?: string;
+}
+
+/**
+ * Arda Checkbox — wraps the canary primitive (vanilla shadcn) with the Figma
+ * spec (shadow-sm, optional label + description, required asterisk). Supports
+ * the same controlled API as the primitive (`checked`, `onCheckedChange`),
+ * including `'indeterminate'`.
+ *
+ * Use the bare form for grid cells and other tight surfaces. Pass `label` /
+ * `description` to render the form layout (8px gap; 6px between label and
+ * description; muted-foreground description).
+ *
+ * Per the canary architecture rule, this atom is the only place to apply Arda
+ * styling — never modify `canary/primitives/checkbox.tsx`.
+ */
+function Checkbox({
+  className,
+  label,
+  description,
+  required,
+  wrapperClassName,
+  id,
+  ...props
+}: CheckboxProps) {
+  // Stable id for label association when one isn't supplied.
+  const reactId = React.useId();
+  const checkboxId = id ?? `checkbox-${reactId}`;
+
+  const checkbox = (
+    <PrimitiveCheckbox
+      id={checkboxId}
+      className={cn('shadow-sm [&_svg]:size-4', className)}
+      {...props}
+    />
+  );
+
+  if (!label && !description) return checkbox;
+
+  return (
+    <div className={cn('flex items-start gap-2', wrapperClassName)}>
+      {checkbox}
+      <div className="flex flex-col items-start gap-1.5">
+        {label && (
+          <label
+            htmlFor={checkboxId}
+            className="flex items-start text-sm font-medium leading-none text-foreground cursor-pointer select-none"
+          >
+            {label}
+            {required && (
+              <span className="pl-0.5 text-sm font-medium leading-none text-destructive">*</span>
+            )}
+          </label>
+        )}
+        {description && (
+          <span className="text-sm leading-5 text-muted-foreground">{description}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { Checkbox };

--- a/src/components/canary/atoms/checkbox/checkbox.tsx
+++ b/src/components/canary/atoms/checkbox/checkbox.tsx
@@ -51,7 +51,21 @@ function Checkbox({
     />
   );
 
-  if (!label && !description) return checkbox;
+  if (!label && !description) {
+    // Bare form (used inside grid cells and other tight surfaces). Wrap in a
+    // label so the tap surface grows to a 44×44 minimum on touch devices
+    // without changing the 16×16 visual on desktop. The label delegates
+    // clicks to the associated input via `htmlFor`, so AG Grid's row-select
+    // and other parent-cell handlers still see the bubbled click.
+    return (
+      <label
+        htmlFor={checkboxId}
+        className="inline-flex items-center justify-center [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:min-w-11"
+      >
+        {checkbox}
+      </label>
+    );
+  }
 
   return (
     <div className={cn('flex items-start gap-2', wrapperClassName)}>

--- a/src/components/canary/atoms/checkbox/index.ts
+++ b/src/components/canary/atoms/checkbox/index.ts
@@ -1,0 +1,2 @@
+export { Checkbox } from './checkbox';
+export type { CheckboxProps } from './checkbox';

--- a/src/components/canary/molecules/token-list/index.ts
+++ b/src/components/canary/molecules/token-list/index.ts
@@ -1,0 +1,2 @@
+export { TokenList } from './token-list';
+export type { TokenListProps } from './token-list';

--- a/src/components/canary/molecules/token-list/token-list.test.tsx
+++ b/src/components/canary/molecules/token-list/token-list.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { TokenList } from './token-list';
+
+describe('TokenList', () => {
+  it('renders one badge per value', () => {
+    render(<TokenList values={['Vendor', 'Carrier']} />);
+    expect(screen.getByText('Vendor')).toBeInTheDocument();
+    expect(screen.getByText('Carrier')).toBeInTheDocument();
+  });
+
+  it('shows the em-dash placeholder when empty', () => {
+    render(<TokenList values={[]} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('shows a custom empty placeholder', () => {
+    render(<TokenList values={[]} emptyText="None" />);
+    expect(screen.getByText('None')).toBeInTheDocument();
+  });
+
+  it('defaults to the secondary variant and honors an explicit variant', () => {
+    const { rerender } = render(<TokenList values={['Vendor']} />);
+    expect(screen.getByText('Vendor')).toHaveAttribute('data-variant', 'secondary');
+
+    rerender(<TokenList values={['Online']} variant="outline" />);
+    expect(screen.getByText('Online')).toHaveAttribute('data-variant', 'outline');
+  });
+
+  it('applies a custom className to the container', () => {
+    const { container } = render(<TokenList values={['Vendor']} className="test-cls" />);
+    expect(container.querySelector('.test-cls')).not.toBeNull();
+  });
+});

--- a/src/components/canary/molecules/token-list/token-list.tsx
+++ b/src/components/canary/molecules/token-list/token-list.tsx
@@ -1,0 +1,46 @@
+import { Badge } from '@/components/canary/atoms/badge/badge';
+import { cn } from '@/types/canary/utilities/utils';
+
+// --- Types ---
+
+export interface TokenListProps {
+  /** The token values to render, one Badge each. */
+  values: string[];
+  /** Badge variant — `secondary` (filled) for multi-token, `outline` for single, by convention. */
+  variant?: 'secondary' | 'outline';
+  /** Placeholder shown when there are no values. Defaults to an em dash. */
+  emptyText?: string;
+  /** Additional CSS classes applied to the container. */
+  className?: string;
+}
+
+// --- Component ---
+
+/**
+ * TokenList — read-mode display for token cells (roles, order methods, tags…).
+ *
+ * Renders one {@link Badge} per value on a single line, clipping overflow rather
+ * than wrapping (so it never balloons a grid row's height). Shared by the grid
+ * cell renderer and any form display so the two can't drift. Pairs with the
+ * typeahead / multiselect editors via {@link createTokenDataType}.
+ */
+export function TokenList({
+  values,
+  variant = 'secondary',
+  emptyText = '—',
+  className,
+}: TokenListProps) {
+  if (values.length === 0) {
+    return <span className="text-muted-foreground text-xs">{emptyText}</span>;
+  }
+
+  return (
+    <div className={cn('flex h-full items-center gap-1 overflow-hidden', className)}>
+      {values.map((value) => (
+        <Badge key={value} variant={variant} className="shrink-0 whitespace-nowrap">
+          {value}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/src/components/canary/molecules/typeahead-input/multiselect-cell-editor.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-cell-editor.tsx
@@ -1,0 +1,101 @@
+import { useState, useRef, useCallback } from 'react';
+import { useGridCellEditor, type CustomCellEditorProps } from 'ag-grid-react';
+
+import { MultiSelectTypeaheadInput, type MultiSelectSource } from './multiselect-typeahead-input';
+import { useCellEditorGeometry } from './use-cell-editor-geometry';
+
+// --- Types ---
+
+export interface MultiSelectCellEditorConfig {
+  /**
+   * Options source — an async lookup function, or a static list (`string[]` or
+   * `MultiSelectOption[]`) filtered client-side by label.
+   */
+  lookup: MultiSelectSource;
+  /** Input placeholder text. */
+  placeholder?: string;
+  /** Maximum number of dropdown results to show. Defaults to 8. */
+  maxResults?: number;
+  /**
+   * When true (default), Enter selects the highlighted item and exits edit mode.
+   * When false, Enter adds items additively — user must Tab or click away to exit.
+   */
+  defaultOne?: boolean;
+}
+
+export interface MultiSelectCellEditorProps {
+  value: string[] | null;
+  onValueChange: (value: string[] | null) => void;
+  stopEditing: (cancel?: boolean) => void;
+}
+
+// --- Component ---
+
+function MultiSelectCellEditorInner({
+  value,
+  onValueChange,
+  stopEditing,
+  column,
+  node,
+  config,
+}: CustomCellEditorProps<Record<string, unknown>, string[] | null> & {
+  config: MultiSelectCellEditorConfig;
+}) {
+  const [currentValue, setCurrentValue] = useState<string[]>(value ?? []);
+  const wasCancelledRef = useRef(false);
+
+  useGridCellEditor({
+    isCancelAfterEnd: () => wasCancelledRef.current,
+  });
+
+  // Match the popup editor to the cell it edits (shared with single-select).
+  const { cellWidth, cellMinHeight } = useCellEditorGeometry(column, node);
+
+  const handleValueChange = useCallback(
+    (val: string[]) => {
+      setCurrentValue(val);
+      onValueChange(val.length > 0 ? val : null);
+    },
+    [onValueChange],
+  );
+
+  const handleCommit = useCallback(() => {
+    stopEditing();
+  }, [stopEditing]);
+
+  return (
+    <MultiSelectTypeaheadInput
+      value={currentValue}
+      onValueChange={handleValueChange}
+      lookup={config.lookup}
+      placeholder={config.placeholder ?? 'Search\u2026'}
+      defaultOne={config.defaultOne ?? true}
+      {...(config.maxResults !== undefined ? { maxResults: config.maxResults } : {})}
+      onCommit={handleCommit}
+      cellEditorMode
+      cellWidth={cellWidth}
+      {...(cellMinHeight !== undefined ? { cellMinHeight } : {})}
+    />
+  );
+}
+
+// --- Factory ---
+
+/**
+ * Creates a MultiSelectCellEditor component configured for a specific entity.
+ *
+ * Usage:
+ * ```tsx
+ * const RoleCellEditor = createMultiSelectCellEditor({
+ *   lookup: lookupRoles,
+ *   placeholder: 'Select roles...',
+ * });
+ * ```
+ */
+export function createMultiSelectCellEditor(config: MultiSelectCellEditorConfig) {
+  function CellEditor(props: CustomCellEditorProps<Record<string, unknown>, string[] | null>) {
+    return <MultiSelectCellEditorInner {...props} config={config} />;
+  }
+  CellEditor.displayName = `MultiSelectCellEditor(${config.placeholder ?? 'Search'})`;
+  return CellEditor;
+}

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.mdx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.mdx
@@ -6,10 +6,12 @@ import * as MultiSelectStories from './multiselect-typeahead-input.stories';
 
 # MultiSelectTypeaheadInput
 
-Async search input with multiselect. Selected values render as dismissible
-Badge tokens in the input area, collapsing to "+N more" when they exceed the
-field width. The dropdown shows a checkmark for already-selected options.
-Works standalone and as an AG Grid cell editor.
+Async search input with multiselect. Selected values render as Badge tokens
+in the input area, collapsing to "+N more" when they exceed the field width.
+Tokens are keyboard-removable (Backspace / Delete with the token focused, or
+Backspace at the start of an empty input removes the last token). The
+dropdown shows a checkmark for already-selected options. Works standalone
+and as an AG Grid cell editor.
 
 **Molecule** &#8212; Canary | Import: `import { MultiSelectTypeaheadInput } from '@arda-cards/design-system/canary'`
 

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.mdx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.mdx
@@ -1,0 +1,222 @@
+{/* multiselect-typeahead-input.mdx */}
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as MultiSelectStories from './multiselect-typeahead-input.stories';
+
+<Meta of={MultiSelectStories} />
+
+# MultiSelectTypeaheadInput
+
+Async search input with multiselect. Selected values render as dismissible
+Badge tokens in the input area, collapsing to "+N more" when they exceed the
+field width. The dropdown shows a checkmark for already-selected options.
+Works standalone and as an AG Grid cell editor.
+
+**Molecule** &#8212; Canary | Import: `import { MultiSelectTypeaheadInput } from '@arda-cards/design-system/canary'`
+
+---
+
+## Default
+
+<Canvas of={MultiSelectStories.Default} />
+
+## Pre-populated
+
+<Canvas of={MultiSelectStories.PrePopulated} />
+
+## Overflow
+
+Tokens that don't fit on one line collapse into a "+N more" label. The visible
+count is measured dynamically against the field width (no fixed limit).
+
+<Canvas of={MultiSelectStories.Overflow} />
+
+---
+
+## Expand on edit
+
+When collapsed, the field is a single line with overflow clipped — it never
+grows tall. On focus it expands (as a floating overlay in standalone mode) to
+show **all** tokens so they're reachable via the keyboard, then collapses back
+to one line on blur.
+
+---
+
+## defaultOne
+
+`defaultOne` controls what Enter (and clicking an option) does:
+
+<table>
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Behavior</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>true</code> (default)</td>
+      <td>Selecting an option (Enter or click) adds it, commits, and closes the dropdown. Never unchecks via Enter/click.</td>
+    </tr>
+    <tr>
+      <td><code>false</code></td>
+      <td>Selecting toggles the option and keeps the dropdown open for continued multi-selection. Exit with Escape, Tab, or by clicking away.</td>
+    </tr>
+  </tbody>
+</table>
+
+After the dropdown closes, clicking the input again reopens it.
+
+---
+
+## Cell editor
+
+`cellEditorMode` adapts the component for AG Grid. Auto-focuses on mount so the
+dropdown opens immediately, the dropdown is portaled via Radix Popover, and the
+field height matches the grid row height. Wrap it with
+`createMultiSelectCellEditor({ lookup, placeholder, defaultOne })` to use as a
+column `cellEditor`.
+
+---
+
+## Keyboard
+
+<table>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Behavior</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>ArrowDown</code> / <code>ArrowUp</code></td>
+      <td>Move the dropdown highlight. <code>ArrowUp</code> from the top result moves focus to the last token.</td>
+    </tr>
+    <tr>
+      <td><code>Enter</code></td>
+      <td>Choose the highlighted option (see <code>defaultOne</code>).</td>
+    </tr>
+    <tr>
+      <td><code>ArrowLeft</code> / <code>ArrowRight</code></td>
+      <td>From an empty input, Left focuses the last token; Left/Right then navigate between tokens. Right past the last token returns to the input.</td>
+    </tr>
+    <tr>
+      <td><code>Delete</code> / <code>Backspace</code></td>
+      <td>On a focused token, removes it. Backspace with an empty input removes the last token.</td>
+    </tr>
+    <tr>
+      <td>Typing on a token</td>
+      <td>Returns focus to the input and starts filtering.</td>
+    </tr>
+    <tr>
+      <td><code>Escape</code></td>
+      <td>Close the dropdown.</td>
+    </tr>
+    <tr>
+      <td><code>Tab</code></td>
+      <td>Commit and move focus on.</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Props
+
+<table>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>value</code></td>
+      <td><code>string[]</code></td>
+      <td>&#8212;</td>
+      <td>Currently selected values (controlled).</td>
+    </tr>
+    <tr>
+      <td><code>onValueChange</code></td>
+      <td><code>(value: string[]) =&gt; void</code></td>
+      <td>&#8212;</td>
+      <td>Called when the selection changes.</td>
+    </tr>
+    <tr>
+      <td><code>lookup</code></td>
+      <td><code>((search: string) =&gt; Promise&lt;MultiSelectOption[]&gt;) | MultiSelectOption[] | string[]</code></td>
+      <td>&#8212;</td>
+      <td>Options source. Pass an async function, or a static list of options or plain strings filtered client-side by label.</td>
+    </tr>
+    <tr>
+      <td><code>placeholder</code></td>
+      <td><code>string</code></td>
+      <td><code>'Search…'</code></td>
+      <td>Placeholder shown when no tokens are selected.</td>
+    </tr>
+    <tr>
+      <td><code>defaultOne</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Enter/click selects-and-closes (true) vs. additive toggle that stays open (false). Never unchecks via Enter/click.</td>
+    </tr>
+    <tr>
+      <td><code>onCommit</code></td>
+      <td><code>() =&gt; void</code></td>
+      <td>&#8212;</td>
+      <td>Called when the selection is committed (Enter with <code>defaultOne</code>, or Tab). In a cell editor, signals "stop editing".</td>
+    </tr>
+    <tr>
+      <td><code>maxResults</code></td>
+      <td><code>number</code></td>
+      <td><code>8</code></td>
+      <td>Maximum number of dropdown results to show.</td>
+    </tr>
+    <tr>
+      <td><code>cellEditorMode</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Adapt for AG Grid: auto-focus on mount, portaled dropdown, row-height sizing.</td>
+    </tr>
+    <tr>
+      <td><code>disabled</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Disable the input.</td>
+    </tr>
+    <tr>
+      <td><code>aria-label</code></td>
+      <td><code>string</code></td>
+      <td><code>placeholder</code></td>
+      <td>Accessible label for the input.</td>
+    </tr>
+    <tr>
+      <td><code>className</code></td>
+      <td><code>string</code></td>
+      <td>&#8212;</td>
+      <td>Additional CSS classes on the wrapper.</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Accessibility
+
+- The input is a `role="combobox"`; the dropdown is a `role="listbox"` with
+  `aria-multiselectable="true"` and `aria-selected` on each option.
+- A visually hidden live region announces result counts and loading/error
+  states.
+- Tokens are focusable for keyboard removal.
+
+---
+
+## Import
+
+```tsx
+import { MultiSelectTypeaheadInput } from '@arda-cards/design-system/canary';
+import { createMultiSelectCellEditor } from '@arda-cards/design-system/canary';
+```

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.stories.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { MultiSelectTypeaheadInput } from './multiselect-typeahead-input';
+import { lookupRoles } from '@/components/canary/__mocks__/role-lookup';
+import { roleLookupHandler } from '@/components/canary/__mocks__/handlers/role-lookup';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function MultiSelectDemo({
+  initialValue = [],
+  ...props
+}: Omit<React.ComponentProps<typeof MultiSelectTypeaheadInput>, 'value' | 'onValueChange'> & {
+  initialValue?: string[];
+}) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <div className="w-80 p-8">
+      <MultiSelectTypeaheadInput value={value} onValueChange={setValue} {...props} />
+      <p className="mt-2 text-xs text-muted-foreground">
+        Value: <code>{value.length > 0 ? value.join(', ') : '(empty)'}</code>
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta = {
+  title: 'Components/Canary/Molecules/TypeaheadInput/MultiSelect',
+  parameters: {
+    msw: { handlers: [roleLookupHandler] },
+  },
+};
+
+export default meta;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Default empty multiselect. Click to open, select multiple roles. */
+export const Default: StoryObj = {
+  render: () => <MultiSelectDemo lookup={lookupRoles} placeholder="Select roles..." />,
+};
+
+/** Pre-populated with two roles. */
+export const PrePopulated: StoryObj = {
+  render: () => (
+    <MultiSelectDemo
+      lookup={lookupRoles}
+      initialValue={['Vendor', 'Carrier']}
+      placeholder="Select roles..."
+    />
+  ),
+};
+
+/** Overflow — many selected, tokens that don't fit show "+N more". */
+export const Overflow: StoryObj = {
+  render: () => (
+    <MultiSelectDemo
+      lookup={lookupRoles}
+      initialValue={['Vendor', 'Customer', 'Carrier', 'Operator', 'Distributor']}
+      placeholder="Select roles..."
+    />
+  ),
+};
+
+/** Disabled state. */
+export const Disabled: StoryObj = {
+  render: () => (
+    <MultiSelectDemo
+      lookup={lookupRoles}
+      initialValue={['Vendor', 'Carrier']}
+      disabled
+      placeholder="Select roles..."
+    />
+  ),
+};
+
+/** Cell editor mode — no border, transparent bg, for use inside AG Grid cells. */
+export const CellEditorMode: StoryObj = {
+  render: () => (
+    <div className="p-8">
+      <p className="text-sm text-muted-foreground mb-4">
+        Cell editor mode: no border, transparent background. Dropdown is portaled.
+      </p>
+      <div className="w-80 overflow-hidden border border-border rounded-md p-2">
+        <MultiSelectDemo
+          lookup={lookupRoles}
+          initialValue={['Vendor']}
+          cellEditorMode
+          placeholder="Select roles..."
+        />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.stories.tsx
@@ -83,21 +83,6 @@ export const Disabled: StoryObj = {
   ),
 };
 
-/** Cell editor mode — no border, transparent bg, for use inside AG Grid cells. */
-export const CellEditorMode: StoryObj = {
-  render: () => (
-    <div className="p-8">
-      <p className="text-sm text-muted-foreground mb-4">
-        Cell editor mode: no border, transparent background. Dropdown is portaled.
-      </p>
-      <div className="w-80 overflow-hidden border border-border rounded-md p-2">
-        <MultiSelectDemo
-          lookup={lookupRoles}
-          initialValue={['Vendor']}
-          cellEditorMode
-          placeholder="Select roles..."
-        />
-      </div>
-    </div>
-  ),
-};
+// Cell-editor behavior is demonstrated end-to-end by the `InGrid` story shipped
+// with the DataGrid molecule — no standalone `CellEditorMode` story is needed
+// here.

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.test.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.test.tsx
@@ -1,0 +1,312 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { useState } from 'react';
+import {
+  MultiSelectTypeaheadInput,
+  type MultiSelectOption,
+  type MultiSelectSource,
+} from './multiselect-typeahead-input';
+
+// jsdom doesn't implement scrollIntoView, which the dropdown calls on highlight.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const ROLES = ['Vendor', 'Customer', 'Carrier', 'Operator', 'Distributor'];
+
+function asyncRoleLookup(search: string): Promise<MultiSelectOption[]> {
+  const q = search.trim().toLowerCase();
+  const matches = q ? ROLES.filter((r) => r.toLowerCase().includes(q)) : ROLES;
+  return Promise.resolve(matches.map((r) => ({ label: r, value: r })));
+}
+
+interface HarnessProps {
+  initialValue?: string[];
+  lookup?: MultiSelectSource;
+  onValueChange?: (v: string[]) => void;
+  onCommit?: () => void;
+  defaultOne?: boolean;
+  disabled?: boolean;
+  maxResults?: number;
+  cellEditorMode?: boolean;
+}
+
+function Harness({
+  initialValue = [],
+  lookup = asyncRoleLookup,
+  onValueChange,
+  ...rest
+}: HarnessProps) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <MultiSelectTypeaheadInput
+      value={value}
+      onValueChange={(v) => {
+        setValue(v);
+        onValueChange?.(v);
+      }}
+      lookup={lookup}
+      placeholder="Select roles"
+      {...rest}
+    />
+  );
+}
+
+/** Returns the dropdown option element for a given label. */
+function optionByLabel(label: string): HTMLElement {
+  const listbox = screen.getByRole('listbox');
+  return within(listbox).getByText(label).closest('[role="option"]') as HTMLElement;
+}
+
+describe('MultiSelectTypeaheadInput', () => {
+  it('shows results when the input is focused', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    expect(optionByLabel('Vendor')).toBeInTheDocument();
+  });
+
+  it('marks already-selected options as selected in the dropdown', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialValue={['Vendor']} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    expect(optionByLabel('Vendor')).toHaveAttribute('aria-selected', 'true');
+    expect(optionByLabel('Customer')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('accepts a static string[] as the lookup source', async () => {
+    const user = userEvent.setup();
+    render(<Harness lookup={['Email', 'EDI', 'Portal']} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    expect(optionByLabel('Portal')).toBeInTheDocument();
+  });
+
+  it('caps the number of results at maxResults', async () => {
+    const user = userEvent.setup();
+    render(<Harness maxResults={2} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  describe('defaultOne (true)', () => {
+    it('selects, commits, and closes the dropdown when an option is clicked', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      const onCommit = vi.fn();
+      render(<Harness onValueChange={onValueChange} onCommit={onCommit} />);
+      await user.click(screen.getByRole('combobox'));
+      await screen.findByRole('listbox');
+      await user.click(optionByLabel('Carrier'));
+      expect(onValueChange).toHaveBeenCalledWith(['Carrier']);
+      expect(onCommit).toHaveBeenCalledOnce();
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    });
+
+    it('does not uncheck an already-selected option on click', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(<Harness initialValue={['Vendor']} onValueChange={onValueChange} />);
+      await user.click(screen.getByRole('combobox'));
+      await screen.findByRole('listbox');
+      await user.click(optionByLabel('Vendor'));
+      // Value is unchanged (still selected); never called with a value that drops Vendor
+      expect(onValueChange).not.toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('defaultOne (false)', () => {
+    it('toggles selection and keeps the dropdown open', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(<Harness defaultOne={false} onValueChange={onValueChange} />);
+      await user.click(screen.getByRole('combobox'));
+      await screen.findByRole('listbox');
+      await user.click(optionByLabel('Vendor'));
+      expect(onValueChange).toHaveBeenCalledWith(['Vendor']);
+      // Dropdown stays open for further selection
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('removes a selected option when clicked again', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(
+        <Harness defaultOne={false} initialValue={['Vendor']} onValueChange={onValueChange} />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      await screen.findByRole('listbox');
+      await user.click(optionByLabel('Vendor'));
+      expect(onValueChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('navigates results with ArrowDown and selects on Enter', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    await user.keyboard('{ArrowDown}'); // Vendor (0) -> Customer (1)
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith(['Customer']);
+  });
+
+  it('closes the dropdown on Escape', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+  });
+
+  it('focuses the last token with ArrowLeft and removes it with Delete', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness initialValue={['Vendor', 'Customer']} onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('{ArrowLeft}'); // focus last token (Customer)
+    await user.keyboard('{Delete}');
+    expect(onValueChange).toHaveBeenCalledWith(['Vendor']);
+  });
+
+  it('shows an error row when the lookup rejects', async () => {
+    const user = userEvent.setup();
+    const failing = () => Promise.reject(new Error('boom'));
+    render(<Harness lookup={failing} />);
+    await user.click(screen.getByRole('combobox'));
+    expect(await screen.findByText(/Click to retry/i)).toBeInTheDocument();
+  });
+
+  it('reopens the dropdown when the focused input is clicked again', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await screen.findByRole('listbox');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await user.click(input);
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('removes the last token on Backspace when the input is empty', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness initialValue={['Vendor', 'Customer']} onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('{Backspace}');
+    expect(onValueChange).toHaveBeenCalledWith(['Vendor']);
+  });
+
+  it('is disabled when disabled is set', () => {
+    render(<Harness disabled />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  function focusedTokenText(): string | undefined {
+    return document.querySelector('[data-token].ring-2')?.textContent ?? undefined;
+  }
+
+  describe('token navigation', () => {
+    it('moves between tokens with ArrowLeft/ArrowRight and back to the input', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue={['Vendor', 'Customer', 'Carrier']} />);
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('{ArrowLeft}'); // input -> last token (Carrier)
+      expect(focusedTokenText()).toBe('Carrier');
+      await user.keyboard('{ArrowLeft}'); // -> Customer
+      expect(focusedTokenText()).toBe('Customer');
+      await user.keyboard('{ArrowRight}'); // -> Carrier
+      expect(focusedTokenText()).toBe('Carrier');
+      await user.keyboard('{ArrowRight}'); // past last -> input
+      expect(input).toHaveFocus();
+    });
+
+    it('returns to the input and opens the dropdown on ArrowDown from a token', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue={['Vendor']} />);
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('{Escape}'); // close dropdown, keep focus
+      await user.keyboard('{ArrowLeft}'); // focus the token
+      expect(focusedTokenText()).toBe('Vendor');
+      await user.keyboard('{ArrowDown}'); // back to input + open
+      expect(input).toHaveFocus();
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('returns focus to the input when typing on a focused token', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue={['Vendor']} />);
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('{ArrowLeft}'); // focus token
+      expect(focusedTokenText()).toBe('Vendor');
+      await user.keyboard('a'); // printable char returns to input
+      expect(input).toHaveFocus();
+    });
+
+    it('focuses the last token with ArrowUp from the top of the dropdown', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue={['Vendor']} />);
+      await user.click(screen.getByRole('combobox'));
+      await screen.findByRole('listbox');
+      await user.keyboard('{ArrowUp}'); // top result + has tokens -> focus last token
+      expect(focusedTokenText()).toBe('Vendor');
+    });
+
+    it('clicking a token focuses it and opens the dropdown', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue={['Vendor', 'Customer']} />);
+      await user.click(screen.getByRole('combobox'));
+      await screen.findByRole('listbox');
+      // Click the rendered token (data-token marks real tokens, not the
+      // off-screen measurer copies).
+      const firstToken = document.querySelector('[data-token]') as HTMLElement;
+      await user.click(firstToken);
+      expect(focusedTokenText()).toBe('Vendor');
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  it('commits and calls onCommit on Tab', async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<Harness onCommit={onCommit} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    await user.keyboard('{Tab}');
+    expect(onCommit).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a static MultiSelectOption[] and commits the option value', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <Harness
+        defaultOne={false}
+        lookup={[
+          { label: 'Air Freight', value: 'AIR' },
+          { label: 'Sea Freight', value: 'SEA' },
+        ]}
+        onValueChange={onValueChange}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    await user.click(optionByLabel('Sea Freight'));
+    expect(onValueChange).toHaveBeenCalledWith(['SEA']);
+  });
+
+  it('auto-focuses and opens the dropdown on mount in cell editor mode', async () => {
+    render(<Harness cellEditorMode />);
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+});

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
@@ -272,10 +272,16 @@ export function MultiSelectTypeaheadInput({
     }
   }, [open, doSearch]);
 
-  // Close on outside click
+  // Close on outside click. Attach the listener once on mount and read `open`
+  // via a ref so the listener isn't torn down + re-added on every open/close
+  // cycle — the previous `[open]` dep created a one-frame window during the
+  // transition where no listener was active, and a fast click in that window
+  // would slip through and leave the dropdown open.
+  const openRef = React.useRef(open);
+  openRef.current = open;
   React.useEffect(() => {
-    if (!open) return;
     const handleClickOutside = (e: MouseEvent) => {
+      if (!openRef.current) return;
       const target = e.target as Node;
       if (
         wrapperRef.current &&
@@ -288,7 +294,7 @@ export function MultiSelectTypeaheadInput({
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
+  }, []);
 
   // --- Focus helpers ---
   const focusToken = React.useCallback((index: number) => {

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
@@ -1,0 +1,686 @@
+import * as React from 'react';
+import { Check, Loader2, AlertCircle } from 'lucide-react';
+
+import { cn } from '@/types/canary/utilities/utils';
+import { Badge } from '@/components/canary/atoms/badge/badge';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/canary/primitives/popover';
+
+// --- Types ---
+
+export interface MultiSelectOption {
+  label: string;
+  value: string;
+}
+
+/**
+ * Source of multiselect options. Either an async function (receives search
+ * text, returns matches) or a static list (`MultiSelectOption[]` or `string[]`)
+ * filtered client-side by label.
+ */
+export type MultiSelectSource =
+  | ((search: string) => Promise<MultiSelectOption[]>)
+  | MultiSelectOption[]
+  | string[];
+
+/** Normalize a MultiSelectSource into an async lookup function. */
+function normalizeLookup(
+  source: MultiSelectSource,
+): (search: string) => Promise<MultiSelectOption[]> {
+  if (typeof source === 'function') return source;
+  const options: MultiSelectOption[] = source.map((o) =>
+    typeof o === 'string' ? { label: o, value: o } : o,
+  );
+  return async (search: string) => {
+    const q = search.trim().toLowerCase();
+    return q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options;
+  };
+}
+
+export interface MultiSelectTypeaheadInputProps extends Omit<
+  React.ComponentProps<'div'>,
+  'onChange'
+> {
+  /** Currently selected values. */
+  value: string[];
+  /** Called when the selection changes. */
+  onValueChange: (value: string[]) => void;
+  /**
+   * Options source — an async lookup function, or a static list of options
+   * (`MultiSelectOption[]` or `string[]`) filtered client-side by label.
+   */
+  lookup: MultiSelectSource;
+  /** Input placeholder text (shown when no tokens are selected). */
+  placeholder?: string;
+  /** Accessible label for the input. */
+  'aria-label'?: string;
+  /** Disable the input. */
+  disabled?: boolean;
+  /**
+   * Cell editor mode — for use inside AG Grid or similar overflow-clipped containers.
+   * Dropdown is portaled via Radix Popover to escape overflow clipping.
+   */
+  cellEditorMode?: boolean;
+  /**
+   * When true (default), Enter selects the highlighted item and signals commit
+   * (exit edit mode in grid context). Enter never unchecks a selected item.
+   * When false, Enter adds the highlighted item without exiting — the dropdown
+   * stays open for continued selection.
+   */
+  defaultOne?: boolean;
+  /**
+   * Called when the user commits the selection (Enter with defaultOne, or Tab).
+   * In cell editor context, this signals "stop editing".
+   */
+  onCommit?: () => void;
+  /** Maximum number of dropdown results to show. Defaults to 8. */
+  maxResults?: number;
+  /**
+   * Cell geometry for `cellEditorMode` (popup). The editor matches the cell's
+   * pixel width and uses the row height as its minimum height, so a single-line
+   * popup aligns with the cell and grows taller as tokens wrap onto more lines.
+   */
+  cellWidth?: number;
+  cellMinHeight?: number;
+}
+
+const DEFAULT_MAX_RESULTS = 8;
+const DEBOUNCE_MS = 250;
+
+// Hoisted static JSX
+const loadingIndicator = (
+  <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+    <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+    Searching&hellip;
+  </div>
+);
+
+const noResults = <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>;
+
+// --- Component ---
+
+/**
+ * MultiSelectTypeaheadInput — async search input with multiselect.
+ *
+ * Shows selected values as dismissible Badge tokens in the input area.
+ * Overflows to "+N more" when tokens exceed the container width.
+ * Dropdown items show a checkmark when already selected.
+ */
+export function MultiSelectTypeaheadInput({
+  value,
+  onValueChange,
+  lookup,
+  placeholder = 'Search\u2026',
+  'aria-label': ariaLabel,
+  disabled = false,
+  cellEditorMode = false,
+  defaultOne = true,
+  onCommit,
+  maxResults = DEFAULT_MAX_RESULTS,
+  cellWidth,
+  cellMinHeight,
+  className,
+  ...rest
+}: MultiSelectTypeaheadInputProps) {
+  // Normalize the lookup source (function | options[] | string[]) into a
+  // single async lookup function.
+  const lookupFn = React.useMemo(() => normalizeLookup(lookup), [lookup]);
+
+  const [inputValue, setInputValue] = React.useState('');
+  const [options, setOptions] = React.useState<MultiSelectOption[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+  const [focusedTokenIndex, setFocusedTokenIndex] = React.useState(-1);
+  const instanceId = React.useId();
+  const listboxId = `multiselect-listbox-${instanceId}`;
+  const optionId = (index: number) => `multiselect-opt-${instanceId}-${index}`;
+
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const tokenRefs = React.useRef<(HTMLSpanElement | null)[]>([]);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortRef = React.useRef<AbortController>(undefined);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+
+  // Refs for stable callbacks
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const inputValueRef = React.useRef(inputValue);
+  inputValueRef.current = inputValue;
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+  const highlightedRef = React.useRef(highlightedIndex);
+  highlightedRef.current = highlightedIndex;
+
+  // --- Search ---
+  const doSearch = React.useCallback(
+    async (search: string) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      setError(false);
+
+      try {
+        const results = await lookupFn(search);
+        if (controller.signal.aborted) return;
+        const sliced = results.slice(0, maxResults);
+        setOptions(sliced);
+        setHighlightedIndex(sliced.length > 0 ? 0 : -1);
+        setLoading(false);
+      } catch {
+        if (controller.signal.aborted) return;
+        setError(true);
+        setLoading(false);
+        setOptions([]);
+      }
+    },
+    [lookupFn, maxResults],
+  );
+
+  const debouncedSearch = React.useCallback(
+    (search: string) => {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => doSearch(search), DEBOUNCE_MS);
+    },
+    [doSearch],
+  );
+
+  // Cleanup on unmount. We intentionally do NOT abort the in-flight lookup
+  // here — under React StrictMode the mount effect is double-invoked on the
+  // same DOM, and aborting would cancel the dropdown's initial search while the
+  // re-run focus() is a no-op (input already focused), leaving `loading` stuck.
+  // Search-racing is handled by the abort inside doSearch; stale setState after
+  // a real unmount is a safe no-op in React 18+.
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // Auto-focus input on mount in cell editor mode so the dropdown opens
+  // immediately and all tokens are visible for keyboard navigation.
+  React.useEffect(() => {
+    if (cellEditorMode) {
+      inputRef.current?.focus();
+    }
+  }, [cellEditorMode]);
+
+  // --- Selection ---
+  const selectedSet = React.useMemo(() => new Set(value), [value]);
+
+  const toggleOption = React.useCallback(
+    (optionValue: string) => {
+      const current = valueRef.current;
+      if (current.includes(optionValue)) {
+        onValueChange(current.filter((v) => v !== optionValue));
+      } else {
+        onValueChange([...current, optionValue]);
+      }
+      // Keep dropdown open, clear search, refocus input
+      setInputValue('');
+      inputRef.current?.focus();
+    },
+    [onValueChange],
+  );
+
+  // Choosing an option — from Enter or a click. With defaultOne, selecting
+  // (never unselecting) commits and closes; otherwise it toggles and stays open.
+  const chooseOption = React.useCallback(
+    (optionValue: string) => {
+      if (defaultOne) {
+        if (!valueRef.current.includes(optionValue)) {
+          onValueChange([...valueRef.current, optionValue]);
+        }
+        setOpen(false);
+        setInputValue('');
+        onCommit?.();
+      } else {
+        toggleOption(optionValue);
+      }
+    },
+    [defaultOne, onValueChange, onCommit, toggleOption],
+  );
+
+  // --- Input handlers ---
+  const handleInputChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value;
+      setInputValue(val);
+      setOpen(true);
+      debouncedSearch(val);
+    },
+    [debouncedSearch],
+  );
+
+  const handleFocus = React.useCallback(() => {
+    setOpen(true);
+    doSearch(inputValueRef.current);
+  }, [doSearch]);
+
+  // Clicking the input reopens the dropdown when it's already focused (focus
+  // alone won't re-fire, e.g. after a defaultOne selection closed it).
+  const handleInputClick = React.useCallback(() => {
+    if (!open) {
+      setOpen(true);
+      doSearch(inputValueRef.current);
+    }
+  }, [open, doSearch]);
+
+  // Close on outside click
+  React.useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(target) &&
+        !popoverRef.current?.contains(target)
+      ) {
+        setOpen(false);
+        setInputValue('');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  // --- Focus helpers ---
+  const focusToken = React.useCallback((index: number) => {
+    setFocusedTokenIndex(index);
+    setHighlightedIndex(-1);
+    tokenRefs.current[index]?.focus();
+  }, []);
+
+  const focusInput = React.useCallback(() => {
+    setFocusedTokenIndex(-1);
+    inputRef.current?.focus();
+  }, []);
+
+  // --- Token keyboard handler ---
+  const handleTokenKeyDown = React.useCallback(
+    (e: React.KeyboardEvent, tokenIndex: number) => {
+      const tokens = valueRef.current;
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault();
+          if (tokenIndex > 0) {
+            focusToken(tokenIndex - 1);
+          }
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          if (tokenIndex < tokens.length - 1) {
+            focusToken(tokenIndex + 1);
+          } else {
+            focusInput();
+          }
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          focusInput();
+          setOpen(true);
+          doSearch(inputValueRef.current);
+          break;
+        case 'Backspace':
+        case 'Delete':
+          e.preventDefault();
+          {
+            const removedValue = tokens[tokenIndex];
+            if (removedValue) {
+              onValueChange(tokens.filter((v) => v !== removedValue));
+            }
+            // Focus neighbor or input
+            if (tokens.length <= 1) {
+              focusInput();
+            } else if (tokenIndex > 0) {
+              // Will shift, so focus same index - 1
+              setTimeout(() => focusToken(tokenIndex - 1), 0);
+            } else {
+              setTimeout(() => focusToken(0), 0);
+            }
+          }
+          break;
+        default:
+          // Any printable character → focus input and let it handle the key
+          if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+            focusInput();
+            // Don't prevent default — let the character reach the input
+          }
+          break;
+      }
+    },
+    [focusToken, focusInput, doSearch, onValueChange],
+  );
+
+  // --- Input keyboard handler ---
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      // Left arrow at cursor position 0 with empty input → focus last token
+      if (e.key === 'ArrowLeft' && inputValueRef.current === '' && valueRef.current.length > 0) {
+        e.preventDefault();
+        focusToken(valueRef.current.length - 1);
+        return;
+      }
+
+      // Backspace with empty input removes last token
+      if (e.key === 'Backspace' && inputValueRef.current === '' && valueRef.current.length > 0) {
+        onValueChange(valueRef.current.slice(0, -1));
+        return;
+      }
+
+      if (!open) {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          setOpen(true);
+          doSearch(inputValueRef.current);
+        }
+        return;
+      }
+
+      const opts = optionsRef.current;
+      const hi = highlightedRef.current;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev + 1) % opts.length);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          if (hi <= 0 && valueRef.current.length > 0) {
+            // At top of dropdown → focus last token
+            focusToken(valueRef.current.length - 1);
+          } else {
+            setHighlightedIndex((prev) => (prev - 1 + opts.length) % opts.length);
+          }
+          break;
+        case 'Enter':
+          e.preventDefault();
+          {
+            const opt = opts[hi];
+            if (hi >= 0 && opt) {
+              chooseOption(opt.value);
+            }
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setOpen(false);
+          setInputValue('');
+          break;
+        case 'Tab':
+          // In a grid, let AG Grid handle Tab (commit + move to the next
+          // editable cell). Just close the dropdown; do NOT stopEditing here or
+          // focus escapes to the next row.
+          setOpen(false);
+          setInputValue('');
+          if (!cellEditorMode) onCommit?.();
+          break;
+      }
+    },
+    [open, cellEditorMode, doSearch, focusToken, chooseOption, onValueChange, onCommit],
+  );
+
+  // Scroll highlighted item into view
+  React.useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const showDropdown = open && (loading || error || options.length > 0);
+
+  // Live region announcement
+  const statusMessage = loading
+    ? 'Searching'
+    : error
+      ? 'Failed to load results'
+      : options.length > 0
+        ? `${options.length} result${options.length === 1 ? '' : 's'} available`
+        : open && inputValue.trim()
+          ? 'No results'
+          : '';
+
+  // --- Token display ---
+  const isEditing = open || focusedTokenIndex >= 0;
+
+  // Dynamic overflow: measure how many tokens fit in one line.
+  // Uses the same hidden-measurer + ResizeObserver pattern as OverflowToolbar.
+  const measurerRef = React.useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = React.useState(value.length);
+  const TOKEN_GAP = 4; // gap-1 = 0.25rem = 4px
+  const OVERFLOW_LABEL_WIDTH = 56; // "+N more" text approximate width
+
+  React.useEffect(() => {
+    if (isEditing) {
+      setVisibleCount(value.length);
+      return;
+    }
+    const measurer = measurerRef.current;
+    const container = wrapperRef.current;
+    if (!measurer || !container) return;
+
+    const measure = () => {
+      const containerWidth = container.offsetWidth - 16; // px-2 padding both sides
+      const items = Array.from(measurer.children) as HTMLElement[];
+      let usedWidth = 0;
+      let count = 0;
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (!item) break;
+        const itemWidth = item.offsetWidth + (i > 0 ? TOKEN_GAP : 0);
+        const needsOverflow = i < items.length - 1;
+        const reserve = needsOverflow ? OVERFLOW_LABEL_WIDTH + TOKEN_GAP : 0;
+        if (usedWidth + itemWidth + reserve <= containerWidth) {
+          usedWidth += itemWidth;
+          count++;
+        } else {
+          break;
+        }
+      }
+      setVisibleCount(count === items.length ? items.length : count);
+    };
+
+    const observer = new ResizeObserver(() => requestAnimationFrame(measure));
+    observer.observe(container);
+    requestAnimationFrame(measure);
+    return () => observer.disconnect();
+  }, [value, isEditing]);
+
+  const visibleTokens = isEditing ? value : value.slice(0, visibleCount);
+  const overflowCount = isEditing ? 0 : value.length - visibleCount;
+
+  // --- Dropdown list content ---
+  const dropdownList = (
+    <div ref={listRef} id={listboxId} role="listbox" aria-multiselectable="true">
+      {loading && loadingIndicator}
+
+      {error && (
+        <button
+          type="button"
+          className="flex items-center gap-2 w-full px-3 py-2 text-sm text-destructive hover:bg-accent cursor-pointer"
+          onClick={() => doSearch(inputValue)}
+        >
+          <AlertCircle className="w-4 h-4" aria-hidden="true" />
+          Failed to load. Click to retry.
+        </button>
+      )}
+
+      {!loading &&
+        !error &&
+        options.map((opt, i) => {
+          const isSelected = selectedSet.has(opt.value);
+          return (
+            <div
+              key={opt.value}
+              id={optionId(i)}
+              role="option"
+              aria-selected={isSelected}
+              className={cn(
+                'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
+                i === highlightedIndex && 'bg-accent text-accent-foreground',
+              )}
+              onPointerDown={(e) => {
+                e.preventDefault();
+                chooseOption(opt.value);
+              }}
+              onMouseEnter={() => setHighlightedIndex(i)}
+            >
+              <div
+                className={cn(
+                  'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border',
+                  isSelected
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-muted-foreground/40',
+                )}
+              >
+                {isSelected && <Check className="h-3 w-3" aria-hidden="true" />}
+              </div>
+              {opt.label}
+            </div>
+          );
+        })}
+
+      {!loading && !error && options.length === 0 && noResults}
+    </div>
+  );
+
+  // --- Input area with tokens ---
+  const inputArea = (
+    <div
+      className={cn(
+        'flex items-center gap-1 rounded-md border border-input bg-background px-2 py-1 text-sm',
+        // Focus treatment via Tailwind ring — soft (matches form inputs); a
+        // container, so :focus-within. Cell editor mode bumps it to full opacity.
+        'focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50',
+        disabled && 'opacity-50 cursor-not-allowed',
+        // Collapsed: single line, clip overflow so the field never grows tall.
+        // Editing: wrap tokens onto multiple lines.
+        isEditing ? 'flex-wrap' : 'flex-nowrap overflow-hidden',
+        // Cell editor mode renders in an AG Grid popup ('over' the cell). Keep
+        // the normal input chrome (rounded border + focus ring from the base) —
+        // a popup floats, so AG Grid does not draw a cell edit border around it.
+        // Width + min-height come from the cell via inline style, so the popup
+        // aligns with the cell on one line and grows downward as tokens wrap.
+        // `min-w-60` keeps the editor usable on narrow columns (extends past the
+        // cell edge; AG Grid keeps the popup in bounds). px-3 matches cell padding.
+        // 2px full-opacity accent ring in edit mode (3px reads too bold).
+        cellEditorMode && 'min-w-60 px-3 py-1.5 focus-within:ring-2 focus-within:ring-ring',
+        // Standalone editing: expand as an absolute overlay so wrapped tokens
+        // don't push surrounding layout.
+        !cellEditorMode &&
+          isEditing &&
+          'absolute inset-x-0 top-0 z-10 bg-background border border-input rounded-md',
+      )}
+      style={cellEditorMode ? { width: cellWidth, minHeight: cellMinHeight } : undefined}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {visibleTokens.map((tokenValue, i) => (
+        <span
+          key={tokenValue}
+          ref={(el) => {
+            tokenRefs.current[i] = el;
+          }}
+          data-token
+          tabIndex={-1}
+          onPointerDown={(e) => {
+            // Select the token (focus it for keyboard nav) and open the
+            // dropdown. Stop the wrapper onClick from stealing focus to the input.
+            // Pointer events (vs mouse) ensure iOS Safari fires the handler
+            // before the document outside-click closes the dropdown.
+            e.preventDefault();
+            e.stopPropagation();
+            focusToken(i);
+            setOpen(true);
+            doSearch(inputValueRef.current);
+          }}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => handleTokenKeyDown(e, i)}
+          onFocus={() => setFocusedTokenIndex(i)}
+          onBlur={() => setFocusedTokenIndex(-1)}
+          className={cn(
+            'shrink-0 rounded-md outline-none',
+            focusedTokenIndex === i && 'ring-2 ring-ring',
+          )}
+        >
+          <Badge variant="secondary" className="text-xs">
+            {tokenValue}
+          </Badge>
+        </span>
+      ))}
+      {overflowCount > 0 && (
+        <span className="shrink-0 whitespace-nowrap px-1 text-xs font-medium text-muted-foreground">
+          +{overflowCount} more
+        </span>
+      )}
+      <input
+        ref={inputRef}
+        value={inputValue}
+        onChange={handleInputChange}
+        onFocus={handleFocus}
+        onClick={handleInputClick}
+        onKeyDownCapture={handleKeyDown}
+        placeholder={value.length === 0 ? placeholder : ''}
+        disabled={disabled}
+        role="combobox"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        aria-controls={showDropdown ? listboxId : undefined}
+        aria-activedescendant={highlightedIndex >= 0 ? optionId(highlightedIndex) : undefined}
+        aria-label={ariaLabel ?? placeholder}
+        autoComplete="off"
+        className="flex-1 min-w-[60px] bg-transparent outline-none placeholder:text-muted-foreground h-7"
+      />
+    </div>
+  );
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn('relative', cellEditorMode ? 'w-fit' : 'min-h-9', className)}
+      data-slot="multiselect-typeahead-input"
+      data-state={open ? 'open' : 'closed'}
+      data-loading={loading || undefined}
+      data-disabled={disabled || undefined}
+      data-cell-editor={cellEditorMode || undefined}
+      {...rest}
+    >
+      {/* Live region for screen readers */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {statusMessage}
+      </div>
+
+      {/* Hidden measurer — renders all tokens off-screen to measure widths */}
+      <div
+        ref={measurerRef}
+        aria-hidden="true"
+        className="pointer-events-none fixed left-[-9999px] top-0 flex items-center gap-1"
+        style={{ visibility: 'hidden' }}
+      >
+        {value.map((tokenValue) => (
+          <Badge key={tokenValue} variant="secondary" className="text-xs">
+            {tokenValue}
+          </Badge>
+        ))}
+      </div>
+
+      <Popover open={showDropdown}>
+        <PopoverAnchor asChild>{inputArea}</PopoverAnchor>
+        <PopoverContent
+          ref={popoverRef}
+          align="start"
+          sideOffset={4}
+          className="w-(--radix-popover-trigger-width) p-1 max-h-52 overflow-auto"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          {dropdownList}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
@@ -101,7 +101,9 @@ const noResults = <div className="px-3 py-2 text-sm text-muted-foreground">No re
 /**
  * MultiSelectTypeaheadInput — async search input with multiselect.
  *
- * Shows selected values as dismissible Badge tokens in the input area.
+ * Shows selected values as Badge tokens in the input area. Tokens are
+ * keyboard-removable (Backspace / Delete with the token focused, or
+ * Backspace at the start of an empty input removes the last token).
  * Overflows to "+N more" when tokens exceed the container width.
  * Dropdown items show a checkmark when already selected.
  */
@@ -387,6 +389,9 @@ export function MultiSelectTypeaheadInput({
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
+          // Guard against opts.length === 0 (possible while loading/error):
+          // the modulo would produce NaN and break the highlight state.
+          if (opts.length === 0) break;
           setHighlightedIndex((prev) => (prev + 1) % opts.length);
           break;
         case 'ArrowUp':
@@ -394,7 +399,7 @@ export function MultiSelectTypeaheadInput({
           if (hi <= 0 && valueRef.current.length > 0) {
             // At top of dropdown → focus last token
             focusToken(valueRef.current.length - 1);
-          } else {
+          } else if (opts.length > 0) {
             setHighlightedIndex((prev) => (prev - 1 + opts.length) % opts.length);
           }
           break;

--- a/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/multiselect-typeahead-input.tsx
@@ -329,6 +329,10 @@ export function MultiSelectTypeaheadInput({
           break;
         case 'Backspace':
         case 'Delete':
+        case 'Enter':
+        case ' ':
+          // Enter / Space are the standard activation keys for a role="button"
+          // element; activating a token removes it, matching Backspace/Delete.
           e.preventDefault();
           {
             const removedValue = tokens[tokenIndex];
@@ -591,6 +595,9 @@ export function MultiSelectTypeaheadInput({
             tokenRefs.current[i] = el;
           }}
           data-token
+          role="button"
+          aria-label={`${tokenValue}, remove`}
+          aria-keyshortcuts="Delete Backspace Enter Space"
           tabIndex={-1}
           onPointerDown={(e) => {
             // Select the token (focus it for keyboard nav) and open the

--- a/src/components/canary/molecules/typeahead-input/typeahead-cell-editor.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-cell-editor.tsx
@@ -1,17 +1,28 @@
 import { useState, useRef, useCallback } from 'react';
-import { useGridCellEditor } from 'ag-grid-react';
+import { useGridCellEditor, type CustomCellEditorProps } from 'ag-grid-react';
 
-import { TypeaheadInput, type TypeaheadOption } from './typeahead-input';
+import { TypeaheadInput, type TypeaheadSource } from './typeahead-input';
+import { useCellEditorGeometry } from './use-cell-editor-geometry';
 
 // --- Types ---
 
 export interface TypeaheadCellEditorConfig {
-  /** Async lookup function for options. */
-  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  /**
+   * Options source — an async lookup function, or a static list (`string[]` or
+   * `TypeaheadOption[]`) filtered client-side by label.
+   */
+  lookup: TypeaheadSource;
   /** Allow creating new values not in the lookup results. */
   allowCreate?: boolean;
   /** Input placeholder text. */
   placeholder?: string;
+  /** Maximum number of dropdown results to show. Defaults to 8. */
+  maxResults?: number;
+  /**
+   * Clear the input on focus to show the full list; restore on Escape/blur.
+   * Delete/Backspace on an empty input clears the value.
+   */
+  clearOnFocus?: boolean;
 }
 
 export interface TypeaheadCellEditorProps {
@@ -25,14 +36,22 @@ export interface TypeaheadCellEditorProps {
 function TypeaheadCellEditorInner({
   value,
   onValueChange,
+  stopEditing,
+  column,
+  node,
   config,
-}: Omit<TypeaheadCellEditorProps, 'stopEditing'> & { config: TypeaheadCellEditorConfig }) {
+}: CustomCellEditorProps<Record<string, unknown>, string | null> & {
+  config: TypeaheadCellEditorConfig;
+}) {
   const [currentValue, setCurrentValue] = useState(value ?? '');
   const wasCancelledRef = useRef(false);
 
   useGridCellEditor({
     isCancelAfterEnd: () => wasCancelledRef.current,
   });
+
+  // Match the popup editor to the cell it edits (shared with multi-select).
+  const { cellWidth, cellMinHeight } = useCellEditorGeometry(column, node);
 
   const handleValueChange = useCallback(
     (val: string) => {
@@ -42,15 +61,21 @@ function TypeaheadCellEditorInner({
     [onValueChange],
   );
 
+  const handleCommit = useCallback(() => stopEditing(), [stopEditing]);
+
   return (
     <TypeaheadInput
       value={currentValue}
       onValueChange={handleValueChange}
+      onCommit={handleCommit}
       lookup={config.lookup}
       allowCreate={config.allowCreate ?? false}
-      placeholder={config.placeholder ?? 'Search\u2026'}
+      placeholder={config.placeholder ?? 'Search…'}
+      maxResults={config.maxResults ?? 8}
+      clearOnFocus={config.clearOnFocus ?? false}
       cellEditorMode
-      className="w-full"
+      cellWidth={cellWidth}
+      {...(cellMinHeight !== undefined ? { cellMinHeight } : {})}
     />
   );
 }
@@ -62,15 +87,16 @@ function TypeaheadCellEditorInner({
  *
  * Usage:
  * ```tsx
- * const UnitCellEditor = createTypeaheadCellEditor({
- *   lookup: lookupUnits,
- *   allowCreate: true,
- *   placeholder: 'Search units...',
+ * const OrderMethodCellEditor = createTypeaheadCellEditor({
+ *   lookup: ORDER_METHODS,
+ *   placeholder: 'Order method...',
+ *   maxResults: ORDER_METHODS.length,
+ *   clearOnFocus: true,
  * });
  * ```
  */
 export function createTypeaheadCellEditor(config: TypeaheadCellEditorConfig) {
-  function CellEditor(props: TypeaheadCellEditorProps) {
+  function CellEditor(props: CustomCellEditorProps<Record<string, unknown>, string | null>) {
     return <TypeaheadCellEditorInner {...props} config={config} />;
   }
   CellEditor.displayName = `TypeaheadCellEditor(${config.placeholder ?? 'Search'})`;

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.mdx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.mdx
@@ -1,0 +1,217 @@
+{/* typeahead-input.mdx */}
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as TypeaheadStories from './typeahead-input.stories';
+
+<Meta of={TypeaheadStories} />
+
+# TypeaheadInput
+
+Async search input with a filtered dropdown. Debounces lookups, auto-highlights
+the first result, supports keyboard navigation, and optionally lets users create
+values not in the list. Works as a standalone form input and as an AG Grid cell
+editor.
+
+**Molecule** &#8212; Canary | Import: `import { TypeaheadInput } from '@arda-cards/design-system/canary'`
+
+---
+
+## Playground
+
+Use the controls panel to explore every prop: `allowCreate`, `disabled`,
+`cellEditorMode`, `clearOnFocus`, and `maxResults`.
+
+<Canvas of={TypeaheadStories.Playground} />
+
+---
+
+## Behaviors
+
+- **Focus shows results** &#8212; focusing the input runs the lookup with the
+  current text (empty by default), so the user sees results immediately.
+- **First result highlighted** &#8212; the top result is auto-highlighted so
+  pressing Enter commits it without arrow-keying.
+- **Debounced search** &#8212; typing debounces the lookup (250ms) and aborts
+  in-flight requests.
+- **Create-on-the-fly** &#8212; with `allowCreate`, a "create" row appears for
+  text that doesn't match an existing option.
+
+---
+
+## Static list
+
+`lookup` accepts a static array instead of a function — pass a `string[]` or
+`TypeaheadOption[]` and the component filters it client-side by label. Useful
+for small fixed enums (e.g. order methods, units).
+
+```tsx
+<TypeaheadInput value={value} onValueChange={setValue} lookup={['each', 'case', 'box']} />
+```
+
+<Canvas of={TypeaheadStories.StaticList} />
+
+---
+
+## clearOnFocus
+
+When `clearOnFocus` is enabled, the input behaves like a re-pick selector:
+
+- **On focus** &#8212; the input clears so the user sees an unfiltered list.
+- **Escape / blur without picking** &#8212; the original value is restored.
+- **Delete / Backspace with empty input** &#8212; clears the value
+  (`onValueChange('')`) and blurs.
+
+Use this for cells/fields where the common action is replacing the existing
+selection rather than editing its text.
+
+---
+
+## Cell editor mode
+
+`cellEditorMode` adapts the input for AG Grid (or any overflow-clipped
+container):
+
+- Blur **accepts** the typed value instead of reverting (unless `clearOnFocus`
+  is set, which restores).
+- The dropdown is portaled via Radix Popover to escape `overflow: hidden`.
+- Borderless, transparent styling to sit flush in a grid cell.
+
+Wrap it with `createTypeaheadCellEditor({ lookup, allowCreate, placeholder })`
+to use as a `cellEditor` in a column definition. A live in-grid demo ships
+with the DataGrid molecule.
+
+---
+
+## Keyboard
+
+<table>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Behavior</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>ArrowDown</code> / <code>ArrowUp</code></td>
+      <td>Move the highlight through results (opens the dropdown if closed).</td>
+    </tr>
+    <tr>
+      <td><code>Enter</code></td>
+      <td>Select the highlighted result, or create the typed value when <code>allowCreate</code>.</td>
+    </tr>
+    <tr>
+      <td><code>Escape</code></td>
+      <td>Close the dropdown and revert to the confirmed value.</td>
+    </tr>
+    <tr>
+      <td><code>Tab</code></td>
+      <td>Commit the highlighted result (or typed value) and move focus on.</td>
+    </tr>
+    <tr>
+      <td><code>Delete</code> / <code>Backspace</code></td>
+      <td>With <code>clearOnFocus</code> and an empty input, clears the value and blurs.</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Props
+
+<table>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>value</code></td>
+      <td><code>string</code></td>
+      <td>&#8212;</td>
+      <td>Current value (controlled).</td>
+    </tr>
+    <tr>
+      <td><code>onValueChange</code></td>
+      <td><code>(value: string) =&gt; void</code></td>
+      <td>&#8212;</td>
+      <td>Called when the user selects or creates a value.</td>
+    </tr>
+    <tr>
+      <td><code>lookup</code></td>
+      <td><code>((search: string) =&gt; Promise&lt;TypeaheadOption[]&gt;) | TypeaheadOption[] | string[]</code></td>
+      <td>&#8212;</td>
+      <td>Options source. Pass an async function (receives search text, returns matches), or a static list of <code>TypeaheadOption</code>s or plain strings that is filtered client-side by label.</td>
+    </tr>
+    <tr>
+      <td><code>allowCreate</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Show a "create" row for text that doesn't match an existing option.</td>
+    </tr>
+    <tr>
+      <td><code>placeholder</code></td>
+      <td><code>string</code></td>
+      <td><code>'Search…'</code></td>
+      <td>Input placeholder text.</td>
+    </tr>
+    <tr>
+      <td><code>aria-label</code></td>
+      <td><code>string</code></td>
+      <td><code>placeholder</code></td>
+      <td>Accessible label for the input.</td>
+    </tr>
+    <tr>
+      <td><code>disabled</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Disable the input.</td>
+    </tr>
+    <tr>
+      <td><code>cellEditorMode</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Adapt for AG Grid: blur accepts the typed value and the dropdown is portaled.</td>
+    </tr>
+    <tr>
+      <td><code>maxResults</code></td>
+      <td><code>number</code></td>
+      <td><code>8</code></td>
+      <td>Maximum number of dropdown results to show.</td>
+    </tr>
+    <tr>
+      <td><code>clearOnFocus</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Clear the input on focus to show an unfiltered list. Restores the original value on Escape/blur; Delete/Backspace on an empty input clears the value and blurs.</td>
+    </tr>
+    <tr>
+      <td><code>className</code></td>
+      <td><code>string</code></td>
+      <td>&#8212;</td>
+      <td>Additional CSS classes on the wrapper.</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Accessibility
+
+- The input is a `role="combobox"` with `aria-expanded`, `aria-controls`, and
+  `aria-activedescendant` wired to the listbox and highlighted option.
+- A visually hidden live region announces result counts and loading/error
+  states.
+- Dropdown options use `role="option"` with `aria-selected` on the highlight.
+
+---
+
+## Import
+
+```tsx
+import { TypeaheadInput } from '@arda-cards/design-system/canary';
+import { createTypeaheadCellEditor } from '@arda-cards/design-system/canary';
+```

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.mdx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.mdx
@@ -73,7 +73,9 @@ container):
 - Blur **accepts** the typed value instead of reverting (unless `clearOnFocus`
   is set, which restores).
 - The dropdown is portaled via Radix Popover to escape `overflow: hidden`.
-- Borderless, transparent styling to sit flush in a grid cell.
+- Input keeps its normal chrome (opaque background, focus ring, minimum
+  width) — sized to the grid cell via `cellWidth` / `cellMinHeight` so it
+  doesn't shrink below the column.
 
 Wrap it with `createTypeaheadCellEditor({ lookup, allowCreate, placeholder })`
 to use as a `cellEditor` in a column definition. A live in-grid demo ships

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -1,14 +1,24 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { AgGridReact } from 'ag-grid-react';
-import { ModuleRegistry, AllCommunityModule, type ColDef } from 'ag-grid-community';
 
-ModuleRegistry.registerModules([AllCommunityModule]);
-
-import { TypeaheadInput } from './typeahead-input';
-import { createTypeaheadCellEditor } from './typeahead-cell-editor';
+import { TypeaheadInput, type TypeaheadSource } from './typeahead-input';
+import { MultiSelectTypeaheadInput } from './multiselect-typeahead-input';
 import { lookupUnits } from '@/components/canary/__mocks__/unit-lookup';
+import { lookupRoles } from '@/components/canary/__mocks__/role-lookup';
 import { unitLookupHandler } from '@/components/canary/__mocks__/handlers/unit-lookup';
+import { roleLookupHandler } from '@/components/canary/__mocks__/handlers/role-lookup';
+
+// ---------------------------------------------------------------------------
+// Playground data sources — async lookup functions + a static array
+// ---------------------------------------------------------------------------
+
+const STATIC_UNITS = ['each', 'case', 'box', 'pallet', 'pair', 'kg', 'lb', 'liter', 'gallon'];
+
+const DATA_SOURCES: Record<string, TypeaheadSource> = {
+  'Units (async fn)': lookupUnits,
+  'Roles (async fn)': lookupRoles,
+  'Static array': STATIC_UNITS,
+};
 
 // ---------------------------------------------------------------------------
 // Wrapper
@@ -39,7 +49,7 @@ function TypeaheadDemo({
 const meta: Meta = {
   title: 'Components/Canary/Molecules/TypeaheadInput',
   parameters: {
-    msw: { handlers: [unitLookupHandler] },
+    msw: { handlers: [unitLookupHandler, roleLookupHandler] },
   },
 };
 
@@ -56,6 +66,16 @@ export const Default: StoryObj = {
 export const AllowCreate: StoryObj = {
   render: () => (
     <TypeaheadDemo lookup={lookupUnits} allowCreate placeholder="Type or create unit..." />
+  ),
+};
+
+/** Static list — pass a plain `string[]` (or `TypeaheadOption[]`) instead of a lookup function. */
+export const StaticList: StoryObj = {
+  render: () => (
+    <TypeaheadDemo
+      lookup={['each', 'case', 'box', 'pallet', 'pair', 'kg', 'lb', 'liter', 'gallon']}
+      placeholder="Select unit..."
+    />
   ),
 };
 
@@ -90,49 +110,94 @@ export const CellEditorMode: StoryObj = {
   ),
 };
 
-/** Cell editor in an AG Grid — double-click the Unit column to edit. */
-export const InGrid: StoryObj = {
-  render: () => {
-    const UnitCellEditor = useMemo(
-      () =>
-        createTypeaheadCellEditor({
-          lookup: lookupUnits,
-          allowCreate: true,
-          placeholder: 'Search units...',
-        }),
-      [],
-    );
+// ---------------------------------------------------------------------------
+// Playground
+// ---------------------------------------------------------------------------
 
-    const [rowData] = useState([
-      { item: 'Hex Bolt M10x30', qty: 100, unit: 'each' },
-      { item: 'Flat Washer 3/8"', qty: 500, unit: 'box' },
-      { item: 'Spring Pin 4x20', qty: 50, unit: '' },
-    ]);
+interface PlaygroundArgs {
+  dataSource: string;
+  multiselect: boolean;
+  placeholder: string;
+  allowCreate: boolean;
+  defaultOne: boolean;
+  disabled: boolean;
+  cellEditorMode: boolean;
+  clearOnFocus: boolean;
+  maxResults: number;
+}
 
-    const columnDefs = useMemo<ColDef[]>(
-      () => [
-        { field: 'item', headerName: 'Item', flex: 2 },
-        { field: 'qty', headerName: 'Qty', width: 80 },
-        {
-          field: 'unit',
-          headerName: 'Unit',
-          flex: 1,
-          editable: true,
-          cellEditor: UnitCellEditor,
-        },
-      ],
-      [UnitCellEditor],
-    );
+function PlaygroundDemo(args: PlaygroundArgs) {
+  const source = DATA_SOURCES[args.dataSource] ?? lookupUnits;
+  const [single, setSingle] = useState('');
+  const [multi, setMulti] = useState<string[]>([]);
 
-    return (
-      <div className="p-8">
-        <p className="text-sm text-muted-foreground mb-4">
-          Double-click the <strong>Unit</strong> column to open the typeahead cell editor.
-        </p>
-        <div className="ag-theme-quartz w-[500px] h-[200px]">
-          <AgGridReact rowData={rowData} columnDefs={columnDefs} />
-        </div>
-      </div>
-    );
+  return (
+    <div className="w-80 p-8">
+      {args.multiselect ? (
+        <MultiSelectTypeaheadInput
+          value={multi}
+          onValueChange={setMulti}
+          lookup={source}
+          placeholder={args.placeholder}
+          defaultOne={args.defaultOne}
+          disabled={args.disabled}
+          cellEditorMode={args.cellEditorMode}
+          maxResults={args.maxResults}
+        />
+      ) : (
+        <TypeaheadInput
+          value={single}
+          onValueChange={setSingle}
+          lookup={source}
+          placeholder={args.placeholder}
+          allowCreate={args.allowCreate}
+          disabled={args.disabled}
+          cellEditorMode={args.cellEditorMode}
+          clearOnFocus={args.clearOnFocus}
+          maxResults={args.maxResults}
+        />
+      )}
+      <p className="mt-2 text-xs text-muted-foreground">
+        Value:{' '}
+        <code>
+          {args.multiselect
+            ? multi.length > 0
+              ? multi.join(', ')
+              : '(empty)'
+            : single || '(empty)'}
+        </code>
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Playground — toggle every prop via the controls panel. Pick a data source
+ * (two async lookups or a static array), switch between single and multiselect,
+ * and try `clearOnFocus`, `allowCreate`, `defaultOne`, `maxResults`, etc.
+ */
+export const Playground: StoryObj<PlaygroundArgs> = {
+  args: {
+    dataSource: 'Units (async fn)',
+    multiselect: false,
+    placeholder: 'Select…',
+    allowCreate: false,
+    defaultOne: true,
+    disabled: false,
+    cellEditorMode: false,
+    clearOnFocus: false,
+    maxResults: 8,
   },
+  argTypes: {
+    dataSource: { control: 'select', options: Object.keys(DATA_SOURCES) },
+    multiselect: { control: 'boolean', description: 'Render MultiSelectTypeaheadInput' },
+    placeholder: { control: 'text' },
+    allowCreate: { control: 'boolean', description: 'Single-select only' },
+    defaultOne: { control: 'boolean', description: 'Multiselect only' },
+    disabled: { control: 'boolean' },
+    cellEditorMode: { control: 'boolean' },
+    clearOnFocus: { control: 'boolean', description: 'Single-select only' },
+    maxResults: { control: { type: 'number', min: 1, max: 20, step: 1 } },
+  },
+  render: (args) => <PlaygroundDemo {...args} />,
 };

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.stories.tsx
@@ -91,24 +91,9 @@ export const Disabled: StoryObj = {
   ),
 };
 
-/** Cell editor mode — blur accepts typed value, dropdown portaled via Popover. */
-export const CellEditorMode: StoryObj = {
-  render: () => (
-    <div className="p-8">
-      <p className="text-sm text-muted-foreground mb-4">
-        Cell editor mode: blur accepts typed value instead of reverting. Dropdown is portaled.
-      </p>
-      <div className="w-64 overflow-hidden border border-border rounded-md p-2">
-        <TypeaheadDemo
-          lookup={lookupUnits}
-          allowCreate
-          cellEditorMode
-          placeholder="Search units (cell editor)..."
-        />
-      </div>
-    </div>
-  ),
-};
+// Cell-editor behavior is demonstrated end-to-end by the `InGrid` story shipped
+// with the DataGrid molecule — no standalone `CellEditorMode` story is needed
+// here.
 
 // ---------------------------------------------------------------------------
 // Playground

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.test.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.test.tsx
@@ -1,0 +1,333 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { useState } from 'react';
+import { TypeaheadInput, type TypeaheadOption, type TypeaheadSource } from './typeahead-input';
+
+// jsdom doesn't implement scrollIntoView, which the dropdown calls on highlight.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const FRUITS = ['Apple', 'Apricot', 'Banana', 'Cherry', 'Date', 'Elderberry'];
+
+function asyncFruitLookup(search: string): Promise<TypeaheadOption[]> {
+  const q = search.trim().toLowerCase();
+  const matches = q ? FRUITS.filter((f) => f.toLowerCase().includes(q)) : FRUITS;
+  return Promise.resolve(matches.map((f) => ({ label: f, value: f })));
+}
+
+interface HarnessProps {
+  initialValue?: string;
+  lookup?: TypeaheadSource;
+  onValueChange?: (v: string) => void;
+  allowCreate?: boolean;
+  disabled?: boolean;
+  clearOnFocus?: boolean;
+  maxResults?: number;
+  cellEditorMode?: boolean;
+}
+
+function Harness({
+  initialValue = '',
+  lookup = asyncFruitLookup,
+  onValueChange,
+  ...rest
+}: HarnessProps) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <TypeaheadInput
+      value={value}
+      onValueChange={(v) => {
+        setValue(v);
+        onValueChange?.(v);
+      }}
+      lookup={lookup}
+      placeholder="Select fruit"
+      {...rest}
+    />
+  );
+}
+
+describe('TypeaheadInput', () => {
+  it('shows results when the input is focused', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    expect(await screen.findByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+  });
+
+  it('auto-highlights the first result', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    const first = await screen.findByText('Apple');
+    expect(first.closest('[role="option"]')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('commits the highlighted result on Enter', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByText('Apple');
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith('Apple');
+  });
+
+  it('selects an option on click', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('Cherry'));
+    expect(onValueChange).toHaveBeenCalledWith('Cherry');
+  });
+
+  it('filters results as the user types', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    await user.type(screen.getByRole('combobox'), 'ap');
+    // "Apple" and "Apricot" match "ap"; "Banana" does not
+    expect(await screen.findByText('Apricot')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('Banana')).not.toBeInTheDocument());
+  });
+
+  it('accepts a static string[] as the lookup source', async () => {
+    const user = userEvent.setup();
+    render(<Harness lookup={['Red', 'Green', 'Blue']} />);
+    await user.click(screen.getByRole('combobox'));
+    expect(await screen.findByText('Green')).toBeInTheDocument();
+  });
+
+  it('caps the number of results at maxResults', async () => {
+    const user = userEvent.setup();
+    render(<Harness maxResults={2} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByText('Apple');
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('shows a create row and creates a value when allowCreate is set', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness allowCreate onValueChange={onValueChange} />);
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'Mango');
+    // Wait for the debounced search to settle (no fruit matches "Mango"),
+    // leaving only the create row.
+    await waitFor(() => expect(screen.queryByText('Apple')).not.toBeInTheDocument());
+    expect(screen.getByText('Mango')).toBeInTheDocument();
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith('Mango');
+  });
+
+  it('is disabled when disabled is set', () => {
+    render(<Harness disabled />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('navigates results with ArrowDown and selects on Enter', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByText('Apple');
+    await user.keyboard('{ArrowDown}'); // move from Apple (0) to Apricot (1)
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith('Apricot');
+  });
+
+  it('closes the dropdown on Escape', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+  });
+
+  it('reopens the dropdown when the focused input is clicked again', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await screen.findByRole('listbox');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await user.click(input);
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('shows an error row and a retry control when the lookup rejects', async () => {
+    const user = userEvent.setup();
+    const failing = () => Promise.reject(new Error('boom'));
+    render(<Harness lookup={failing} />);
+    await user.click(screen.getByRole('combobox'));
+    // The retry text is unique to the error row (the live region only says
+    // "Failed to load results").
+    expect(await screen.findByText(/Click to retry/i)).toBeInTheDocument();
+  });
+
+  it('shows a loading indicator while the lookup is pending', async () => {
+    const user = userEvent.setup();
+    const pending = () => new Promise<TypeaheadOption[]>(() => {});
+    render(<Harness lookup={pending} />);
+    await user.click(screen.getByRole('combobox'));
+    // "Searching" appears in both the live region and the indicator row.
+    await waitFor(() => expect(screen.getAllByText(/Searching/i).length).toBeGreaterThan(0));
+  });
+
+  it('navigates upward with ArrowUp', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByText('Apple');
+    // From Apple (0), ArrowUp wraps to the last option (Elderberry)
+    await user.keyboard('{ArrowUp}');
+    await user.keyboard('{Enter}');
+    expect(onValueChange).toHaveBeenCalledWith('Elderberry');
+  });
+
+  it('commits the highlighted option on Tab', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByText('Apple');
+    await user.keyboard('{Tab}');
+    expect(onValueChange).toHaveBeenCalledWith('Apple');
+  });
+
+  it('reopens with ArrowDown after the dropdown was closed', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('listbox');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await user.keyboard('{ArrowDown}');
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('accepts a static TypeaheadOption[] as the lookup source', async () => {
+    const user = userEvent.setup();
+    const options: TypeaheadOption[] = [
+      { label: 'United States', value: 'US' },
+      { label: 'Canada', value: 'CA' },
+    ];
+    const onValueChange = vi.fn();
+    render(<Harness lookup={options} onValueChange={onValueChange} />);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('Canada'));
+    // The option's value (not label) is committed
+    expect(onValueChange).toHaveBeenCalledWith('CA');
+  });
+
+  it('retries the lookup when the error row is clicked', async () => {
+    const user = userEvent.setup();
+    const lookup = vi.fn(() => Promise.reject(new Error('boom')));
+    render(<Harness lookup={lookup} />);
+    await user.click(screen.getByRole('combobox'));
+    const retry = await screen.findByText(/Click to retry/i);
+    const callsBefore = lookup.mock.calls.length;
+    await user.click(retry);
+    await waitFor(() => expect(lookup.mock.calls.length).toBeGreaterThan(callsBefore));
+  });
+
+  it('creates a value when the create row is clicked', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Harness allowCreate onValueChange={onValueChange} />);
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'Guava');
+    const createRow = await screen.findByText('Guava');
+    await user.click(createRow);
+    expect(onValueChange).toHaveBeenCalledWith('Guava');
+  });
+
+  it('reverts to the confirmed value on blur in form mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Harness initialValue="Apple" />
+        <button type="button">outside</button>
+      </>,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'xyz');
+    await user.click(screen.getByText('outside'));
+    expect(input.value).toBe('Apple');
+  });
+
+  it('accepts the typed value on blur in cell editor mode', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <>
+        <Harness cellEditorMode onValueChange={onValueChange} />
+        <button type="button">outside</button>
+      </>,
+    );
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'Kiwi');
+    await user.click(screen.getByText('outside'));
+    expect(onValueChange).toHaveBeenCalledWith('Kiwi');
+  });
+
+  describe('clearOnFocus', () => {
+    it('clears the input on focus to show the full list', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue="Apple" clearOnFocus />);
+      const input = screen.getByRole('combobox') as HTMLInputElement;
+      expect(input.value).toBe('Apple');
+      await user.click(input);
+      await waitFor(() => expect(input.value).toBe(''));
+      // Full list visible, including options other than the prior value
+      expect(await screen.findByText('Banana')).toBeInTheDocument();
+    });
+
+    it('restores the original value on blur (outside click)', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Harness initialValue="Apple" clearOnFocus />
+          <button type="button">outside</button>
+        </>,
+      );
+      const input = screen.getByRole('combobox') as HTMLInputElement;
+      await user.click(input);
+      await waitFor(() => expect(input.value).toBe(''));
+      await user.click(screen.getByText('outside'));
+      expect(input.value).toBe('Apple');
+    });
+
+    it('restores the original value on Escape', async () => {
+      const user = userEvent.setup();
+      render(<Harness initialValue="Apple" clearOnFocus />);
+      const input = screen.getByRole('combobox') as HTMLInputElement;
+      await user.click(input);
+      await waitFor(() => expect(input.value).toBe(''));
+      await user.keyboard('{Escape}');
+      expect(input.value).toBe('Apple');
+    });
+
+    it('clears the value when Delete is pressed on an empty input', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(<Harness initialValue="Apple" clearOnFocus onValueChange={onValueChange} />);
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await waitFor(() => expect((input as HTMLInputElement).value).toBe(''));
+      await user.keyboard('{Delete}');
+      expect(onValueChange).toHaveBeenCalledWith('');
+    });
+  });
+});

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -200,16 +200,31 @@ export function TypeaheadInput({
     [doSearch],
   );
 
-  // Cleanup on unmount. Note: we intentionally do NOT abort the in-flight
-  // lookup here. Under React StrictMode the mount effect is double-invoked
-  // (mount → cleanup → mount) on the same DOM; aborting would cancel the
-  // dropdown's initial search while the re-run focus() is a no-op (the input
-  // is already focused), leaving `loading` stuck. Search-racing is already
-  // handled by the abort inside doSearch; stale setState after a real unmount
-  // is a safe no-op in React 18+.
+  // Cleanup on unmount: abort any in-flight lookup so we don't waste server
+  // work or land stale responses on a remount of a similar component.
+  //
+  // React StrictMode complicates this: in dev the mount effect is double-
+  // invoked (mount → cleanup → mount) synchronously on the same DOM. Aborting
+  // in that synthetic cleanup would cancel the dropdown's initial search and
+  // leave `loading` stuck (the remount's focus() is a no-op since the input
+  // is already focused).
+  //
+  // The fix defers the abort one event-loop tick. StrictMode's remount runs
+  // synchronously, so the next effect call cancels the queued abort before it
+  // fires. A real unmount has no follow-up effect, so the abort proceeds.
+  const pendingAbortRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   React.useEffect(() => {
+    // Remount: cancel any abort queued by a previous synthetic cleanup.
+    if (pendingAbortRef.current) {
+      clearTimeout(pendingAbortRef.current);
+      pendingAbortRef.current = null;
+    }
     return () => {
       clearTimeout(debounceRef.current);
+      pendingAbortRef.current = setTimeout(() => {
+        abortRef.current?.abort();
+        pendingAbortRef.current = null;
+      }, 0);
     };
   }, []);
 

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -12,13 +12,39 @@ export interface TypeaheadOption {
   value: string;
 }
 
+/**
+ * Source of typeahead options. Either:
+ * - an async function that receives the search text and returns matches, or
+ * - a static list (of `TypeaheadOption`s or plain strings) that is filtered
+ *   client-side by label.
+ */
+export type TypeaheadSource =
+  | ((search: string) => Promise<TypeaheadOption[]>)
+  | TypeaheadOption[]
+  | string[];
+
+/** Normalize a TypeaheadSource into an async lookup function. */
+function normalizeLookup(source: TypeaheadSource): (search: string) => Promise<TypeaheadOption[]> {
+  if (typeof source === 'function') return source;
+  const options: TypeaheadOption[] = source.map((o) =>
+    typeof o === 'string' ? { label: o, value: o } : o,
+  );
+  return async (search: string) => {
+    const q = search.trim().toLowerCase();
+    return q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options;
+  };
+}
+
 export interface TypeaheadInputProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
   /** Current value. */
   value: string;
   /** Called when the user selects or creates a value. */
   onValueChange: (value: string) => void;
-  /** Async lookup function — receives search text, returns matching options. */
-  lookup: (search: string) => Promise<TypeaheadOption[]>;
+  /**
+   * Options source — an async lookup function, or a static list of options
+   * (`TypeaheadOption[]` or `string[]`) filtered client-side by label.
+   */
+  lookup: TypeaheadSource;
   /** Allow creating new values not in the lookup results. */
   allowCreate?: boolean;
   /** Input placeholder text. */
@@ -33,9 +59,30 @@ export interface TypeaheadInputProps extends Omit<React.ComponentProps<'div'>, '
    * is portaled via Radix Popover to escape overflow clipping.
    */
   cellEditorMode?: boolean;
+  /** Maximum number of dropdown results to show. Defaults to 8. */
+  maxResults?: number;
+  /**
+   * When true, clears the input on focus to show an unfiltered list of results.
+   * The original value is restored if the user exits without picking (Escape or
+   * blur). Pressing Delete/Backspace while the input is empty clears the value
+   * (calls `onValueChange('')`) and blurs.
+   */
+  clearOnFocus?: boolean;
+  /**
+   * Called when the user commits a value (selecting an option, creating one, or
+   * Tab). In a cell editor this signals "stop editing".
+   */
+  onCommit?: () => void;
+  /**
+   * Cell geometry for `cellEditorMode` (popup). The editor matches the cell's
+   * pixel width and uses the row height as its minimum, so the popup aligns with
+   * the cell. See `useCellEditorGeometry`.
+   */
+  cellWidth?: number;
+  cellMinHeight?: number;
 }
 
-const MAX_RESULTS = 8;
+const DEFAULT_MAX_RESULTS = 8;
 const DEBOUNCE_MS = 250;
 // LISTBOX_ID generated per instance via useId() — see component body
 
@@ -66,9 +113,18 @@ export function TypeaheadInput({
   'aria-label': ariaLabel,
   disabled = false,
   cellEditorMode = false,
+  maxResults = DEFAULT_MAX_RESULTS,
+  clearOnFocus = false,
+  onCommit,
+  cellWidth,
+  cellMinHeight,
   className,
   ...rest
 }: TypeaheadInputProps) {
+  // Normalize the lookup source (function | options[] | string[]) into a
+  // single async lookup function.
+  const lookupFn = React.useMemo(() => normalizeLookup(lookup), [lookup]);
+
   const [inputValue, setInputValue] = React.useState(value);
   const [options, setOptions] = React.useState<TypeaheadOption[]>([]);
   const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
@@ -101,6 +157,14 @@ export function TypeaheadInput({
     setInputValue(value);
   }, [value]);
 
+  // Auto-focus on mount in cell editor mode so the editor is ready immediately
+  // (opens the dropdown; with clearOnFocus, clears to show the full list).
+  React.useEffect(() => {
+    if (cellEditorMode) {
+      inputRef.current?.focus();
+    }
+  }, [cellEditorMode]);
+
   // --- Search ---
   const doSearch = React.useCallback(
     async (search: string) => {
@@ -112,10 +176,11 @@ export function TypeaheadInput({
       setError(false);
 
       try {
-        const results = await lookup(search);
+        const results = await lookupFn(search);
         if (controller.signal.aborted) return;
-        setOptions(results.slice(0, MAX_RESULTS));
-        setHighlightedIndex(-1);
+        const sliced = results.slice(0, maxResults);
+        setOptions(sliced);
+        setHighlightedIndex(sliced.length > 0 ? 0 : -1);
         setLoading(false);
       } catch {
         if (controller.signal.aborted) return;
@@ -124,7 +189,7 @@ export function TypeaheadInput({
         setOptions([]);
       }
     },
-    [lookup],
+    [lookupFn, maxResults],
   );
 
   const debouncedSearch = React.useCallback(
@@ -135,11 +200,16 @@ export function TypeaheadInput({
     [doSearch],
   );
 
-  // Cleanup on unmount
+  // Cleanup on unmount. Note: we intentionally do NOT abort the in-flight
+  // lookup here. Under React StrictMode the mount effect is double-invoked
+  // (mount → cleanup → mount) on the same DOM; aborting would cancel the
+  // dropdown's initial search while the re-run focus() is a no-op (the input
+  // is already focused), leaving `loading` stuck. Search-racing is already
+  // handled by the abort inside doSearch; stale setState after a real unmount
+  // is a safe no-op in React 18+.
   React.useEffect(() => {
     return () => {
       clearTimeout(debounceRef.current);
-      abortRef.current?.abort();
     };
   }, []);
 
@@ -150,8 +220,9 @@ export function TypeaheadInput({
       onValueChange(opt.value);
       setOpen(false);
       setOptions([]);
+      onCommit?.();
     },
-    [onValueChange],
+    [onValueChange, onCommit],
   );
 
   const createValue = React.useCallback(
@@ -162,8 +233,9 @@ export function TypeaheadInput({
       onValueChange(trimmed);
       setOpen(false);
       setOptions([]);
+      onCommit?.();
     },
-    [onValueChange],
+    [onValueChange, onCommit],
   );
 
   // --- Derived state ---
@@ -184,8 +256,23 @@ export function TypeaheadInput({
 
   const handleFocus = React.useCallback(() => {
     setOpen(true);
-    doSearch(inputValueRef.current);
-  }, [doSearch]);
+    if (clearOnFocus) {
+      setInputValue('');
+      doSearch('');
+    } else {
+      doSearch(inputValueRef.current);
+    }
+  }, [doSearch, clearOnFocus]);
+
+  // Clicking the input reopens the dropdown when it's already focused (focus
+  // alone won't re-fire, e.g. after selecting an option closed it).
+  const handleInputClick = React.useCallback(() => {
+    if (!open) {
+      setOpen(true);
+      doSearch(clearOnFocus ? '' : inputValueRef.current);
+      if (clearOnFocus) setInputValue('');
+    }
+  }, [open, doSearch, clearOnFocus]);
 
   // Close on outside click — deps narrowed to [open, cellEditorMode] via refs
   React.useEffect(() => {
@@ -199,7 +286,10 @@ export function TypeaheadInput({
         !popoverRef.current?.contains(target)
       ) {
         setOpen(false);
-        if (cellEditorMode) {
+        if (clearOnFocus) {
+          // clearOnFocus: blur without selecting → restore the original value
+          setInputValue(valueRef.current);
+        } else if (cellEditorMode) {
           // Cell editor: accept typed value on blur
           const trimmed = inputValueRef.current.trim();
           if (trimmed && trimmed !== valueRef.current) {
@@ -215,11 +305,26 @@ export function TypeaheadInput({
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open, cellEditorMode, onValueChange]);
+  }, [open, cellEditorMode, clearOnFocus, onValueChange]);
 
   // --- Keyboard — uses refs for stable callback ---
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
+      // clearOnFocus: Delete/Backspace with empty input clears the value and blurs
+      if (
+        clearOnFocus &&
+        (e.key === 'Delete' || e.key === 'Backspace') &&
+        inputValueRef.current === ''
+      ) {
+        e.preventDefault();
+        if (valueRef.current !== '') {
+          onValueChange('');
+        }
+        setOpen(false);
+        inputRef.current?.blur();
+        return;
+      }
+
       if (!open) {
         if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
           e.preventDefault();
@@ -264,18 +369,33 @@ export function TypeaheadInput({
           setInputValue(valueRef.current);
           break;
         case 'Tab':
+          // In a grid, let AG Grid handle Tab (commit + move to the next
+          // editable cell). Just close the dropdown; do NOT preventDefault or
+          // stopEditing ourselves, or focus escapes to the next row.
+          if (cellEditorMode) {
+            setOpen(false);
+            break;
+          }
           if (hi >= 0 && hi < opts.length) {
             selectOption(opts[hi] as TypeaheadOption);
           } else if (inputValueRef.current.trim() && allowCreate) {
             createValue(inputValueRef.current.trim());
-          } else if (cellEditorMode && inputValueRef.current.trim()) {
-            onValueChange(inputValueRef.current.trim());
           }
           setOpen(false);
           break;
       }
     },
-    [open, allowCreate, cellEditorMode, doSearch, selectOption, createValue, onValueChange],
+    [
+      open,
+      allowCreate,
+      cellEditorMode,
+      clearOnFocus,
+      doSearch,
+      selectOption,
+      createValue,
+      onValueChange,
+      onCommit,
+    ],
   );
 
   // Scroll highlighted item into view
@@ -323,10 +443,13 @@ export function TypeaheadInput({
             role="option"
             aria-selected={i === highlightedIndex}
             className={cn(
-              'px-3 py-2 text-sm cursor-pointer',
-              i === highlightedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',
+              'cursor-pointer rounded-sm px-2 py-1.5 text-sm',
+              i === highlightedIndex && 'bg-accent text-accent-foreground',
             )}
-            onMouseDown={(e) => {
+            // Use pointerdown so the option-select fires consistently on touch
+            // (mouse-down events are sometimes swallowed on iOS, letting the
+            // document-level outside-click handler close the dropdown first).
+            onPointerDown={(e) => {
               e.preventDefault();
               selectOption(opt);
             }}
@@ -342,10 +465,10 @@ export function TypeaheadInput({
           role="option"
           aria-selected={highlightedIndex === options.length}
           className={cn(
-            'flex items-center gap-2 px-3 py-2 text-sm cursor-pointer text-primary',
-            highlightedIndex === options.length ? 'bg-accent text-primary' : 'hover:bg-accent/50',
+            'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-primary',
+            highlightedIndex === options.length && 'bg-accent text-primary',
           )}
-          onMouseDown={(e) => {
+          onPointerDown={(e) => {
             e.preventDefault();
             createValue(trimmedInput);
           }}
@@ -367,9 +490,15 @@ export function TypeaheadInput({
       value={inputValue}
       onChange={handleInputChange}
       onFocus={handleFocus}
+      onClick={handleInputClick}
       onKeyDownCapture={handleKeyDown}
       placeholder={placeholder}
       disabled={disabled}
+      // iOS Safari blocks programmatic focus() outside a fresh user-gesture
+      // frame, which the useEffect-on-mount focus call usually misses. The
+      // autoFocus attribute is applied during the first render and is honored
+      // as user-driven, so the keyboard reliably comes up.
+      autoFocus={cellEditorMode}
       role="combobox"
       aria-expanded={showDropdown}
       aria-haspopup="listbox"
@@ -378,17 +507,23 @@ export function TypeaheadInput({
       aria-label={ariaLabel ?? placeholder}
       autoComplete="off"
       className={
+        // Popup editor (floats over the cell): keep the normal input chrome —
+        // rounded border + focus ring — since AG Grid does not draw a cell edit
+        // border around a popup. Make the background opaque, drop the input's own
+        // shadow (the popup provides one), apply the min-width, and use a thin
+        // (1px) full-opacity accent ring (`ring-1 ring-ring`) — 3px reads too bold.
         cellEditorMode
-          ? 'border-0 shadow-none bg-transparent focus-visible:ring-0 focus-visible:border-transparent h-full'
+          ? 'min-w-60 bg-background shadow-none focus-visible:ring-2 focus-visible:ring-ring'
           : undefined
       }
+      style={cellEditorMode ? { width: cellWidth, minHeight: cellMinHeight } : undefined}
     />
   );
 
   return (
     <div
       ref={wrapperRef}
-      className={cn('relative', className)}
+      className={cn('relative', cellEditorMode && 'w-fit', className)}
       data-slot="typeahead-input"
       data-state={open ? 'open' : 'closed'}
       data-loading={loading || undefined}
@@ -407,7 +542,7 @@ export function TypeaheadInput({
           ref={popoverRef}
           align="start"
           sideOffset={4}
-          className="w-(--radix-popover-trigger-width) p-0 max-h-52 overflow-auto"
+          className="w-(--radix-popover-trigger-width) p-1 max-h-52 overflow-auto"
           onOpenAutoFocus={(e) => e.preventDefault()}
           onCloseAutoFocus={(e) => e.preventDefault()}
         >

--- a/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
+++ b/src/components/canary/molecules/typeahead-input/typeahead-input.tsx
@@ -373,7 +373,24 @@ export function TypeaheadInput({
           // editable cell). Just close the dropdown; do NOT preventDefault or
           // stopEditing ourselves, or focus escapes to the next row.
           if (cellEditorMode) {
+            // Push current intent (selection or typed value) BEFORE AG Grid
+            // reads getValue() — without this AG Grid commits the prior value
+            // because onValueChange only fires on select/create/blur, and the
+            // input box's typing-state never reaches the cell. Do NOT call
+            // onCommit/stopEditing here; AG Grid drives the focus move.
+            let nextValue: string | null = null;
+            if (hi >= 0 && hi < opts.length) {
+              nextValue = (opts[hi] as TypeaheadOption).value;
+            } else {
+              const trimmed = inputValueRef.current.trim();
+              if (trimmed) nextValue = trimmed;
+            }
+            if (nextValue !== null && nextValue !== valueRef.current) {
+              setInputValue(nextValue);
+              onValueChange(nextValue);
+            }
             setOpen(false);
+            setOptions([]);
             break;
           }
           if (hi >= 0 && hi < opts.length) {

--- a/src/components/canary/molecules/typeahead-input/use-cell-editor-geometry.ts
+++ b/src/components/canary/molecules/typeahead-input/use-cell-editor-geometry.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import type { Column, IRowNode } from 'ag-grid-community';
+
+/**
+ * Default minimum width (px) for a popup cell editor. On narrow columns the
+ * editor extends past the cell edge rather than squeezing its content; AG Grid
+ * keeps the popup within the grid bounds.
+ */
+export const DEFAULT_CELL_EDITOR_MIN_WIDTH = 240;
+
+export interface CellEditorGeometry {
+  /** The editing cell's pixel width — the popup matches it so it looks attached. */
+  cellWidth: number;
+  /** The row height — the popup's minimum height, so a single line aligns with
+   * the cell and taller content grows downward. Omitted if AG Grid has no row height. */
+  cellMinHeight?: number;
+}
+
+/**
+ * Reads the editing cell's geometry from AG Grid for a popup cell editor.
+ *
+ * A popup editor (`cellEditorPopup: true`) is not constrained to the cell, so to
+ * look attached it should match the cell's width and use the row height as its
+ * minimum. Shared by every popup cell editor (tokens, single-select, and future
+ * notes/etc.) so they stay consistent. Pair with the `min-w-60` floor in the
+ * input's `cellEditorMode` styling for narrow columns.
+ */
+export function useCellEditorGeometry(column: Column, node: IRowNode): CellEditorGeometry {
+  return React.useMemo(() => {
+    const cellWidth = column.getActualWidth();
+    const cellMinHeight = node.rowHeight ?? undefined;
+    return cellMinHeight !== undefined ? { cellWidth, cellMinHeight } : { cellWidth };
+  }, [column, node]);
+}


### PR DESCRIPTION
## Summary

**PR A of the #117 split.** Lands the typeahead/atom foundation independently so PR B (DataGrid + ConnectedDataGrid + write-path) reviews against a small, focused diff. The integration branch in #117 stays alive as the npm `nail60-vendorgrid` dist-tag source so downstream consumers (`arda-frontend-app`'s vendors page) keep working through the split.

## Highlights

- **`Checkbox` canary atom** — Arda-styled wrapper around the canary primitive (Figma node `46:112`) with `shadow-sm`, optional `label` + `description` + `required` layout, and `[&_svg]:size-4` so the Lucide checkmark fills the 16px box. Exported from `canary.ts` as `Checkbox` / `CheckboxProps`.
- **`TypeaheadInput` and `MultiSelectTypeaheadInput` molecules** — debounced async lookup, allowCreate, keyboard navigation (arrow keys, Enter, Escape, Home/End, Tab), `defaultOne`, expand-on-edit, `maxResults`, `clearOnFocus`, array lookup, click-to-open.
- **`createTypeaheadCellEditor` / `createMultiSelectCellEditor`** — AG Grid popup cell-editor factories backed by a shared `useCellEditorGeometry` hook.
- **`TokenList` molecule** — pill renderer for tagged values; consumed by PR B's token cell-data-type.
- **Mobile-correct pointer events** — both inputs use `onPointerDown` (vs `onMouseDown`) for option-select; multiselect's token-click handler too. On iOS, the synthesized mousedown raced the document outside-click handler and let the dropdown close before option-select fired. PointerEvents normalize mouse + touch and fire before that race.
- **Mobile keyboard on cell-editor open** — `TypeaheadInput` sets `autoFocus` while in `cellEditorMode` so iOS Safari reliably brings up the keyboard.
- **`Badge.onDismiss`** — accessible close affordance for dismissible badges.
- `./css` package export for the `design-system.css` bundle.

## What stayed in PR B (#117 split — second half)

- DataGrid molecule rewrite (themeQuartz Theming API, rich cell data types, spreadsheet capabilities, mobile tap-to-edit)
- ConnectedDataGrid organism + draft/commit/auto-publish hooks
- Combined column (Address)
- Add-row / row-actions / row-state row classes
- Selection column wiring (uses the Checkbox from this PR)
- Styling tweaks (white rows, double-thick header bottom border, squared corners, outer wrapper border)
- `ag-grid-enterprise` dependency

## Story changes

The `InGrid` demo stories on `TypeaheadInput` and `MultiSelectTypeaheadInput` were removed from this PR — they depend on DataGrid props (`editable`) introduced in PR B. They'll be reintroduced in PR B alongside the DataGrid rewrite, where they make sense as integration tests of cell-editor + grid.

## Testing

- `make typecheck` ✅
- `make lint` ✅ (zero warnings)
- `make test` ✅ — **111 test files / 1,399 tests** pass
- `make build` ✅ (Storybook static)
- VRT not run locally; deferred to CI

## CHANGELOG

`CHANGELOG.md` updated with a new **5.4.0** entry (minor bump — net-new `Added` items per `changemap.json`).

> [!note]
> Authored by Claude Code for nail60