### PR TITLE
fix(canary): restore native Ctrl-Z on ConnectedDataGrid auto-publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [6.0.1] - 2026-06-15
+
+### Fixed
+- **Native cell-edit Ctrl-Z now survives auto-publish on `ConnectedDataGrid`.** The per-row publish lifecycle in `useRowAutoPublish` previously called `api.redrawRows({ rowNodes: [node] })` to flip `'ag-row-saving'` / `'ag-row-error'` classes; redrawRows tears down the row's DOM and AG Grid's per-row cell-edit state, which silently dropped the native Ctrl-Z undo stack for any row that auto-published. The hook now updates the row class via direct DOM mutation; `getRowClass` remains the source of truth for AG Grid's own re-renders (scroll virtualization, sort, filter), so a row that scrolls out of view and back in still picks up the right class on rebuild. **Known limitation:** multi-Ctrl-Z while a publish is in flight can still silently lose intermediate undos because the publish queue drops concurrent requests and a successful publish wipes pending changes — tracked separately and intentionally out of scope for this patch.
+
 ## [6.0.0] - 2026-06-12
 
 ### Added

--- a/src/components/canary/organisms/shared/entity-data-grid/use-row-auto-publish.test.ts
+++ b/src/components/canary/organisms/shared/entity-data-grid/use-row-auto-publish.test.ts
@@ -349,6 +349,79 @@ describe('useRowAutoPublish', () => {
     expect(cls).toBeUndefined();
   });
 
+  it('row state updates via direct DOM class mutation, not redrawRows', async () => {
+    // Regression: previously `setRowState` called `api.redrawRows({ rowNodes: [node] })`
+    // to flip the row class, but redrawRows destroys and recreates the row's DOM and
+    // tears down AG Grid's per-row cell-edit state — which silently drops the
+    // native Ctrl-Z undo stack for the edited row.
+    //
+    // This test pins the contract: while a publish is in flight, the row's
+    // class is updated *directly on the DOM element* and `redrawRows` is NOT
+    // called. AG Grid's `getRowClass` callback continues to return the right
+    // class as a backstop for AG Grid's own re-renders (scroll virtualization,
+    // sort, filter).
+    let resolveFn: () => void;
+    const publishPromise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    const onRowPublish = vi.fn().mockReturnValue(publishPromise);
+
+    // Mount a row element matching the selector used by `findRowElement`.
+    const rowEl = document.createElement('div');
+    rowEl.className = 'ag-row';
+    rowEl.setAttribute('row-id', '1');
+    document.body.appendChild(rowEl);
+
+    const redrawRows = vi.fn();
+    const api = {
+      getRowNode: (id: string) => (id === '1' ? { rowIndex: 0 } : null),
+      getEditingCells: () => [],
+      redrawRows,
+    };
+
+    const { result } = renderHook(() =>
+      useRowAutoPublish<TestEntity>({
+        getEntityId,
+        onRowPublish,
+        getApi: () => api as any,
+      }),
+    );
+
+    const entity: TestEntity = { id: '1', name: 'Updated' };
+
+    act(() => {
+      result.current.handleCellValueChanged(
+        makeCellValueChangedEvent(entity, 'name', 'Updated') as any,
+      );
+    });
+    act(() => {
+      result.current.handleCellEditingStopped(makeCellEditingStoppedEvent(entity, 0) as any);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+      await Promise.resolve();
+    });
+
+    // While publishing: DOM has 'ag-row-saving' AND redrawRows was never called.
+    expect(rowEl.classList.contains('ag-row-saving')).toBe(true);
+    expect(redrawRows).not.toHaveBeenCalled();
+    // And getRowClass still returns the same string as a backstop.
+    expect(result.current.getRowClass({ data: entity } as any)).toBe('ag-row-saving');
+
+    await act(async () => {
+      resolveFn!();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // After publish success: class is off the DOM AND redrawRows was still never called.
+    expect(rowEl.classList.contains('ag-row-saving')).toBe(false);
+    expect(rowEl.classList.contains('ag-row-error')).toBe(false);
+    expect(redrawRows).not.toHaveBeenCalled();
+
+    document.body.removeChild(rowEl);
+  });
+
   // -------------------------------------------------------------------------
   // Imperative handle: saveAll, discardAll, getDirtyRowIds
   // -------------------------------------------------------------------------

--- a/src/components/canary/organisms/shared/entity-data-grid/use-row-auto-publish.ts
+++ b/src/components/canary/organisms/shared/entity-data-grid/use-row-auto-publish.ts
@@ -77,6 +77,33 @@ export interface UseRowAutoPublishOptions<T> {
 }
 
 // ============================================================================
+// DOM helpers
+// ============================================================================
+
+/**
+ * Find a row's DOM element by its grid row id.
+ *
+ * AG Grid renders each row with a `row-id="<entity-id>"` attribute; we use
+ * that as a stable selector to update the row's class without going through
+ * `api.redrawRows`, which would destroy the per-row cell-edit state and
+ * silently drop the native Ctrl-Z undo stack for the row.
+ *
+ * Returns `null` when not in a DOM environment (SSR / Vitest jsdom edge
+ * cases) or when no row with that id is currently rendered (e.g. it was
+ * virtualized out of view — that's fine, `getRowClass` will paint the
+ * right class when AG Grid rebuilds the row on scroll-in).
+ */
+function findRowElement(rowId: string): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  // `.ag-row[row-id="..."]` scopes us to AG Grid-rendered rows. Row IDs are
+  // entity identifiers (UUIDs / DB ids) and are unique across the document
+  // in the consumer apps that use ConnectedDataGrid; if two grids on the
+  // same page ever share a row id, this will need an explicit grid-root
+  // scope, but no consumer has that shape today.
+  return document.querySelector<HTMLElement>(`.ag-row[row-id="${CSS.escape(rowId)}"]`);
+}
+
+// ============================================================================
 // Hook
 // ============================================================================
 
@@ -183,17 +210,33 @@ export function useRowAutoPublish<T extends Record<string, any>>({
       if (prev[rowId] === state) return prev;
       return { ...prev, [rowId]: state };
     });
-    // 3. Ask AG Grid to re-evaluate getRowClass for just this row. Without
-    //    this, the previous class (e.g. 'ag-row-saving') stays on the DOM
-    //    forever even after the state map shows 'idle'. Skip while the row is
-    //    being edited so we don't cancel the user's typing.
+    // 3. Update the row's class on the DOM without destroying AG Grid's row
+    //    state. We previously called `api.redrawRows({ rowNodes: [node] })`
+    //    so AG Grid would re-evaluate `getRowClass`, but redrawRows tears
+    //    down and recreates the row's DOM and its associated cell-edit
+    //    state — which silently drops AG Grid's native Ctrl-Z undo stack
+    //    for that row. The cheapest way to update the class without that
+    //    side effect is to mutate the row element's classList directly;
+    //    `getRowClass` remains the source of truth for AG Grid's own
+    //    re-renders (e.g. scroll virtualization, sort, filter), so a row
+    //    that scrolls out of view and back in still picks up the right
+    //    class on rebuild.
+    //
+    //    Skip the mutation while the row has a cell in edit mode — the
+    //    class flip itself is harmless, but the original implementation
+    //    skipped here to avoid AG Grid edit-state churn and we keep the
+    //    same guard for parity.
     const api = getApiRef.current?.();
     if (!api) return;
     const node = api.getRowNode(rowId);
     if (!node) return;
     const rowIsEditing = api.getEditingCells().some((cell) => cell.rowIndex === node.rowIndex);
     if (rowIsEditing) return;
-    api.redrawRows({ rowNodes: [node] });
+    const rowEl = findRowElement(rowId);
+    if (rowEl) {
+      rowEl.classList.toggle('ag-row-saving', state === 'saving');
+      rowEl.classList.toggle('ag-row-error', state === 'error');
+    }
   }, []);
 
   const notifyDirty = useCallback(() => {
@@ -398,14 +441,16 @@ export function useRowAutoPublish<T extends Record<string, any>>({
         rowStateMapRef.current.clear();
         setRowStates({});
         notifyDirty();
-        // Redraw rows that had a non-idle state so 'ag-row-saving' /
-        // 'ag-row-error' classes actually come off.
-        const api = getApiRef.current?.();
-        if (api && idsToRedraw.length > 0) {
-          const nodes = idsToRedraw
-            .map((id) => api.getRowNode(id))
-            .filter((n): n is NonNullable<typeof n> => n !== null && n !== undefined);
-          if (nodes.length > 0) api.redrawRows({ rowNodes: nodes });
+        // Strip 'ag-row-saving' / 'ag-row-error' classes from the rows that
+        // had a non-idle state. Direct DOM mutation here for the same reason
+        // as in setRowState — `redrawRows` would tear down per-row cell-edit
+        // state and break native Ctrl-Z undo on any row that wasn't being
+        // discarded but happened to share a redraw batch.
+        for (const id of idsToRedraw) {
+          const rowEl = findRowElement(id);
+          if (rowEl) {
+            rowEl.classList.remove('ag-row-saving', 'ag-row-error');
+          }
         }
       },
       getDirtyRowIds: () => Array.from(dirtyRowIdsRef.current),


### PR DESCRIPTION
## Summary

Restores native cell-edit Ctrl-Z on `ConnectedDataGrid` when `onRowPublish` (auto-publish) is wired — the path the vendor grid uses.

The per-row publish lifecycle in `useRowAutoPublish.setRowState` called `api.redrawRows({ rowNodes: [node] })` whenever it flipped a row's state class (`ag-row-saving`, `ag-row-error`, or off). `redrawRows` destroys and recreates the row's DOM and tears down AG Grid's per-row cell-edit state — which silently drops the native Ctrl-Z undo stack for any row that auto-published. The bare `DataGrid` (no auto-publish) was unaffected.

The fix replaces the redraw with direct DOM mutation: find the row element by its `[row-id]` attribute and toggle the state class on the element's `classList`. `getRowClass` is unchanged and remains the source of truth for AG Grid's own re-renders (scroll virtualization, sort, filter), so a row that scrolls out of view and back in still picks up the right class on rebuild.

## What changed

- `useRowAutoPublish.ts`:
  - Added a small `findRowElement(rowId)` helper that queries `.ag-row[row-id="..."]` via `CSS.escape`.
  - `setRowState`: replaced `api.redrawRows({ rowNodes: [node] })` with `rowEl.classList.toggle(...)`.
  - `discardAll` imperative handle: same — replaced batched `redrawRows` with class removal on each row element.
- `use-row-auto-publish.test.ts`: added a regression test pinning the contract — while a publish is in flight the row element has the `ag-row-saving` class AND `redrawRows` was never called; after success the class is gone AND redrawRows was still never called.
- `CHANGELOG.md`: 6.0.1 patch entry.

## Known limitation (deliberately out of scope)

A multi-Ctrl-Z burst that lands while a publish is in flight can still silently lose intermediate undos because the publish queue drops concurrent requests (`publishingRef.has(rowId)` early return) and a successful publish wipes the pending changes accumulated during the flight. That's a deeper publish-layer fix and is being tracked separately so this patch can ship the visible bug fix without dragging in the bigger refactor.

## Test plan

- [x] `make check` (lint + tsc)
- [x] `make test` — 1441/1441 green (20 prior + 1 new regression test in `use-row-auto-publish.test.ts`)
- [ ] Manual verification on Storybook preview: open a `ConnectedDataGrid` story with `onRowPublish` wired, edit a cell, commit, Ctrl-Z reverts the value.
- [ ] Manual verification on `/vendors` via arda-frontend-app once 6.0.1 publishes and PR #864 is bumped.

> [!note]
> Authored by Claude Code for nail60